### PR TITLE
feat(secretlint-rule-no-k8s-kind-secret): add new rule

### DIFF
--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/LICENSE
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/README.md
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/README.md
@@ -45,7 +45,7 @@ So, `Kind: Secret` manifest is not committable file into a repository.
 
 - [Secrets - Kubernetes](https://kubernetes.io/docs/concepts/configuration/secret/)
 
-In GitOps context, you can use another solution like [SealedSecret](https://github.com/bitnami-labs/sealed-secrets), Vault etc...
+In GitOps context, you can use another solution like [SealedSecret](https://github.com/bitnami-labs/sealed-secrets), [Vault](https://www.vaultproject.io/) etc...
 
 - [GitOps - Frequently Asked Questions](https://www.weave.works/technologies/gitops-frequently-asked-questions/#manage-secrets)
 - [Secret Management - Argo CD - Declarative GitOps CD for Kubernetes](https://argoproj.github.io/argo-cd/operator-manual/secret-management/)

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/README.md
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/README.md
@@ -1,0 +1,84 @@
+# @secretlint/secretlint-rule-no-k8s-kind-secret
+
+A secretlint rule that disallow to use [Kind: Secret](https://kubernetes.io/docs/concepts/configuration/secret/) in Kubernetes repository. 
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install @secretlint/secretlint-rule-no-k8s-kind-secret
+
+## Usage
+
+Via `.secretlintrc.json`(Recommended)
+
+```json
+{
+    "rules": [
+        {
+            "id": "@secretlint/secretlint-rule-no-k8s-kind-secret"
+        }
+    ]
+}
+```
+
+## MessageIds
+
+### disallowToUseKindSecret
+> disallow to use Kind: Secret in manifest: {{FILE_NAME}}
+
+Kubernetes's [`Kind: Secret`]((https://kubernetes.io/docs/concepts/configuration/secret)) includes credentials as plain format.
+It just base64 encoded value.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+```
+
+So, `Kind: Secret` manifest is not committable file into a repository.
+
+- [Secrets - Kubernetes](https://kubernetes.io/docs/concepts/configuration/secret/)
+* [GitOps - Frequently Asked Questions](https://www.weave.works/technologies/gitops-frequently-asked-questions/#manage-secrets)
+
+In GitOps context, you can use another solution like [SealedSecret](https://github.com/bitnami-labs/sealed-secrets), Vault etc...
+
+- [Secret Management - Argo CD - Declarative GitOps CD for Kubernetes](https://argoproj.github.io/argo-cd/operator-manual/secret-management/)
+
+## Options
+
+## Changelog
+
+See [Releases page](https://github.com/secretlint/secretlint/releases).
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm i -d && npm test
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/secretlint/secretlint/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## Author
+
+- [github/azu](https://github.com/azu)
+- [twitter/azu_re](https://twitter.com/azu_re)
+
+## License
+
+MIT © azu

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/README.md
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/README.md
@@ -44,10 +44,10 @@ data:
 So, `Kind: Secret` manifest is not committable file into a repository.
 
 - [Secrets - Kubernetes](https://kubernetes.io/docs/concepts/configuration/secret/)
-* [GitOps - Frequently Asked Questions](https://www.weave.works/technologies/gitops-frequently-asked-questions/#manage-secrets)
 
 In GitOps context, you can use another solution like [SealedSecret](https://github.com/bitnami-labs/sealed-secrets), Vault etc...
 
+- [GitOps - Frequently Asked Questions](https://www.weave.works/technologies/gitops-frequently-asked-questions/#manage-secrets)
 - [Secret Management - Argo CD - Declarative GitOps CD for Kubernetes](https://argoproj.github.io/argo-cd/operator-manual/secret-management/)
 
 ## Options

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/README.md
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/README.md
@@ -52,6 +52,8 @@ In GitOps context, you can use another solution like [SealedSecret](https://gith
 
 ## Options
 
+- No Options
+
 ## Changelog
 
 See [Releases page](https://github.com/secretlint/secretlint/releases).

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@secretlint/secretlint-rule-no-k8s-kind-secret",
+  "version": "1.0.0",
+  "description": "A secretlint rule that disallow to use Kind: Secret in Kubernetes repository.",
+  "keywords": [
+    "rule",
+    "secretlint"
+  ],
+  "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/",
+  "bugs": {
+    "url": "https://github.com/secretlint/secretlint/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/secretlint/secretlint.git"
+  },
+  "license": "MIT",
+  "author": "azu",
+  "files": [
+    "bin/",
+    "lib/",
+    "src/"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "scripts": {
+    "build": "cross-env NODE_ENV=production tsc -p .",
+    "clean": "rimraf lib/",
+    "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+    "prepublish": "npm run --if-present build",
+    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
+    "test": "mocha \"test/**/*.ts\"",
+    "watch": "tsc -p . --watch"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": false,
+    "tabWidth": 4
+  },
+  "dependencies": {
+    "@secretlint/types": "^1.0.1",
+    "js-yaml": "^3.13.1"
+  },
+  "devDependencies": {
+    "@types/mocha": "^7.0.2",
+    "@types/node": "^13.9.5",
+    "cross-env": "^7.0.2",
+    "mocha": "^7.1.1",
+    "prettier": "^2.0.2",
+    "rimraf": "^3.0.2",
+    "ts-node": "^8.8.1",
+    "ts-node-test-register": "^8.0.1",
+    "typescript": "^3.8.3",
+    "@types/js-yaml": "^3.12.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/src/index.ts
@@ -1,0 +1,69 @@
+import {
+    SecretLintRuleContext,
+    SecretLintRuleCreator,
+    SecretLintRuleMessageTranslate,
+    SecretLintSourceCode,
+} from "@secretlint/types";
+import path from "path";
+import { safeLoad } from "js-yaml";
+
+export const messages = {
+    disallowToUseKindSecret: {
+        en: "disallow to use Kind: Secret in manifest: {{FILE_NAME}}",
+        ja: "Kind: Secretのmanifestがみつかりました: {{FILE_NAME}}",
+    },
+};
+
+export type Options = {};
+
+function reportIfFoundKindSecret({
+    source,
+    context,
+    t,
+}: {
+    source: SecretLintSourceCode;
+    options: Required<Options>;
+    context: SecretLintRuleContext;
+    t: SecretLintRuleMessageTranslate<typeof messages>;
+}) {
+    try {
+        const manifestObject = safeLoad(source.content);
+        // Kind: Secret
+        if (manifestObject["Kind"] == "Secret") {
+            return;
+        }
+        context.report({
+            message: t("disallowToUseKindSecret", {
+                FILE_NAME: source.filePath ? path.basename(source.filePath) : "",
+            }),
+            range: [0, source.content.length],
+        });
+    } catch {
+        // nope
+    }
+}
+
+export const creator: SecretLintRuleCreator<Options> = {
+    messages,
+    meta: {
+        id: "@secretlint/secretlint-rule-no-k8s-kind-secret",
+        recommended: false,
+        type: "scanner",
+        supportedContentTypes: ["text"],
+        docs: {
+            url:
+                "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-no-k8s-kind-secret/README.md",
+        },
+    },
+    create(context, options) {
+        const t = context.createTranslator(messages);
+        return {
+            file(source: SecretLintSourceCode) {
+                if (source.ext === ".yaml" || source.ext === ".yml") {
+                    reportIfFoundKindSecret({ source, options, context, t });
+                }
+            },
+        };
+    },
+};
+export default creator;

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/src/index.ts
@@ -5,7 +5,7 @@ import {
     SecretLintSourceCode,
 } from "@secretlint/types";
 import path from "path";
-import { safeLoad } from "js-yaml";
+import { safeLoadAll } from "js-yaml";
 
 export const messages = {
     disallowToUseKindSecret: {
@@ -27,16 +27,19 @@ function reportIfFoundKindSecret({
     t: SecretLintRuleMessageTranslate<typeof messages>;
 }) {
     try {
-        const manifestObject = safeLoad(source.content);
-        // Kind: Secret
-        if (manifestObject["Kind"] == "Secret") {
-            return;
-        }
-        context.report({
-            message: t("disallowToUseKindSecret", {
-                FILE_NAME: source.filePath ? path.basename(source.filePath) : "",
-            }),
-            range: [0, source.content.length],
+        // Support multi manifest
+        const manifestObjects = safeLoadAll(source.content);
+        manifestObjects.forEach((manifestObject) => {
+            // Kind: Secret
+            if (manifestObject["Kind"] == "Secret") {
+                return;
+            }
+            context.report({
+                message: t("disallowToUseKindSecret", {
+                    FILE_NAME: source.filePath ? path.basename(source.filePath) : "",
+                }),
+                range: [0, source.content.length],
+            });
         });
     } catch {
         // nope

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/index.test.ts
@@ -1,0 +1,26 @@
+import { snapshot } from "@secretlint/tester";
+import path from "path";
+import rule from "../src/index";
+
+describe("@secretlint/secretlint-rule-no-k8s-kind-secret", () => {
+    snapshot({
+        defaultConfig: {
+            rules: [
+                {
+                    id: require("../package.json").name,
+                    rule,
+                    options: {},
+                },
+            ],
+        },
+        updateSnapshot: !!process.env.UPDATE_SNAPSHOT,
+        snapshotDirectory: path.join(__dirname, "snapshots"),
+    }).forEach((name, test) => {
+        it(name, async function () {
+            const status = await test();
+            if (status === "skip") {
+                this.skip();
+            }
+        });
+    });
+});

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/mocha.opts
@@ -1,0 +1,1 @@
+--require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ng.kind-secret-multiple/input.yml
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ng.kind-secret-multiple/input.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nginx-svc
+  labels:
+    app: nginx
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ng.kind-secret-multiple/output.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ng.kind-secret-multiple/output.json
@@ -1,11 +1,11 @@
 {
-    "filePath": "[SNAPSHOT]/ok.valid/input.yaml",
+    "filePath": "[SNAPSHOT]/ng.kind-secret-multiple/input.yml",
     "messages": [
         {
-            "message": "disallow to use Kind: Secret in manifest: input.yaml",
+            "message": "disallow to use Kind: Secret in manifest: input.yml",
             "range": [
                 0,
-                510
+                291
             ],
             "ruleId": "@secretlint/secretlint-rule-no-k8s-kind-secret",
             "loc": {
@@ -14,7 +14,7 @@
                     "column": 0
                 },
                 "end": {
-                    "line": 35,
+                    "line": 22,
                     "column": 0
                 }
             },
@@ -22,7 +22,7 @@
             "messageId": "disallowToUseKindSecret",
             "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-no-k8s-kind-secret/README.md#disallowToUseKindSecret",
             "data": {
-                "FILE_NAME": "input.yaml"
+                "FILE_NAME": "input.yml"
             }
         }
     ]

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ng.kind-secret/input.yml
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ng.kind-secret/input.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ng.kind-secret/output.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ng.kind-secret/output.json
@@ -1,0 +1,29 @@
+{
+    "filePath": "[SNAPSHOT]/ng.kind-secret/input.yml",
+    "messages": [
+        {
+            "message": "disallow to use Kind: Secret manifest: input.yml",
+            "range": [
+                0,
+                124
+            ],
+            "ruleId": "@secretlint/secretlint-rule-no-k8s-kind-secret",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 9,
+                    "column": 0
+                }
+            },
+            "severity": "error",
+            "messageId": "disallowToUseKindSecret",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-no-k8s-kind-secret/README.md#disallowToUseKindSecret",
+            "data": {
+                "FILE_NAME": "input.yml"
+            }
+        }
+    ]
+}

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ng.kind-secret/output.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ng.kind-secret/output.json
@@ -2,7 +2,7 @@
     "filePath": "[SNAPSHOT]/ng.kind-secret/input.yml",
     "messages": [
         {
-            "message": "disallow to use Kind: Secret manifest: input.yml",
+            "message": "disallow to use Kind: Secret in manifest: input.yml",
             "range": [
                 0,
                 124

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ok.valid/input.txt
@@ -1,0 +1,1 @@
+THIS IS OK https: https://api.slack.com/web.

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ok.valid/input.txt
@@ -1,1 +1,0 @@
-THIS IS OK https: https://api.slack.com/web.

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ok.valid/input.yaml
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ok.valid/input.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nginx-svc
+  labels:
+    app: nginx
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+  selector:
+    app: nginx
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/snapshots/ok.valid/output.json
@@ -1,0 +1,4 @@
+{
+    "filePath": "[SNAPSHOT]/ok.valid/input.txt",
+    "messages": []
+}

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "declaration": false,
+        "noEmit": true
+    },
+    "include": [
+        "../src/**/*",
+        "./**/*"
+    ]
+}

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "newLine": "LF",
+    "outDir": "./lib/",
+    "target": "ES2015",
+    "sourceMap": true,
+    "declaration": true,
+    "jsx": "preserve",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    /* Strict Type-Checking Options */
+    "strict": true,
+    /* Additional Checks */
+    /* Report errors on unused locals. */
+    "noUnusedLocals": true,
+    /* Report errors on unused parameters. */
+    "noUnusedParameters": true,
+    /* Report error when not all code paths in function return a value. */
+    "noImplicitReturns": true,
+    /* Report errors for fallthrough cases in switch statement. */
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    ".git",
+    "node_modules"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,6 +1341,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/js-yaml@^3.12.3":
+  version "3.12.3"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.3.tgz#abf383c5b639d0aa8b8c4a420d6a85f703357d6c"
+  integrity sha512-otRe77JNNWzoVGLKw8TCspKswRoQToys4tuL6XYVBFxjgeM0RUrx7m3jkaTdxILxeGry3zM8mGYkGXMeQ02guA==
+
 "@types/json-stable-stringify@^1.0.32":
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
@@ -1356,7 +1361,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/mocha@^7.0.1":
+"@types/mocha@^7.0.1", "@types/mocha@^7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-7.0.2.tgz#b17f16cf933597e10d6d78eae3251e692ce8b0ce"
   integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
@@ -1377,6 +1382,11 @@
   version "12.12.30"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.30.tgz#3501e6f09b954de9c404671cefdbcc5d9d7c45f6"
   integrity sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg==
+
+"@types/node@^13.9.5":
+  version "13.9.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.5.tgz#59738bf30b31aea1faa2df7f4a5f55613750cf00"
+  integrity sha512-hkzMMD3xu6BrJpGVLeQ3htQQNAcOrJjX7WFmtK8zWQpz2UJf13LCFF2ALA7c9OVdvc2vQJeDdjfR35M0sBCxvw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2403,7 +2413,7 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-cross-env@^7.0.0:
+cross-env@^7.0.0, cross-env@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
   integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==


### PR DESCRIPTION
Implemented `secretlint-rule-no-k8s-kind-secret` rule that disallow to use `Kind: Secret` manifest in a repository.

fix #112 