### PR TITLE
chore: migrate mocha.opts to .mocharc.json

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/config-creator/.mocharc.json
+++ b/packages/@secretlint/config-creator/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/config-creator/test/mocha.opts
+++ b/packages/@secretlint/config-creator/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/config-loader/.mocharc.json
+++ b/packages/@secretlint/config-loader/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/config-loader/test/mocha.opts
+++ b/packages/@secretlint/config-loader/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/config-validator/.mocharc.json
+++ b/packages/@secretlint/config-validator/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/config-validator/test/mocha.opts
+++ b/packages/@secretlint/config-validator/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/core/.mocharc.json
+++ b/packages/@secretlint/core/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/core/test/mocha.opts
+++ b/packages/@secretlint/core/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/formatter/.mocharc.json
+++ b/packages/@secretlint/formatter/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/formatter/test/mocha.opts
+++ b/packages/@secretlint/formatter/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/messages-to-markdown/.mocharc.json
+++ b/packages/@secretlint/messages-to-markdown/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/messages-to-markdown/test/mocha.opts
+++ b/packages/@secretlint/messages-to-markdown/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/node/.mocharc.json
+++ b/packages/@secretlint/node/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/node/test/mocha.opts
+++ b/packages/@secretlint/node/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/profiler/.mocharc.json
+++ b/packages/@secretlint/profiler/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/profiler/test/mocha.opts
+++ b/packages/@secretlint/profiler/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-aws/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-aws/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/secretlint-rule-aws/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-aws/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-basicauth/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/secretlint-rule-basicauth/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-basicauth/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-example/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-example/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/secretlint-rule-example/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-example/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-gcp/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-gcp/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/secretlint-rule-gcp/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-gcp/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-npm/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-npm/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/secretlint-rule-npm/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-npm/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-preset-canary/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-preset-recommend/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-privatekey/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/secretlint-rule-privatekey/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-privatekey/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/secretlint-rule-slack/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-slack/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/secretlint-rule-slack/test/mocha.opts
+++ b/packages/@secretlint/secretlint-rule-slack/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/source-creator/.mocharc.json
+++ b/packages/@secretlint/source-creator/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/source-creator/test/mocha.opts
+++ b/packages/@secretlint/source-creator/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/tester/.mocharc.json
+++ b/packages/@secretlint/tester/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/tester/test/mocha.opts
+++ b/packages/@secretlint/tester/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@secretlint/types/.mocharc.json
+++ b/packages/@secretlint/types/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/@secretlint/types/test/mocha.opts
+++ b/packages/@secretlint/types/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/secretlint/.mocharc.json
+++ b/packages/secretlint/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/packages/secretlint/test/mocha.opts
+++ b/packages/secretlint/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/publish/binary-compiler/.mocharc.json
+++ b/publish/binary-compiler/.mocharc.json
@@ -1,0 +1,5 @@
+{
+ "require": [
+  "ts-node-test-register"
+ ]
+}

--- a/publish/binary-compiler/test/mocha.opts
+++ b/publish/binary-compiler/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register


### PR DESCRIPTION
Migrate `mocha.opts` files to `.mocharc.json` files by using [@azu/mocha-migrate](https://github.com/azu/mocha-migrate).

fix #125