### PR TITLE
revert: remove secretlint-rule-secp256k1-privatekey from canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Secretlint rules has been implemented as separated modules.
 - [@secretlint/secretlint-rule-privatekey](./packages/@secretlint/secretlint-rule-privatekey)
 - [@secretlint/secretlint-rule-basicauth](./packages/@secretlint/secretlint-rule-basicauth)
 - [@secretlint/secretlint-rule-slack](./packages/@secretlint/secretlint-rule-slack)
+- [@secretlint/secretlint-rule-secp256k1-privatekey](./packages/@secretlint/secretlint-rule-secp256k1-privatekey)
 
 Also, Secretlint provide rule preset that package some rule set.
 

--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -49,8 +49,7 @@
         "@secretlint/secretlint-rule-gcp": "^1.0.0",
         "@secretlint/secretlint-rule-npm": "^1.0.0",
         "@secretlint/secretlint-rule-privatekey": "^1.0.0",
-        "@secretlint/secretlint-rule-slack": "^1.0.0",
-        "@secretlint/secretlint-rule-secp256k1-privatekey": "^1.0.0"
+        "@secretlint/secretlint-rule-slack": "^1.0.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^11.0.2",

--- a/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
@@ -5,9 +5,8 @@ import ruleNpm from "@secretlint/secretlint-rule-npm";
 import ruleSlack from "@secretlint/secretlint-rule-slack";
 import ruleBasicAuth from "@secretlint/secretlint-rule-basicauth";
 import rulePrivateKey from "@secretlint/secretlint-rule-privatekey";
-import ruleSecp256k1PrivateKey from "@secretlint/secretlint-rule-secp256k1-privatekey";
 
-export const rules = [ruleAWS, ruleGCP, rulePrivateKey, ruleNpm, ruleBasicAuth, ruleSlack, ruleSecp256k1PrivateKey];
+export const rules = [ruleAWS, ruleGCP, rulePrivateKey, ruleNpm, ruleBasicAuth, ruleSlack];
 export type Options = {};
 
 export const creator: SecretLintRulePresetCreator<Options> = {

--- a/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
@@ -12,7 +12,7 @@ export type Options = {};
 
 export const creator: SecretLintRulePresetCreator<Options> = {
     meta: {
-        id: "@secretlint/secretlint-rule-preset-recommend",
+        id: "@secretlint/secretlint-rule-preset-canary",
         recommended: true,
         type: "preset",
     },

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/README.md
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/README.md
@@ -8,6 +8,21 @@ Install with [npm](https://www.npmjs.com/):
 
     npm install @secretlint/secretlint-rule-secp256k1-privatekey
 
+## Usage
+
+Via `.secretlintrc.json`(Recommended)
+
+```json
+{
+    "rules": [
+        {
+            "id": "@secretlint/secretlint-rule-secp256k1-privatekey"
+        }
+    ]
+}
+```
+
+
 ## MessageIDs
 
 ### secp256k1Priv

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/README.md
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/README.md
@@ -8,7 +8,6 @@ Install with [npm](https://www.npmjs.com/):
 
     npm install @secretlint/secretlint-rule-secp256k1-privatekey
 
-
 ## MessageIDs
 
 ### secp256k1Priv

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/src/index.ts
@@ -1,13 +1,13 @@
 import { SecretLintRuleCreator, SecretLintSourceCode } from "@secretlint/types";
 
-import secp256k1 from 'secp256k1'
-import BN from 'bn.js'
+import secp256k1 from "secp256k1";
+import BN from "bn.js";
 
 export const messages = {
     secp256k1Priv: {
         en: "found secp256k1 private key: {{KEY}}",
-        ja: "秘密鍵(secp256k1) {{KEY}} が見つかりました"
-    }
+        ja: "秘密鍵(secp256k1) {{KEY}} が見つかりました",
+    },
 };
 
 export type Options = {
@@ -22,36 +22,36 @@ export const creator: SecretLintRuleCreator<Options> = {
     messages,
     meta: {
         id: "@secretlint/secretlint-rule-secp256k1-privatekey",
-        recommended: true,
+        recommended: false,
         type: "scanner",
         supportedContentTypes: ["text"],
         docs: {
             url:
-                "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-secp256k1-privatekey/README.md"
-        }
+                "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-secp256k1-privatekey/README.md",
+        },
     },
     create(context) {
         const t = context.createTranslator(messages);
         return {
             file(source: SecretLintSourceCode) {
                 const pattern = /[0-9a-f]{64}/gi;
-                let match
+                let match;
                 while ((match = pattern.exec(source.content)) !== null) {
                     const index = match.index || 0;
                     const matchString = match[0] || "";
                     const range = [index, index + matchString.length];
 
-                    if (!secp256k1.privateKeyVerify(new BN(matchString, 16).toBuffer())) return
+                    if (!secp256k1.privateKeyVerify(new BN(matchString, 16).toBuffer())) return;
 
                     context.report({
                         message: t("secp256k1Priv", {
-                            KEY: matchString
+                            KEY: matchString,
                         }),
-                        range
+                        range,
                     });
                 }
-            }
+            },
         };
-    }
+    },
 };
 export default creator;


### PR DESCRIPTION
This PR will fix benchmark scripts
#107 

Via `.secretlintrc.json`

```json
{
    "rules": [
        {
            "id": "@secretlint/secretlint-rule-preset-recommend"
        },
        {
            "id": "@secretlint/secretlint-rule-secp256k1-privatekey"
        }
    ]
}
```