### PR TITLE
v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+
+### Bug Fixes
+
+* **binary-compiler:** fix binary compiler workflow ([13a1660](https://github.com/secretlint/secretlint/commit/13a1660d35f533e28efa0a04f9159755c5e388b0))
+* **deps:** add @changesets/changelog-github ([4cd589a](https://github.com/secretlint/secretlint/commit/4cd589a9ddc64a04a0b656f4fda287135edcc4a6))
+* **deps:** revert @changesets/changelog-github ([f8560bd](https://github.com/secretlint/secretlint/commit/f8560bd59abf40e2eb3aa8aa6daac487cc8d6986))
+* **messages-to-markdown:** rename bin script ([c6a620c](https://github.com/secretlint/secretlint/commit/c6a620c9ba774f8373653a31fbb536712da3ae94))
+
+
+### Features
+
+* **cli:** support --secretlintrcJSON flag ([#78](https://github.com/secretlint/secretlint/issues/78)) ([449b4a1](https://github.com/secretlint/secretlint/commit/449b4a1c78c33722c41d1251d2dde4d8d040cf88))
+
+
+### Performance Improvements
+
+* **profiler:** add profile mark to config-loader ([d127d23](https://github.com/secretlint/secretlint/commit/d127d237843341d7704fe96852e0d4638da50eaa))
+* **secretlint-rule-preset-recommend:** rollup ([#76](https://github.com/secretlint/secretlint/issues/76)) ([71c382a](https://github.com/secretlint/secretlint/commit/71c382abb4c2f8bf60319e2716f3d6600f1de8ba))
+
+
+
+
+
 ## [0.7.3](https://github.com/secretlint/secretlint/compare/v0.7.2...v0.7.3) (2020-03-01)
 
 

--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -1,23 +1,18 @@
 # Change Log
 
-## 0.7.5
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/secretlint-rule-preset-recommend@0.7.3
-    -   secretlint@0.8.1
-
-## 0.7.4
-
-### Patch Changes
-
--   Updated dependencies [4d0413a]
-    -   secretlint@0.8.0
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+
+### Performance Improvements
+
+* **secretlint-rule-preset-recommend:** rollup ([#76](https://github.com/secretlint/secretlint/issues/76)) ([71c382a](https://github.com/secretlint/secretlint/commit/71c382abb4c2f8bf60319e2716f3d6600f1de8ba))
+
+
+
+
 
 ## [0.7.3](https://github.com/secretlint/secretlint/compare/v0.7.2...v0.7.3) (2020-03-01)
 

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@secretlint/benchmark",
-    "version": "0.7.5",
+    "version": "0.9.0",
     "description": "Internal benchmark for Secretlint",
     "keywords": [
         "secretlint",
@@ -32,9 +32,8 @@
         "access": "public"
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^0.7.3",
+        "@secretlint/secretlint-rule-preset-recommend": "^0.9.0",
         "benchmark": "^2.1.4",
-        "secretlint": "^0.8.1"
-    },
-    "devDependencies": {}
+        "secretlint": "^0.9.0"
+    }
 }

--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -1,23 +1,15 @@
 # Change Log
 
-## 0.7.5
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/secretlint-rule-preset-recommend@0.7.3
-    -   secretlint@0.8.1
-
-## 0.7.4
-
-### Patch Changes
-
--   Updated dependencies [4d0413a]
-    -   secretlint@0.8.0
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/example-cli
+
+
+
+
 
 ## [0.7.3](https://github.com/secretlint/secretlint/compare/v0.7.2...v0.7.3) (2020-03-01)
 

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@secretlint/example-cli",
-    "version": "0.7.5",
+    "version": "0.9.0",
     "description": "",
     "homepage": "https://github.com/secretlint/secretlint/tree/master/examples/cli/",
     "bugs": {
@@ -27,9 +27,9 @@
         "test": "expected-exit-status 1 --command 'secretlint \"**/*\"'"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^0.7.3",
+        "@secretlint/secretlint-rule-preset-recommend": "^0.9.0",
         "expected-exit-status": "^1.0.2",
-        "secretlint": "^0.8.1"
+        "secretlint": "^0.9.0"
     },
     "publishConfig": {
         "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "packages/@secretlint/*",
     "examples/*"
   ],
-  "version": "0.7.3",
+  "version": "0.9.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/@secretlint/config-creator/CHANGELOG.md
+++ b/packages/@secretlint/config-creator/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Change Log
 
-## 0.7.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/types@0.7.1
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/config-creator
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/config-creator/package.json
+++ b/packages/@secretlint/config-creator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-creator",
-    "version": "0.7.1",
+    "version": "0.9.0",
     "description": "Config file creator for secretlint.",
     "keywords": [
         "secretlint"
@@ -40,7 +40,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^0.7.1"
+        "@secretlint/types": "^0.9.0"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/config-loader/CHANGELOG.md
+++ b/packages/@secretlint/config-loader/CHANGELOG.md
@@ -1,19 +1,23 @@
 # Change Log
 
-## 0.7.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
--   Updated dependencies [5a22277]
-    -   @secretlint/config-validator@0.7.1
-    -   @secretlint/profiler@0.7.1
-    -   @secretlint/secretlint-rule-example@0.7.1
-    -   @secretlint/types@0.7.1
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+
+### Features
+
+* **cli:** support --secretlintrcJSON flag ([#78](https://github.com/secretlint/secretlint/issues/78)) ([449b4a1](https://github.com/secretlint/secretlint/commit/449b4a1c78c33722c41d1251d2dde4d8d040cf88))
+
+
+### Performance Improvements
+
+* **profiler:** add profile mark to config-loader ([d127d23](https://github.com/secretlint/secretlint/commit/d127d237843341d7704fe96852e0d4638da50eaa))
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/config-loader/package.json
+++ b/packages/@secretlint/config-loader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-loader",
-    "version": "0.7.1",
+    "version": "0.9.0",
     "description": "Config loader for secretlint.",
     "keywords": [
         "secretlint",
@@ -43,16 +43,16 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/profiler": "^0.7.1",
-        "@secretlint/config-validator": "^0.7.1",
-        "@secretlint/types": "^0.7.1",
+        "@secretlint/config-validator": "^0.9.0",
+        "@secretlint/profiler": "^0.9.0",
+        "@secretlint/types": "^0.9.0",
         "@textlint/module-interop": "^1.0.2",
         "debug": "^4.1.1",
         "rc-config-loader": "^3.0.0",
         "try-resolve": "^1.0.1"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^0.7.1",
+        "@secretlint/secretlint-rule-example": "^0.9.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/config-validator/CHANGELOG.md
+++ b/packages/@secretlint/config-validator/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Change Log
 
-## 0.7.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/types@0.7.1
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/config-validator
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/config-validator/package.json
+++ b/packages/@secretlint/config-validator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-validator",
-    "version": "0.7.1",
+    "version": "0.9.0",
     "description": ".secretlintrc config validation library",
     "keywords": [
         "secretlint",
@@ -45,7 +45,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^0.7.1",
+        "@secretlint/types": "^0.9.0",
         "ajv": "^6.11.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/core/CHANGELOG.md
+++ b/packages/@secretlint/core/CHANGELOG.md
@@ -1,22 +1,15 @@
 # Change Log
 
-## 0.8.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/profiler@0.7.1
-    -   @secretlint/types@0.7.1
-
-## 0.8.0
-
-### Minor Changes
-
--   4d0413a: `secretlint` CLI support `--secretlintrcJSON` flag
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/core
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/core/package.json
+++ b/packages/@secretlint/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/core",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "description": "Core library for @secretlint.",
     "keywords": [
         "secretlint"
@@ -40,8 +40,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/profiler": "^0.7.1",
-        "@secretlint/types": "^0.7.1",
+        "@secretlint/profiler": "^0.9.0",
+        "@secretlint/types": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "structured-source": "^3.0.2"
     },

--- a/packages/@secretlint/formatter/CHANGELOG.md
+++ b/packages/@secretlint/formatter/CHANGELOG.md
@@ -1,21 +1,15 @@
 # Change Log
 
-## 0.8.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/types@0.7.1
-
-## 0.8.0
-
-### Minor Changes
-
--   4d0413a: `secretlint` CLI support `--secretlintrcJSON` flag
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/formatter
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/formatter/package.json
+++ b/packages/@secretlint/formatter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/formatter",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "description": "A formatter collection for Secretlint.",
     "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/formatter/",
     "bugs": {
@@ -37,7 +37,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^0.7.1",
+        "@secretlint/types": "^0.9.0",
         "@textlint/linter-formatter": "^3.1.12",
         "@textlint/types": "^1.3.1",
         "debug": "^4.1.1",

--- a/packages/@secretlint/messages-to-markdown/CHANGELOG.md
+++ b/packages/@secretlint/messages-to-markdown/CHANGELOG.md
@@ -1,21 +1,18 @@
 # Change Log
 
-## 0.8.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/types@0.7.1
-
-## 0.8.0
-
-### Minor Changes
-
--   4d0413a: `secretlint` CLI support `--secretlintrcJSON` flag
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+
+### Bug Fixes
+
+* **messages-to-markdown:** rename bin script ([c6a620c](https://github.com/secretlint/secretlint/commit/c6a620c9ba774f8373653a31fbb536712da3ae94))
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/messages-to-markdown/package.json
+++ b/packages/@secretlint/messages-to-markdown/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/messages-to-markdown",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "description": "Create Markdown text from rule's messages(ids)",
     "keywords": [
         "secretlint"
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^0.7.1",
+        "@secretlint/types": "^0.9.0",
         "meow": "^6.0.1",
         "ts-node": "^8.6.2",
         "typescript": "^3.8.2"

--- a/packages/@secretlint/node/CHANGELOG.md
+++ b/packages/@secretlint/node/CHANGELOG.md
@@ -1,33 +1,18 @@
 # Change Log
 
-## 0.8.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
--   Updated dependencies [5a22277]
-    -   @secretlint/config-loader@0.7.1
-    -   @secretlint/core@0.8.1
-    -   @secretlint/formatter@0.8.1
-    -   @secretlint/profiler@0.7.1
-    -   @secretlint/secretlint-rule-example@0.7.1
-    -   @secretlint/source-creator@0.7.1
-
-## 0.8.0
-
-### Minor Changes
-
--   4d0413a: `secretlint` CLI support `--secretlintrcJSON` flag
-
-### Patch Changes
-
--   Updated dependencies [4d0413a]
-    -   @secretlint/core@0.8.0
-    -   @secretlint/formatter@0.8.0
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+
+### Features
+
+* **cli:** support --secretlintrcJSON flag ([#78](https://github.com/secretlint/secretlint/issues/78)) ([449b4a1](https://github.com/secretlint/secretlint/commit/449b4a1c78c33722c41d1251d2dde4d8d040cf88))
+
+
+
+
 
 ## [0.7.3](https://github.com/secretlint/secretlint/compare/v0.7.2...v0.7.3) (2020-03-01)
 

--- a/packages/@secretlint/node/package.json
+++ b/packages/@secretlint/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/node",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "description": "Secretlint client library for Node.js",
     "keywords": [
         "secretlint",
@@ -41,16 +41,16 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-loader": "^0.7.1",
-        "@secretlint/core": "^0.8.1",
-        "@secretlint/formatter": "^0.8.1",
-        "@secretlint/profiler": "^0.7.1",
-        "@secretlint/source-creator": "^0.7.1",
+        "@secretlint/config-loader": "^0.9.0",
+        "@secretlint/core": "^0.9.0",
+        "@secretlint/formatter": "^0.9.0",
+        "@secretlint/profiler": "^0.9.0",
+        "@secretlint/source-creator": "^0.9.0",
         "debug": "^4.1.1",
         "p-map": "^3.0.0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^0.7.1",
+        "@secretlint/secretlint-rule-example": "^0.9.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/profiler/CHANGELOG.md
+++ b/packages/@secretlint/profiler/CHANGELOG.md
@@ -1,13 +1,23 @@
 # Change Log
 
-## 0.7.1
-
-### Patch Changes
-
--   aaef596: Path Update
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+
+### Features
+
+* **cli:** support --secretlintrcJSON flag ([#78](https://github.com/secretlint/secretlint/issues/78)) ([449b4a1](https://github.com/secretlint/secretlint/commit/449b4a1c78c33722c41d1251d2dde4d8d040cf88))
+
+
+### Performance Improvements
+
+* **profiler:** add profile mark to config-loader ([d127d23](https://github.com/secretlint/secretlint/commit/d127d237843341d7704fe96852e0d4638da50eaa))
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/profiler/package.json
+++ b/packages/@secretlint/profiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/profiler",
-    "version": "0.7.1",
+    "version": "0.9.0",
     "description": "Profile manager for Secretlint.",
     "keywords": [
         "secretlint"

--- a/packages/@secretlint/quick-start/CHANGELOG.md
+++ b/packages/@secretlint/quick-start/CHANGELOG.md
@@ -1,23 +1,15 @@
 # Change Log
 
-## 0.7.5
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/secretlint-rule-preset-recommend@0.7.3
-    -   secretlint@0.8.1
-
-## 0.7.4
-
-### Patch Changes
-
--   Updated dependencies [4d0413a]
-    -   secretlint@0.8.0
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/quick-start
+
+
+
+
 
 ## [0.7.3](https://github.com/secretlint/secretlint/compare/v0.7.2...v0.7.3) (2020-03-01)
 

--- a/packages/@secretlint/quick-start/package.json
+++ b/packages/@secretlint/quick-start/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/quick-start",
-    "version": "0.7.5",
+    "version": "0.9.0",
     "description": "Quick Stater CLI for secretlint.",
     "keywords": [
         "secretlint",
@@ -46,8 +46,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^0.7.3",
-        "secretlint": "^0.8.1"
+        "@secretlint/secretlint-rule-preset-recommend": "^0.9.0",
+        "secretlint": "^0.9.0"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/secretlint-rule-aws/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-aws/CHANGELOG.md
@@ -1,23 +1,15 @@
 # Change Log
 
-## 0.7.2
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/tester@0.8.1
-    -   @secretlint/types@0.7.1
-
-## 0.7.1
-
-### Patch Changes
-
--   Updated dependencies [4d0413a]
-    -   @secretlint/tester@0.8.0
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-aws
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/secretlint-rule-aws/package.json
+++ b/packages/@secretlint/secretlint-rule-aws/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-aws",
-    "version": "0.7.2",
+    "version": "0.9.0",
     "description": "A secretlint rule for AWS.",
     "keywords": [
         "secretlint",
@@ -43,13 +43,13 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^0.7.1",
+        "@secretlint/types": "^0.9.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "regx": "^1.0.4",
         "string.prototype.matchall": "^4.0.2"
     },
     "devDependencies": {
-        "@secretlint/tester": "^0.8.1",
+        "@secretlint/tester": "^0.9.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-basicauth/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-basicauth/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Change Log
 
-## 0.7.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/types@0.7.1
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-basicauth
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/secretlint-rule-basicauth/package.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-basicauth",
-    "version": "0.7.1",
+    "version": "0.9.0",
     "description": "A secretlint rule that check Basic Authentication.",
     "keywords": [
         "secretlint",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^0.7.1",
+        "@secretlint/types": "^0.9.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "string.prototype.matchall": "^4.0.2"
     },

--- a/packages/@secretlint/secretlint-rule-example/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-example/CHANGELOG.md
@@ -1,19 +1,15 @@
 # Change Log
 
-## 0.7.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   5a22277: rule-example: fix typo [#85](https://github.com/secretlint/secretlint/pull/85)
-
-    Fix typo `it`
-
--   Updated dependencies [aaef596]
-    -   @secretlint/types@0.7.1
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/secretlint-rule-example/package.json
+++ b/packages/@secretlint/secretlint-rule-example/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-example",
-    "version": "0.7.1",
+    "version": "0.9.0",
     "description": "An example rule for secretlint. It it for testing.",
     "keywords": [
         "secretlint",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^0.7.1"
+        "@secretlint/types": "^0.9.0"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/secretlint-rule-gcp/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-gcp/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Change Log
 
-## 0.7.3
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/types@0.7.1
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-gcp
+
+
+
+
 
 ## [0.7.2](https://github.com/secretlint/secretlint/compare/v0.7.1...v0.7.2) (2020-03-01)
 

--- a/packages/@secretlint/secretlint-rule-gcp/package.json
+++ b/packages/@secretlint/secretlint-rule-gcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-gcp",
-    "version": "0.7.3",
+    "version": "0.9.0",
     "description": "A secretlint rule for GCP.",
     "keywords": [
         "rule",
@@ -42,7 +42,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^0.7.1",
+        "@secretlint/types": "^0.9.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "node-forge": "^0.9.1"
     },

--- a/packages/@secretlint/secretlint-rule-npm/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-npm/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Change Log
 
-## 0.7.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/types@0.7.1
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-npm
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/secretlint-rule-npm/package.json
+++ b/packages/@secretlint/secretlint-rule-npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-npm",
-    "version": "0.7.1",
+    "version": "0.9.0",
     "description": "A secretlint rule for npm.",
     "keywords": [
         "npm",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^0.7.1",
+        "@secretlint/types": "^0.9.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-preset-recommend/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/CHANGELOG.md
@@ -1,20 +1,18 @@
 # Change Log
 
-## 0.7.3
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/secretlint-rule-aws@0.7.2
-    -   @secretlint/secretlint-rule-basicauth@0.7.1
-    -   @secretlint/secretlint-rule-gcp@0.7.3
-    -   @secretlint/secretlint-rule-npm@0.7.1
-    -   @secretlint/secretlint-rule-privatekey@0.7.2
-    -   @secretlint/secretlint-rule-slack@0.7.2
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+
+### Performance Improvements
+
+* **secretlint-rule-preset-recommend:** rollup ([#76](https://github.com/secretlint/secretlint/issues/76)) ([71c382a](https://github.com/secretlint/secretlint/commit/71c382abb4c2f8bf60319e2716f3d6600f1de8ba))
+
+
+
+
 
 ## [0.7.2](https://github.com/secretlint/secretlint/compare/v0.7.1...v0.7.2) (2020-03-01)
 

--- a/packages/@secretlint/secretlint-rule-preset-recommend/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-preset-recommend",
-    "version": "0.7.3",
+    "version": "0.9.0",
     "description": "Recommended rule preset of secretlint.",
     "keywords": [
         "secretlint",
@@ -44,12 +44,12 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-aws": "^0.7.2",
-        "@secretlint/secretlint-rule-basicauth": "^0.7.1",
-        "@secretlint/secretlint-rule-gcp": "^0.7.3",
-        "@secretlint/secretlint-rule-npm": "^0.7.1",
-        "@secretlint/secretlint-rule-privatekey": "^0.7.2",
-        "@secretlint/secretlint-rule-slack": "^0.7.2"
+        "@secretlint/secretlint-rule-aws": "^0.9.0",
+        "@secretlint/secretlint-rule-basicauth": "^0.9.0",
+        "@secretlint/secretlint-rule-gcp": "^0.9.0",
+        "@secretlint/secretlint-rule-npm": "^0.9.0",
+        "@secretlint/secretlint-rule-privatekey": "^0.9.0",
+        "@secretlint/secretlint-rule-slack": "^0.9.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^11.0.2",

--- a/packages/@secretlint/secretlint-rule-privatekey/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-privatekey/CHANGELOG.md
@@ -1,23 +1,15 @@
 # Change Log
 
-## 0.7.2
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/secretlint-scripts@0.7.1
-    -   @secretlint/tester@0.8.1
-
-## 0.7.1
-
-### Patch Changes
-
--   Updated dependencies [4d0413a]
-    -   @secretlint/tester@0.8.0
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-privatekey
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/secretlint-rule-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-privatekey",
-    "version": "0.7.2",
+    "version": "0.9.0",
     "description": "A secretlint rule for PrivateKey.",
     "keywords": [
         "secretlint",
@@ -47,8 +47,8 @@
         "string.prototype.matchall": "^4.0.2"
     },
     "devDependencies": {
-        "@secretlint/secretlint-scripts": "^0.7.1",
-        "@secretlint/tester": "^0.8.1",
+        "@secretlint/secretlint-scripts": "^0.9.0",
+        "@secretlint/tester": "^0.9.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-slack/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-slack/CHANGELOG.md
@@ -1,23 +1,15 @@
 # Change Log
 
-## 0.7.2
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/tester@0.8.1
-    -   @secretlint/types@0.7.1
-
-## 0.7.1
-
-### Patch Changes
-
--   Updated dependencies [4d0413a]
-    -   @secretlint/tester@0.8.0
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-slack
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/secretlint-rule-slack/package.json
+++ b/packages/@secretlint/secretlint-rule-slack/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-slack",
-    "version": "0.7.2",
+    "version": "0.9.0",
     "description": "A secretlint rule for slack.",
     "keywords": [
         "rule",
@@ -43,12 +43,12 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^0.7.1",
+        "@secretlint/types": "^0.9.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "string.prototype.matchall": "^4.0.2"
     },
     "devDependencies": {
-        "@secretlint/tester": "^0.8.1",
+        "@secretlint/tester": "^0.9.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-scripts/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-scripts/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Change Log
 
-## 0.7.1
-
-### Patch Changes
-
--   aaef596: Path Update
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-scripts
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/secretlint-scripts/package.json
+++ b/packages/@secretlint/secretlint-scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-scripts",
-    "version": "0.7.1",
+    "version": "0.9.0",
     "description": "Secretlint rule scripts",
     "keywords": [
         "secretlint"

--- a/packages/@secretlint/source-creator/CHANGELOG.md
+++ b/packages/@secretlint/source-creator/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Change Log
 
-## 0.7.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/types@0.7.1
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/source-creator
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/source-creator/package.json
+++ b/packages/@secretlint/source-creator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/source-creator",
-    "version": "0.7.1",
+    "version": "0.9.0",
     "description": "Create SecretLintRawSource from content.",
     "keywords": [
         "secretlint",
@@ -42,7 +42,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^0.7.1",
+        "@secretlint/types": "^0.9.0",
         "istextorbinary": "^3.3.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/tester/CHANGELOG.md
+++ b/packages/@secretlint/tester/CHANGELOG.md
@@ -1,29 +1,15 @@
 # Change Log
 
-## 0.8.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
-    -   @secretlint/config-loader@0.7.1
-    -   @secretlint/core@0.8.1
-    -   @secretlint/source-creator@0.7.1
-    -   @secretlint/types@0.7.1
-
-## 0.8.0
-
-### Minor Changes
-
--   4d0413a: `secretlint` CLI support `--secretlintrcJSON` flag
-
-### Patch Changes
-
--   Updated dependencies [4d0413a]
-    -   @secretlint/core@0.8.0
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/tester
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/tester/package.json
+++ b/packages/@secretlint/tester/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/tester",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "description": "A testing library for secretlint rule",
     "keywords": [
         "secretlint",
@@ -41,10 +41,10 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-loader": "^0.7.1",
-        "@secretlint/core": "^0.8.1",
-        "@secretlint/source-creator": "^0.7.1",
-        "@secretlint/types": "^0.7.1"
+        "@secretlint/config-loader": "^0.9.0",
+        "@secretlint/core": "^0.9.0",
+        "@secretlint/source-creator": "^0.9.0",
+        "@secretlint/types": "^0.9.0"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/types/CHANGELOG.md
+++ b/packages/@secretlint/types/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Change Log
 
-## 0.7.1
-
-### Patch Changes
-
--   aaef596: Path Update
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/types
+
+
+
+
 
 # [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
 

--- a/packages/@secretlint/types/package.json
+++ b/packages/@secretlint/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/types",
-    "version": "0.7.1",
+    "version": "0.9.0",
     "description": "A typing package for @secretlint",
     "keywords": [
         "secretlint"

--- a/packages/secretlint/CHANGELOG.md
+++ b/packages/secretlint/CHANGELOG.md
@@ -1,33 +1,18 @@
 # Change Log
 
-## 0.8.1
-
-### Patch Changes
-
--   aaef596: Path Update
--   Updated dependencies [aaef596]
--   Updated dependencies [5a22277]
-    -   @secretlint/config-creator@0.7.1
-    -   @secretlint/formatter@0.8.1
-    -   @secretlint/node@0.8.1
-    -   @secretlint/profiler@0.7.1
-    -   @secretlint/secretlint-rule-example@0.7.1
-    -   @secretlint/secretlint-rule-preset-recommend@0.7.3
-
-## 0.8.0
-
-### Minor Changes
-
--   4d0413a: `secretlint` CLI support `--secretlintrcJSON` flag
-
-### Patch Changes
-
--   Updated dependencies [4d0413a]
-    -   @secretlint/formatter@0.8.0
-    -   @secretlint/node@0.8.0
-
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+
+### Features
+
+* **cli:** support --secretlintrcJSON flag ([#78](https://github.com/secretlint/secretlint/issues/78)) ([449b4a1](https://github.com/secretlint/secretlint/commit/449b4a1c78c33722c41d1251d2dde4d8d040cf88))
+
+
+
+
 
 ## [0.7.3](https://github.com/secretlint/secretlint/compare/v0.7.2...v0.7.3) (2020-03-01)
 

--- a/packages/secretlint/package.json
+++ b/packages/secretlint/package.json
@@ -1,6 +1,6 @@
 {
     "name": "secretlint",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "description": "Secretlint CLI that scan secret/credential data.",
     "keywords": [
         "secretlint",
@@ -45,18 +45,18 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-creator": "^0.7.1",
-        "@secretlint/formatter": "^0.8.1",
-        "@secretlint/node": "^0.8.1",
-        "@secretlint/profiler": "^0.7.1",
+        "@secretlint/config-creator": "^0.9.0",
+        "@secretlint/formatter": "^0.9.0",
+        "@secretlint/node": "^0.9.0",
+        "@secretlint/profiler": "^0.9.0",
         "debug": "^4.1.1",
         "globby": "^11.0.0",
         "meow": "^6.0.1",
         "read-pkg": "^5.2.0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^0.7.1",
-        "@secretlint/secretlint-rule-preset-recommend": "^0.7.3",
+        "@secretlint/secretlint-rule-example": "^0.9.0",
+        "@secretlint/secretlint-rule-preset-recommend": "^0.9.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",


### PR DESCRIPTION
This release is only bump 0.9.0.

We adopt new release flow #88 
For more details, see https://github.com/secretlint/secretlint/blob/master/CONTRIBUTING.md#release-flow