### PR TITLE
fix(quick-start): fix bin script name

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@0.3.0/schema.json",
   "changelog": "@changesets/cli/changelog",
-  "commit": false,
+  "commit": true,
   "linked": [],
   "access": "public",
   "baseBranch": "master"

--- a/.changeset/tough-actors-allow.md
+++ b/.changeset/tough-actors-allow.md
@@ -1,0 +1,11 @@
+---
+"@secretlint/quick-start": patch
+---
+
+Fix to work `secretlint/quick-start`:
+
+```
+npx @secretlint/quick-start "**/*"
+```
+
+Refer to `@secretlint/quick-start`'s `quick-start` script by default.

--- a/packages/@secretlint/quick-start/package.json
+++ b/packages/@secretlint/quick-start/package.json
@@ -25,7 +25,7 @@
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "bin": {
-        "secretlint-quick-start": "./bin/quick-start.js"
+        "quick-start": "./bin/quick-start.js"
     },
     "directories": {
         "lib": "lib",


### PR DESCRIPTION
```
npx @secretlint/quick-start "**/*"
```

Refer to `@secretlint/quick-start`'s `quick-start` script by default.