### PR TITLE
v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+
+### Bug Fixes
+
+* **secretlint-rule-preset-canary:** fix id name ([4c91c60](https://github.com/secretlint/secretlint/commit/4c91c6053194be74ea1d0f080d8a547693c40555))
+* japanese message translation ([629125a](https://github.com/secretlint/secretlint/commit/629125ae11fd5ce842bad4f216abd5ac488805c2))
+* package author ([dddd0f7](https://github.com/secretlint/secretlint/commit/dddd0f764039952ea215c90218b001b865753032))
+
+
+### Features
+
+* **secretlint-rule-preset-canary:** add secretlint-rule-secp256k1-privatekey ([d9d93ed](https://github.com/secretlint/secretlint/commit/d9d93ed657b80fd673e3172ba76792261dc022f4))
+* check for the presence of secp256k1 curve private keys ([a8f1902](https://github.com/secretlint/secretlint/commit/a8f190266c6f3def98592ba599096ddb5e007dd3))
+
+
+### Reverts
+
+* remove secretlint-rule-secp256k1-privatekey from canary ([d6b3aea](https://github.com/secretlint/secretlint/commit/d6b3aea646826334d995426e19b1e998fd6caaa6))
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package root

--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/benchmark
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/benchmark

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@secretlint/benchmark",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Internal benchmark for Secretlint",
     "keywords": [
         "secretlint",
@@ -32,8 +32,8 @@
         "access": "public"
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-preset-canary": "^1.0.0",
+        "@secretlint/secretlint-rule-preset-canary": "^1.0.1",
         "benchmark": "^2.1.4",
-        "secretlint": "^1.0.0"
+        "secretlint": "^1.0.1"
     }
 }

--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/example-cli
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/example-cli

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@secretlint/example-cli",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "",
     "homepage": "https://github.com/secretlint/secretlint/tree/master/examples/cli/",
     "bugs": {
@@ -27,9 +27,9 @@
         "test": "expected-exit-status 1 --command 'secretlint \"**/*\"'"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^1.0.0",
+        "@secretlint/secretlint-rule-preset-recommend": "^1.0.1",
         "expected-exit-status": "^1.0.2",
-        "secretlint": "^1.0.0"
+        "secretlint": "^1.0.1"
     },
     "publishConfig": {
         "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "packages/@secretlint/*",
     "examples/*"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/@secretlint/config-creator/CHANGELOG.md
+++ b/packages/@secretlint/config-creator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/config-creator
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/config-creator

--- a/packages/@secretlint/config-creator/package.json
+++ b/packages/@secretlint/config-creator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-creator",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Config file creator for secretlint.",
     "keywords": [
         "secretlint"
@@ -40,7 +40,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0"
+        "@secretlint/types": "^1.0.1"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/config-loader/CHANGELOG.md
+++ b/packages/@secretlint/config-loader/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/config-loader
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/config-loader

--- a/packages/@secretlint/config-loader/package.json
+++ b/packages/@secretlint/config-loader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-loader",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Config loader for secretlint.",
     "keywords": [
         "secretlint",
@@ -43,16 +43,16 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-validator": "^1.0.0",
-        "@secretlint/profiler": "^1.0.0",
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/config-validator": "^1.0.1",
+        "@secretlint/profiler": "^1.0.1",
+        "@secretlint/types": "^1.0.1",
         "@textlint/module-interop": "^1.0.2",
         "debug": "^4.1.1",
         "rc-config-loader": "^3.0.0",
         "try-resolve": "^1.0.1"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^1.0.0",
+        "@secretlint/secretlint-rule-example": "^1.0.1",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.9.3",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/config-validator/CHANGELOG.md
+++ b/packages/@secretlint/config-validator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/config-validator
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/config-validator

--- a/packages/@secretlint/config-validator/package.json
+++ b/packages/@secretlint/config-validator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-validator",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": ".secretlintrc config validation library",
     "keywords": [
         "secretlint",
@@ -45,7 +45,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/types": "^1.0.1",
         "ajv": "^6.11.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/core/CHANGELOG.md
+++ b/packages/@secretlint/core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/core
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/core

--- a/packages/@secretlint/core/package.json
+++ b/packages/@secretlint/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/core",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Core library for @secretlint.",
     "keywords": [
         "secretlint"
@@ -40,8 +40,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/profiler": "^1.0.0",
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/profiler": "^1.0.1",
+        "@secretlint/types": "^1.0.1",
         "debug": "^4.1.1",
         "escape-string-regexp": "^2.0.0",
         "structured-source": "^3.0.2"

--- a/packages/@secretlint/formatter/CHANGELOG.md
+++ b/packages/@secretlint/formatter/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/formatter
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/formatter

--- a/packages/@secretlint/formatter/package.json
+++ b/packages/@secretlint/formatter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/formatter",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A formatter collection for Secretlint.",
     "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/formatter/",
     "bugs": {
@@ -37,7 +37,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/types": "^1.0.1",
         "@textlint/linter-formatter": "^3.1.12",
         "@textlint/types": "^1.3.1",
         "debug": "^4.1.1",

--- a/packages/@secretlint/messages-to-markdown/CHANGELOG.md
+++ b/packages/@secretlint/messages-to-markdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/messages-to-markdown
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/messages-to-markdown

--- a/packages/@secretlint/messages-to-markdown/package.json
+++ b/packages/@secretlint/messages-to-markdown/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/messages-to-markdown",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Create Markdown text from rule's messages(ids)",
     "keywords": [
         "secretlint"
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/types": "^1.0.1",
         "meow": "^6.1.0",
         "ts-node": "^8.8.1",
         "typescript": "^3.8.2"

--- a/packages/@secretlint/node/CHANGELOG.md
+++ b/packages/@secretlint/node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/node
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/node

--- a/packages/@secretlint/node/package.json
+++ b/packages/@secretlint/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/node",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Secretlint client library for Node.js",
     "keywords": [
         "secretlint",
@@ -41,16 +41,16 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-loader": "^1.0.0",
-        "@secretlint/core": "^1.0.0",
-        "@secretlint/formatter": "^1.0.0",
-        "@secretlint/profiler": "^1.0.0",
-        "@secretlint/source-creator": "^1.0.0",
+        "@secretlint/config-loader": "^1.0.1",
+        "@secretlint/core": "^1.0.1",
+        "@secretlint/formatter": "^1.0.1",
+        "@secretlint/profiler": "^1.0.1",
+        "@secretlint/source-creator": "^1.0.1",
         "debug": "^4.1.1",
         "p-map": "^4.0.0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^1.0.0",
+        "@secretlint/secretlint-rule-example": "^1.0.1",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.9.3",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/profiler/CHANGELOG.md
+++ b/packages/@secretlint/profiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/profiler
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/profiler

--- a/packages/@secretlint/profiler/package.json
+++ b/packages/@secretlint/profiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/profiler",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Profile manager for Secretlint.",
     "keywords": [
         "secretlint"

--- a/packages/@secretlint/quick-start/CHANGELOG.md
+++ b/packages/@secretlint/quick-start/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/quick-start
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/quick-start

--- a/packages/@secretlint/quick-start/package.json
+++ b/packages/@secretlint/quick-start/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/quick-start",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Quick Stater CLI for secretlint.",
     "keywords": [
         "secretlint",
@@ -46,8 +46,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^1.0.0",
-        "secretlint": "^1.0.0"
+        "@secretlint/secretlint-rule-preset-recommend": "^1.0.1",
+        "secretlint": "^1.0.1"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/secretlint-rule-aws/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-aws/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-aws
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-aws

--- a/packages/@secretlint/secretlint-rule-aws/package.json
+++ b/packages/@secretlint/secretlint-rule-aws/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-aws",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A secretlint rule for AWS.",
     "keywords": [
         "secretlint",
@@ -43,13 +43,13 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/types": "^1.0.1",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "regx": "^1.0.4",
         "string.prototype.matchall": "^4.0.2"
     },
     "devDependencies": {
-        "@secretlint/tester": "^1.0.0",
+        "@secretlint/tester": "^1.0.1",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.9.3",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-basicauth/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-basicauth/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-basicauth
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-basicauth

--- a/packages/@secretlint/secretlint-rule-basicauth/package.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-basicauth",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A secretlint rule that check Basic Authentication.",
     "keywords": [
         "secretlint",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/types": "^1.0.1",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "string.prototype.matchall": "^4.0.2"
     },

--- a/packages/@secretlint/secretlint-rule-example/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-example/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-example

--- a/packages/@secretlint/secretlint-rule-example/package.json
+++ b/packages/@secretlint/secretlint-rule-example/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-example",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "An example rule for secretlint. It it for testing.",
     "keywords": [
         "secretlint",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0"
+        "@secretlint/types": "^1.0.1"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/secretlint-rule-gcp/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-gcp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-gcp
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-gcp

--- a/packages/@secretlint/secretlint-rule-gcp/package.json
+++ b/packages/@secretlint/secretlint-rule-gcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-gcp",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A secretlint rule for GCP.",
     "keywords": [
         "rule",
@@ -42,7 +42,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/types": "^1.0.1",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "node-forge": "^0.9.1"
     },

--- a/packages/@secretlint/secretlint-rule-npm/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-npm/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-npm
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-npm

--- a/packages/@secretlint/secretlint-rule-npm/package.json
+++ b/packages/@secretlint/secretlint-rule-npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-npm",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A secretlint rule for npm.",
     "keywords": [
         "npm",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/types": "^1.0.1",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-preset-canary/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-preset-canary/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+
+### Bug Fixes
+
+* **secretlint-rule-preset-canary:** fix id name ([4c91c60](https://github.com/secretlint/secretlint/commit/4c91c6053194be74ea1d0f080d8a547693c40555))
+
+
+### Features
+
+* **secretlint-rule-preset-canary:** add secretlint-rule-secp256k1-privatekey ([d9d93ed](https://github.com/secretlint/secretlint/commit/d9d93ed657b80fd673e3172ba76792261dc022f4))
+
+
+### Reverts
+
+* remove secretlint-rule-secp256k1-privatekey from canary ([d6b3aea](https://github.com/secretlint/secretlint/commit/d6b3aea646826334d995426e19b1e998fd6caaa6))
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-preset-canary

--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-preset-canary",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Canary rule preset of secretlint.",
     "keywords": [
         "secretlint",
@@ -44,18 +44,18 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-aws": "^1.0.0",
-        "@secretlint/secretlint-rule-basicauth": "^1.0.0",
-        "@secretlint/secretlint-rule-gcp": "^1.0.0",
-        "@secretlint/secretlint-rule-npm": "^1.0.0",
-        "@secretlint/secretlint-rule-privatekey": "^1.0.0",
-        "@secretlint/secretlint-rule-slack": "^1.0.0"
+        "@secretlint/secretlint-rule-aws": "^1.0.1",
+        "@secretlint/secretlint-rule-basicauth": "^1.0.1",
+        "@secretlint/secretlint-rule-gcp": "^1.0.1",
+        "@secretlint/secretlint-rule-npm": "^1.0.1",
+        "@secretlint/secretlint-rule-privatekey": "^1.0.1",
+        "@secretlint/secretlint-rule-slack": "^1.0.1"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^11.0.2",
+        "@rollup/plugin-json": "^4.0.2",
         "@rollup/plugin-node-resolve": "^7.1.1",
         "@rollup/plugin-typescript": "^4.0.0",
-        "@rollup/plugin-json": "^4.0.2",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-preset-recommend/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-preset-recommend
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-preset-recommend

--- a/packages/@secretlint/secretlint-rule-preset-recommend/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-preset-recommend",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Recommended rule preset of secretlint.",
     "keywords": [
         "secretlint",
@@ -45,12 +45,12 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-aws": "^1.0.0",
-        "@secretlint/secretlint-rule-basicauth": "^1.0.0",
-        "@secretlint/secretlint-rule-gcp": "^1.0.0",
-        "@secretlint/secretlint-rule-npm": "^1.0.0",
-        "@secretlint/secretlint-rule-privatekey": "^1.0.0",
-        "@secretlint/secretlint-rule-slack": "^1.0.0"
+        "@secretlint/secretlint-rule-aws": "^1.0.1",
+        "@secretlint/secretlint-rule-basicauth": "^1.0.1",
+        "@secretlint/secretlint-rule-gcp": "^1.0.1",
+        "@secretlint/secretlint-rule-npm": "^1.0.1",
+        "@secretlint/secretlint-rule-privatekey": "^1.0.1",
+        "@secretlint/secretlint-rule-slack": "^1.0.1"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^11.0.2",

--- a/packages/@secretlint/secretlint-rule-privatekey/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-privatekey/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-privatekey
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-privatekey

--- a/packages/@secretlint/secretlint-rule-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-privatekey",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A secretlint rule for PrivateKey.",
     "keywords": [
         "secretlint",
@@ -47,8 +47,8 @@
         "string.prototype.matchall": "^4.0.2"
     },
     "devDependencies": {
-        "@secretlint/secretlint-scripts": "^1.0.0",
-        "@secretlint/tester": "^1.0.0",
+        "@secretlint/secretlint-scripts": "^1.0.1",
+        "@secretlint/tester": "^1.0.1",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+
+### Features
+
+* **secretlint-rule-preset-canary:** add secretlint-rule-secp256k1-privatekey ([d9d93ed](https://github.com/secretlint/secretlint/commit/d9d93ed657b80fd673e3172ba76792261dc022f4))

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-secp256k1-privatekey",
-    "version": "1.1.0",
+    "version": "1.0.1",
     "description": "A secretlint rule that checks for secp256k1 private keys.",
     "keywords": [
         "secretlint",
@@ -48,7 +48,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/types": "^1.0.1",
         "@types/bn.js": "^4.11.6",
         "@types/secp256k1": "^3.5.3",
         "bn.js": "^5.1.1",

--- a/packages/@secretlint/secretlint-rule-slack/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-slack/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-slack
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-slack

--- a/packages/@secretlint/secretlint-rule-slack/package.json
+++ b/packages/@secretlint/secretlint-rule-slack/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-slack",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A secretlint rule for slack.",
     "keywords": [
         "rule",
@@ -43,12 +43,12 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/types": "^1.0.1",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "string.prototype.matchall": "^4.0.2"
     },
     "devDependencies": {
-        "@secretlint/tester": "^1.0.0",
+        "@secretlint/tester": "^1.0.1",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-scripts/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-scripts/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-scripts
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/secretlint-scripts

--- a/packages/@secretlint/secretlint-scripts/package.json
+++ b/packages/@secretlint/secretlint-scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-scripts",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Secretlint rule scripts",
     "keywords": [
         "secretlint"

--- a/packages/@secretlint/source-creator/CHANGELOG.md
+++ b/packages/@secretlint/source-creator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/source-creator
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/source-creator

--- a/packages/@secretlint/source-creator/package.json
+++ b/packages/@secretlint/source-creator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/source-creator",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Create SecretLintRawSource from content.",
     "keywords": [
         "secretlint",
@@ -42,7 +42,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^1.0.0",
+        "@secretlint/types": "^1.0.1",
         "istextorbinary": "^3.3.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/tester/CHANGELOG.md
+++ b/packages/@secretlint/tester/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/tester
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/tester

--- a/packages/@secretlint/tester/package.json
+++ b/packages/@secretlint/tester/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/tester",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A testing library for secretlint rule",
     "keywords": [
         "secretlint",
@@ -41,10 +41,10 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-loader": "^1.0.0",
-        "@secretlint/core": "^1.0.0",
-        "@secretlint/source-creator": "^1.0.0",
-        "@secretlint/types": "^1.0.0"
+        "@secretlint/config-loader": "^1.0.1",
+        "@secretlint/core": "^1.0.1",
+        "@secretlint/source-creator": "^1.0.1",
+        "@secretlint/types": "^1.0.1"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/types/CHANGELOG.md
+++ b/packages/@secretlint/types/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/types
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package @secretlint/types

--- a/packages/@secretlint/types/package.json
+++ b/packages/@secretlint/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/types",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A typing package for @secretlint",
     "keywords": [
         "secretlint"

--- a/packages/secretlint/CHANGELOG.md
+++ b/packages/secretlint/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package secretlint
+
+
+
+
+
 # [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
 
 **Note:** Version bump only for package secretlint

--- a/packages/secretlint/package.json
+++ b/packages/secretlint/package.json
@@ -1,6 +1,6 @@
 {
     "name": "secretlint",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Secretlint CLI that scan secret/credential data.",
     "keywords": [
         "secretlint",
@@ -45,18 +45,18 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-creator": "^1.0.0",
-        "@secretlint/formatter": "^1.0.0",
-        "@secretlint/node": "^1.0.0",
-        "@secretlint/profiler": "^1.0.0",
+        "@secretlint/config-creator": "^1.0.1",
+        "@secretlint/formatter": "^1.0.1",
+        "@secretlint/node": "^1.0.1",
+        "@secretlint/profiler": "^1.0.1",
         "debug": "^4.1.1",
         "globby": "^11.0.0",
         "meow": "^6.1.0",
         "read-pkg": "^5.2.0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^1.0.0",
-        "@secretlint/secretlint-rule-preset-recommend": "^1.0.0",
+        "@secretlint/secretlint-rule-example": "^1.0.1",
+        "@secretlint/secretlint-rule-preset-recommend": "^1.0.1",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.9.3",
         "cross-env": "^7.0.0",


### PR DESCRIPTION
## ✨ New Rules

### [@secretlint/secretlint-rule-secp256k1-privatekey](https://github.com/secretlint/secretlint/tree/master/packages/%40secretlint/secretlint-rule-secp256k1-privatekey)

@mtsalenc implemented [@secretlint/secretlint-rule-secp256k1-privatekey](https://github.com/secretlint/secretlint/tree/master/packages/%40secretlint/secretlint-rule-secp256k1-privatekey) in #103 

This rule to check against the inclusion of secp256k1 private keys, used by the Bitcoin and Ethereum blockchains.

You can install it with npm

```
npm install @secretlint/secretlint-rule-secp256k1-privatekey
```

and edit `.secretlintrc.json`

```json
{
    "rules": [
        {
            "id": "@secretlint/secretlint-rule-preset-recommend"
        },
        {
            "id": "@secretlint/secretlint-rule-secp256k1-privatekey"
        }
    ]
}
```