### PR TITLE
v1.0.2: secretlint-rule-secp256k1-privatekey bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.2](https://github.com/secretlint/secretlint/compare/v1.0.1...v1.0.2) (2020-03-29)
+
+
+### Bug Fixes
+
+* **secretlint-rule-secp256k1-privatekey:** handle thrown exception due to invalid key ([#110](https://github.com/secretlint/secretlint/issues/110)) ([320b344](https://github.com/secretlint/secretlint/commit/320b3446d7afd85e342cb9bb15f6e9df7dae8036))
+
+
+
+
+
 ## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "packages/@secretlint/*",
     "examples/*"
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "includeMergedTags": true

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.2](https://github.com/secretlint/secretlint/compare/v1.0.1...v1.0.2) (2020-03-29)
+
+
+### Bug Fixes
+
+* **secretlint-rule-secp256k1-privatekey:** handle thrown exception due to invalid key ([#110](https://github.com/secretlint/secretlint/issues/110)) ([320b344](https://github.com/secretlint/secretlint/commit/320b3446d7afd85e342cb9bb15f6e9df7dae8036))
+
+
+
+
+
 ## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
 
 

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-secp256k1-privatekey",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "A secretlint rule that checks for secp256k1 private keys.",
     "keywords": [
         "secretlint",


### PR DESCRIPTION
## Bug Fixes

**secretlint-rule-secp256k1-privatekey:** handle thrown exception due to invalid key ([#110](https://github.com/secretlint/secretlint/issues/110)) ([320b344](https://github.com/secretlint/secretlint/commit/320b3446d7afd85e342cb9bb15f6e9df7dae8036))

A check is missed. `secp256k1.privateKeyVerify()` can throw for invalid keys as well.