### PR TITLE
docs(rule-example): fix typo

### DIFF
--- a/packages/@secretlint/secretlint-rule-example/README.md
+++ b/packages/@secretlint/secretlint-rule-example/README.md
@@ -1,6 +1,6 @@
 # @secretlint/secretlint-rule-example
 
-An example rule for secretlint. It it for testing.
+An example rule for secretlint. It is for testing.
 
 ## Install
 


### PR DESCRIPTION
Fix typo `it`