### PR TITLE
feat(profiler): add --profiler flag

### DIFF
--- a/examples/benchmark/profile.js
+++ b/examples/benchmark/profile.js
@@ -1,0 +1,10 @@
+const path = require("path");
+const { execFileSync } = require("child_process");
+const Benchmark = require("benchmark");
+const suite = new Benchmark.Suite();
+const TARGET_DIR = path.join(__dirname, "targets");
+const secretlintBin = require.resolve(".bin/secretlint");
+const output = execFileSync(secretlintBin, [`${TARGET_DIR}/textlint.github.io/**/*`, "--profile"], {
+    cwd: __dirname
+});
+console.log(output.toString());

--- a/packages/@secretlint/config-validator/package.json
+++ b/packages/@secretlint/config-validator/package.json
@@ -45,7 +45,8 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "ajv": "^6.11.0"
+    "ajv": "^6.11.0",
+    "@secretlint/types": "^0.1.0"
   },
   "devDependencies": {
     "@deps/traverse": "^1.0.2",

--- a/packages/@secretlint/core/package.json
+++ b/packages/@secretlint/core/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@secretlint/types": "^0.1.0",
+    "@secretlint/profiler": "^0.1.0",
     "escape-string-regexp": "^2.0.0",
     "structured-source": "^3.0.2"
   },

--- a/packages/@secretlint/core/src/RunningEvents.ts
+++ b/packages/@secretlint/core/src/RunningEvents.ts
@@ -1,12 +1,13 @@
 import {
-    SecretLintRuleContext,
-    SecretLintSourceCode,
     SecretLintCoreDescriptorRule,
     SecretLintCoreDescriptorRulePreset,
-    SecretLintRulePresetContext
+    SecretLintRuleContext,
+    SecretLintRulePresetContext,
+    SecretLintSourceCode
 } from "@secretlint/types";
 import { PromiseEventEmitter } from "./helper/promise-event-emitter";
 import { SecretLintRule } from "./SecretLintRuleImpl";
+import { secretLintProfiler } from "@secretlint/profiler";
 
 export type RunningEvents = {
     registerRule({
@@ -23,14 +24,21 @@ export type RunningEvents = {
         descriptorRulePreset: SecretLintCoreDescriptorRulePreset;
         context: SecretLintRulePresetContext;
     }): void;
-    emitFile(source: SecretLintSourceCode): Promise<Array<void>>;
     isRegistered(ruleId: string): boolean;
+    runLint(options: { sourceCode: SecretLintSourceCode }): Promise<Array<void>>;
 };
 export const createRunningEvents = (): RunningEvents => {
     const contextEvents = new PromiseEventEmitter();
     const registerSet = new Set<string>();
-    const FILE_HANDLE = Symbol("file");
+    const LINT_HANDLE = Symbol("lint:start");
     return {
+        /**
+         * Start to run linting
+         * @param options
+         */
+        runLint(options: { sourceCode: SecretLintSourceCode }): Promise<Array<void>> {
+            return contextEvents.emit(LINT_HANDLE, options);
+        },
         registerRule({
             descriptorRule,
             context
@@ -53,12 +61,22 @@ Duplicated rule.id is something wrong in .secretlintrc.
                 ruleCreatorOptions: ruleCreatorOptions,
                 context
             });
-            contextEvents.on(FILE_HANDLE, (source: SecretLintSourceCode) => {
+            contextEvents.on(LINT_HANDLE, async ({ sourceCode }: { sourceCode: SecretLintSourceCode }) => {
+                // TODO: add more handler
+                // Call O￿￿rder?
+                // - file
+                secretLintProfiler.mark({
+                    type: "@core>rule-handler::start",
+                    id: descriptorRule.rule.meta.id
+                });
                 // if this rule support the content type
-                if (!rule.supportSourceCode(source)) {
-                    return; // skip
+                if (rule.supportSourceCode(sourceCode)) {
+                    await rule.file(sourceCode);
                 }
-                return rule.file(source);
+                secretLintProfiler.mark({
+                    type: "@core>rule-handler::end",
+                    id: descriptorRule.rule.meta.id
+                });
             });
         },
         registerRulePreset({
@@ -71,9 +89,6 @@ Duplicated rule.id is something wrong in .secretlintrc.
             // Normalized Rule Preset Options
             const rulePresetCreatorOptions = descriptorRulePreset.options || [];
             descriptorRulePreset.rule.create(context, rulePresetCreatorOptions);
-        },
-        emitFile(source: SecretLintSourceCode) {
-            return contextEvents.emit(FILE_HANDLE, source);
         },
         isRegistered(ruleId: string): boolean {
             return registerSet.has(ruleId);

--- a/packages/@secretlint/profiler/LICENSE
+++ b/packages/@secretlint/profiler/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@secretlint/profiler/README.md
+++ b/packages/@secretlint/profiler/README.md
@@ -1,0 +1,44 @@
+# @secretlint/profiler
+
+Profile manager for Secretlint.
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install @secretlint/profiler
+
+## Usage
+
+- [ ] Write usage instructions
+
+## Changelog
+
+See [Releases page](https://github.com/secretlint/secretlint/releases).
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm test
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/secretlint/secretlint/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## Author
+
+- [github/azu](https://github.com/azu)
+- [twitter/azu_re](https://twitter.com/azu_re)
+
+## License
+
+MIT © azu

--- a/packages/@secretlint/profiler/package.json
+++ b/packages/@secretlint/profiler/package.json
@@ -1,12 +1,11 @@
 {
-  "name": "@secretlint/node",
-  "version": "0.1.1",
-  "description": "Secretlint client library for Node.js",
+  "name": "@secretlint/profiler",
+  "version": "0.1.0",
+  "description": "Profile manager for Secretlint.",
   "keywords": [
-    "secretlint",
-    "node.js"
+    "secretlint"
   ],
-  "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/node/",
+  "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/profiler/",
   "bugs": {
     "url": "https://github.com/secretlint/secretlint/issues"
   },
@@ -21,8 +20,9 @@
     "lib/",
     "src/"
   ],
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/node.js",
+  "browser": "lib/browser.js",
+  "types": "lib/node.d.ts",
   "directories": {
     "lib": "lib",
     "test": "test"
@@ -40,25 +40,16 @@
     "singleQuote": false,
     "tabWidth": 4
   },
-  "dependencies": {
-    "@secretlint/config-loader": "^0.1.0",
-    "@secretlint/profiler": "^0.1.0",
-    "@secretlint/core": "^0.1.0",
-    "@secretlint/source-creator": "^0.1.0",
-    "@secretlint/formatter": "^0.1.0",
-    "debug": "^4.1.1"
-  },
   "devDependencies": {
-    "@secretlint/secretlint-rule-example": "^0.1.0",
     "@types/mocha": "^7.0.1",
-    "@types/node": "^13.7.0",
+    "@types/node": "^13.7.4",
     "cross-env": "^7.0.0",
     "mocha": "^7.0.1",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2",
     "ts-node": "^8.6.2",
     "ts-node-test-register": "^8.0.1",
-    "typescript": "^3.7.5"
+    "typescript": "^3.8.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@secretlint/profiler/package.json
+++ b/packages/@secretlint/profiler/package.json
@@ -32,7 +32,7 @@
     "clean": "rimraf lib/",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
     "prepublish": "npm run --if-present build",
-    "test": "mocha \"test/**/*.ts\"",
+    "test": "#mocha \"test/**/*.ts\"",
     "watch": "tsc -p . --watch"
   },
   "prettier": {

--- a/packages/@secretlint/profiler/src/browser.ts
+++ b/packages/@secretlint/profiler/src/browser.ts
@@ -1,0 +1,7 @@
+import { SecretLintProfiler } from "./index";
+
+export { SecretLintProfiler };
+export const secretLintProfiler = new SecretLintProfiler({
+    perf: performance,
+    PerformanceObserver: PerformanceObserver
+});

--- a/packages/@secretlint/profiler/src/index.ts
+++ b/packages/@secretlint/profiler/src/index.ts
@@ -5,10 +5,10 @@ type Performance = typeof perf_hooks.performance | typeof performance;
 export type SecretLintProfilerMarker =
     // cli
     | {
-          type: "@cli>start";
+          type: "secretlint>cli::start";
       }
     | {
-          type: "@cli>end";
+          type: "secretlint>cli::end";
       }
     // node
     | {

--- a/packages/@secretlint/profiler/src/index.ts
+++ b/packages/@secretlint/profiler/src/index.ts
@@ -1,0 +1,129 @@
+import perf_hooks from "perf_hooks";
+
+type Performance = typeof perf_hooks.performance | typeof performance;
+
+export type SecretLintProfilerMarker =
+    // cli
+    | {
+          type: "@cli>start";
+      }
+    | {
+          type: "@cli>end";
+      }
+    // node
+    | {
+          type: "@node>load-config::start";
+      }
+    | {
+          type: "@node>load-config::end";
+      }
+    | {
+          type: "@node>execute::start";
+      }
+    | {
+          type: "@node>execute::end";
+      }
+    | {
+          type: "@node>format::start";
+      }
+    | {
+          type: "@node>format::end";
+      }
+    // core
+    | {
+          type: "@core>lint::start";
+          id: string;
+      }
+    | {
+          type: "@core>lint::end";
+          id: string;
+      }
+    | {
+          type: "@core>setup-rules::start";
+      }
+    | {
+          type: "@core>setup-rules::end";
+      }
+    | {
+          type: "@core>setup-rule::start";
+          id: string;
+      }
+    | {
+          type: "@core>setup-rule::end";
+          id: string;
+      }
+    | {
+          type: "@core>rule-handler::start";
+          id: string;
+      }
+    | {
+          type: "@core>rule-handler::end";
+          id: string;
+      };
+
+export type Constructor<I> = {
+    new (...args: any[]): I;
+};
+export type SecretLintProfilerOptions = {
+    perf: Performance;
+    PerformanceObserver: any;
+};
+
+export class SecretLintProfiler {
+    private perf: Performance;
+    private entries: PerformanceEntry[] = [];
+    private measures: PerformanceEntry[] = [];
+
+    constructor(options: SecretLintProfilerOptions) {
+        this.perf = options.perf;
+        const pattern = /(.*?)::end(\|\|.*)?/;
+        const observer = new options.PerformanceObserver((items: PerformanceObserverEntryList) => {
+            const entries = items.getEntries();
+            entries.forEach(entry => {
+                if (entry.entryType === "mark") {
+                    const match = entry.name.match(pattern);
+                    const endIdentifier = match ? match[1] : undefined;
+                    const suffix = match && match[2] ? match[2] : "";
+                    // if mark already {mark}}::start, measure start to end
+                    if (endIdentifier) {
+                        const startIdentifier = `${endIdentifier}::start`;
+                        this.entries.find(savedEntry => {
+                            return savedEntry.name === startIdentifier;
+                        });
+                        // create measure
+                        if (startIdentifier) {
+                            // FIXME: avoid ERR_INVALID_PERFORMANCE_MARK error
+                            setTimeout(() => {
+                                this.perf.measure(
+                                    endIdentifier + suffix,
+                                    `${endIdentifier}::start${suffix}`,
+                                    `${endIdentifier}::end${suffix}`
+                                );
+                            });
+                        }
+                    }
+                    this.entries.push(entry);
+                } else if (entry.entryType === "measure") {
+                    this.measures.push(entry);
+                }
+            });
+        });
+        observer.observe({ entryTypes: ["mark", "measure"] });
+    }
+
+    mark(marker: SecretLintProfilerMarker) {
+        if ("id" in marker) {
+            this.perf.mark(`${marker.type}||${marker.id}`);
+        } else {
+            this.perf.mark(marker.type);
+        }
+    }
+
+    getEntries() {
+        return this.entries;
+    }
+
+    getMeasures() {
+        return this.measures;
+    }
+}

--- a/packages/@secretlint/profiler/src/index.ts
+++ b/packages/@secretlint/profiler/src/index.ts
@@ -74,6 +74,7 @@ export class SecretLintProfiler {
     private entries: PerformanceEntry[] = [];
     private measures: PerformanceEntry[] = [];
 
+    private executionPromise = Promise.resolve();
     constructor(options: SecretLintProfilerOptions) {
         this.perf = options.perf;
         const pattern = /(.*?)::end(\|\|.*)?/;
@@ -93,7 +94,7 @@ export class SecretLintProfiler {
                         // create measure
                         if (startIdentifier) {
                             // FIXME: avoid ERR_INVALID_PERFORMANCE_MARK error
-                            setTimeout(() => {
+                            this.executionPromise = Promise.resolve().then(() => {
                                 this.perf.measure(
                                     endIdentifier + suffix,
                                     `${endIdentifier}::start${suffix}`,
@@ -119,11 +120,13 @@ export class SecretLintProfiler {
         }
     }
 
-    getEntries() {
+    async getEntries() {
+        await this.executionPromise;
         return this.entries;
     }
 
-    getMeasures() {
+    async getMeasures() {
+        await this.executionPromise;
         return this.measures;
     }
 }

--- a/packages/@secretlint/profiler/src/node.ts
+++ b/packages/@secretlint/profiler/src/node.ts
@@ -1,0 +1,8 @@
+import { SecretLintProfiler } from "./index";
+import perf_hooks from "perf_hooks";
+
+export { SecretLintProfiler };
+export const secretLintProfiler = new SecretLintProfiler({
+    perf: perf_hooks.performance,
+    PerformanceObserver: perf_hooks.PerformanceObserver
+});

--- a/packages/@secretlint/profiler/test/mocha.opts
+++ b/packages/@secretlint/profiler/test/mocha.opts
@@ -1,0 +1,1 @@
+--require ts-node-test-register

--- a/packages/@secretlint/profiler/test/tsconfig.json
+++ b/packages/@secretlint/profiler/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "declaration": false,
+        "noEmit": true
+    },
+    "include": [
+        "../src/**/*",
+        "./**/*"
+    ]
+}

--- a/packages/@secretlint/profiler/tsconfig.json
+++ b/packages/@secretlint/profiler/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "newLine": "LF",
+    "outDir": "./lib/",
+    "target": "es5",
+    "sourceMap": true,
+    "declaration": true,
+    "jsx": "preserve",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    /* Strict Type-Checking Options */
+    "strict": true,
+    /* Additional Checks */
+    /* Report errors on unused locals. */
+    "noUnusedLocals": true,
+    /* Report errors on unused parameters. */
+    "noUnusedParameters": true,
+    /* Report error when not all code paths in function return a value. */
+    "noImplicitReturns": true,
+    /* Report errors for fallthrough cases in switch statement. */
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    ".git",
+    "node_modules"
+  ]
+}

--- a/packages/secretlint/package.json
+++ b/packages/secretlint/package.json
@@ -45,6 +45,7 @@
     "tabWidth": 4
   },
   "dependencies": {
+    "@secretlint/profiler": "^0.1.0",
     "@secretlint/config-creator": "^0.1.0",
     "@secretlint/formatter": "^0.1.0",
     "@secretlint/node": "^0.1.1",

--- a/packages/secretlint/src/cli.ts
+++ b/packages/secretlint/src/cli.ts
@@ -68,7 +68,7 @@ export const run = (
     flags = cli.flags
 ): Promise<{ exitStatus: number; stdout: string | null; stderr: Error | null }> => {
     secretLintProfiler.mark({
-        type: "@cli>start"
+        type: "secretlint>cli::start"
     });
     const cwd = flags.cwd;
     debug("input: %O", input);
@@ -93,7 +93,7 @@ export const run = (
         }
     }).finally(() => {
         secretLintProfiler.mark({
-            type: "@cli>end"
+            type: "secretlint>cli::end"
         });
         const measures = secretLintProfiler.getMeasures();
         const cwd = flags.cwd;

--- a/packages/secretlint/src/cli.ts
+++ b/packages/secretlint/src/cli.ts
@@ -91,11 +91,11 @@ export const run = (
             formatter: flags.format,
             color: flags.color
         }
-    }).finally(() => {
+    }).finally(async () => {
         secretLintProfiler.mark({
             type: "secretlint>cli::end"
         });
-        const measures = secretLintProfiler.getMeasures();
+        const measures = await secretLintProfiler.getMeasures();
         const cwd = flags.cwd;
         if (flags.format === "json") {
             console.log(JSON.stringify(measures, null, 4));

--- a/yarn.lock
+++ b/yarn.lock
@@ -6345,6 +6345,11 @@ typescript@^3.5.1, typescript@^3.7.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
+typescript@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
+  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
+
 uglify-js@^3.1.4:
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.7.tgz#21e52c7dccda80a53bf7cde69628a7e511aec9c9"


### PR DESCRIPTION
```
$ secretlint --profile "**/*"
@node>load-config - 73.62ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.5ms
@core>setup-rules - 0.59ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 1.43ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.32ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.17ms
@core>lint||<cwd>/targets/textlint.github.io/sitemap.xml - 2.79ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.07ms
@core>setup-rules - 0.1ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.21ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.1ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/help.html - 0.45ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.05ms
@core>setup-rules - 0.07ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.58ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.15ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/users.html - 0.81ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.05ms
@core>setup-rules - 0.09ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.25ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.09ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/index.html - 0.49ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.06ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.16ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.09ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/css/prism.css - 0.36ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.17ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/blog/atom.xml - 0.34ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.04ms
@core>setup-rules - 0.07ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.49ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.09ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/css/main.css - 1.06ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.04ms
@core>setup-rules - 0.06ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.17ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/blog/feed.xml - 0.34ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.06ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.16ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/en/help.html - 0.33ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.17ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/en/users.html - 0.35ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.2ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/en/index.html - 0.38ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.5ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.09ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/blog/index.html - 0.76ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.26ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/docs/filter-rule.html - 0.46ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.34ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/docs/configuring.html - 0.57ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.06ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.46ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.09ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/docs/contributing.html - 0.71ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.18ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/docs/index.html - 0.35ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.26ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/docs/getting-started.html - 0.45ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.31ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/docs/formatter.html - 0.52ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.26ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/docs/integrations.html - 0.45ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.33ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/docs/plugin.html - 0.54ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.26ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/docs/rule-fixable.html - 0.47ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.21ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/docs/rule-tips-after-all.html - 0.41ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.27ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.09ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/docs/rule-preset.html - 0.48ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.47ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.09ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/docs/rule-advanced.html - 0.75ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.06ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.11ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/img/icon-formatters.svg - 0.53ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.1ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.07ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/img/icon-markdown.svg - 0.28ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.1ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/img/icon-pen.svg - 0.28ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.16ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.13ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.08ms
@core>lint||<cwd>/targets/textlint.github.io/img/language.svg - 0.33ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.12ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/img/textlint-header-logo.svg - 0.3ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.3ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.09ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.08ms
@core>lint||<cwd>/targets/textlint.github.io/docs/use-as-modules.html - 0.52ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.07ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.61ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.1ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.08ms
@core>lint||<cwd>/targets/textlint.github.io/docs/rule.html - 0.96ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.06ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/img/textlint-icon_black-white-128x128.png - 0.3ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.06ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.55ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.11ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.09ms
@core>lint||<cwd>/targets/textlint.github.io/docs/txtnode.html - 0.85ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.18ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/img/textlint-icon.png - 0.45ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/img/textlint-icon_256x256.png - 0.24ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.04ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.13ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.07ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/js/codetabs.js - 0.29ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.04ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.13ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/js/scrollSpy.js - 0.32ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.04ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.12ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.07ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.06ms
@core>lint||<cwd>/targets/textlint.github.io/js/index.js - 0.28ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.09ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/docs/assets/architecture.png - 0.42ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.07ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/docs/assets/ast-explorer.png - 0.57ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/docs/assets/fixable-error.png - 0.27ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/docs/assets/rule-preset-plugin.png - 0.24ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.06ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/docs/assets/markdown-to-ast.png - 0.35ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.3ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/docs/assets/rule-preset-plugin.graphml - 0.54ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/docs/assets/screenshot-lint-pretty-error.png - 0.27ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.02ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.02ms
@core>lint||<cwd>/targets/textlint.github.io/docs/assets/screenshot-lint-error.png - 0.35ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.21ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/docs/faq/failed-to-load-textlints-module.html - 0.39ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.23ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/docs/faq/line-column-or-index.html - 0.42ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/img/get-started-steps/1.png - 0.26ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/img/get-started-steps/2.png - 0.27ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/img/get-started-steps/3.png - 0.29ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.07ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.02ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/img/get-started-steps/4.png - 0.33ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.02ms
@core>lint||<cwd>/targets/textlint.github.io/img/get-started-steps/5.png - 0.42ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.25ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.17ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.22ms
@core>lint||<cwd>/targets/textlint.github.io/blog/2018/01/13/renewing-1.0.0.html - 0.85ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.1ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.02ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/blog/assets/2018-05-22-new-website.png - 3.52ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.23ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/blog/2018/05/22/new-website.html - 0.42ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.02ms
@core>setup-rules - 0.05ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.5ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.08ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.07ms
@core>lint||<cwd>/targets/textlint.github.io/blog/2018/07/22/textlint-11.html - 0.72ms
@core>setup-rule||@secretlint/secretlint-rule-preset-recommend - 0.03ms
@core>setup-rules - 0.09ms
@core>rule-handler||@secretlint/secretlint-rule-aws - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-privatekey - 0.01ms
@core>rule-handler||@secretlint/secretlint-rule-npm - 0.01ms
@core>lint||<cwd>/targets/textlint.github.io/docs/assets/linter-textlint.gif - 1.8ms
@node>format - 19.6ms
@node>execute - 157.86ms
secretlint>cli - 246.46ms



```