### PR TITLE
feat(secretlint-rule-no-homedir): add new rule

### DIFF
--- a/packages/@secretlint/messages-to-markdown/src/index.ts
+++ b/packages/@secretlint/messages-to-markdown/src/index.ts
@@ -5,12 +5,15 @@ export type messagesToMarkdownOptions = {
 };
 export const messagesToMarkdown = (messages: SecretLintRuleLocalizeMessages, options: messagesToMarkdownOptions) => {
     let output = "";
-    const proxy = new Proxy({}, {
-        get(_target: {}, p: PropertyKey, _receiver: any): any {
-            return `{{${String(p)}}`;
+    const proxy = new Proxy(
+        {},
+        {
+            get(_target: {}, p: PropertyKey, _receiver: any): any {
+                return `{{${String(p)}}}`;
+            },
         }
-    });
-    Object.keys(messages).forEach(messageId => {
+    );
+    Object.keys(messages).forEach((messageId) => {
         const enMessage = (messages[messageId] as SecretLintRuleLocalizeMessageMulti<any>)["en"];
         const shortDescription = enMessage(proxy).split("\n")[0];
         output += `${"#".repeat(options.headerLevel)} ${messageId}

--- a/packages/@secretlint/secretlint-rule-no-homedir/.mocharc.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-no-homedir/LICENSE
+++ b/packages/@secretlint/secretlint-rule-no-homedir/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@secretlint/secretlint-rule-no-homedir/README.md
+++ b/packages/@secretlint/secretlint-rule-no-homedir/README.md
@@ -24,7 +24,12 @@ Via `.secretlintrc.json`(Recommended)
 
 ## MessageIDs
 
-- [ ] Rule Description
+### HOMEDIR
+> found user's homedir path: {{PATH}}
+
+If it is expected exposed, please ignore it by following way.
+
+- `.secretlintignore`: ignore specific file
 
 ## Options
 

--- a/packages/@secretlint/secretlint-rule-no-homedir/README.md
+++ b/packages/@secretlint/secretlint-rule-no-homedir/README.md
@@ -1,6 +1,8 @@
 # @secretlint/secretlint-rule-no-homedir
 
-A secretlint rule that disallow to include user&#39;s homedir path.
+A secretlint rule that disallow to include user's homedir path.
+
+For example, The user homedir is `/Usrs/exampleuser`, then this rule check if `/Usrs/exampleuser` is included. 
 
 ## Install
 

--- a/packages/@secretlint/secretlint-rule-no-homedir/README.md
+++ b/packages/@secretlint/secretlint-rule-no-homedir/README.md
@@ -1,0 +1,60 @@
+# @secretlint/secretlint-rule-no-homedir
+
+A secretlint rule that disallow to include user&#39;s homedir path.
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install @secretlint/secretlint-rule-no-homedir
+
+## Usage
+
+Via `.secretlintrc.json`(Recommended)
+
+```json
+{
+    "rules": [
+        {
+            "id": "@secretlint/secretlint-rule-no-homedir"
+        }
+    ]
+}
+```
+
+## MessageIDs
+
+- [ ] Rule Description
+
+## Options
+
+## Changelog
+
+See [Releases page](https://github.com/secretlint/secretlint/releases).
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm i -d && npm test
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/secretlint/secretlint/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## Author
+
+- [github/azu](https://github.com/azu)
+- [twitter/azu_re](https://twitter.com/azu_re)
+
+## License
+
+MIT © azu

--- a/packages/@secretlint/secretlint-rule-no-homedir/package.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@secretlint/secretlint-rule-no-homedir",
+  "version": "1.0.0",
+  "description": "A secretlint rule that disallow to include user's homedir path.",
+  "keywords": [
+    "rule",
+    "secretlint"
+  ],
+  "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-no-homedir/",
+  "bugs": {
+    "url": "https://github.com/secretlint/secretlint/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/secretlint/secretlint.git"
+  },
+  "license": "MIT",
+  "author": "azu",
+  "files": [
+    "bin/",
+    "lib/",
+    "src/"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "scripts": {
+    "build": "cross-env NODE_ENV=production tsc -p .",
+    "clean": "rimraf lib/",
+    "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+    "prepublish": "npm run --if-present build",
+    "test": "mocha \"test/**/*.ts\"",
+    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
+    "watch": "tsc -p . --watch"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": false,
+    "tabWidth": 4
+  },
+  "dependencies": {
+    "escape-string-regexp": "^4.0.0",
+    "@secretlint/types": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/mocha": "^7.0.2",
+    "@types/node": "^13.13.4",
+    "cross-env": "^7.0.2",
+    "mocha": "^7.1.2",
+    "prettier": "^2.0.5",
+    "rimraf": "^3.0.2",
+    "ts-node": "^8.9.1",
+    "ts-node-test-register": "^8.0.1",
+    "typescript": "^3.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@secretlint/secretlint-rule-no-homedir/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-no-homedir/src/index.ts
@@ -32,13 +32,6 @@ export type Options = {
      * See https://github.com/textlint/regexp-string-matcher#regexp-like-string
      **/
     allows?: string[];
-
-    /**
-     * allow partial match like "/path/to/Users/exampleuser/"
-     * "/Users/exampleuser/" will be secret, but it is partial match.
-     * If you want to allow it, set to true.
-     */
-    allowPartialMatch: boolean;
     /**
      * For debug
      */

--- a/packages/@secretlint/secretlint-rule-no-homedir/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-no-homedir/src/index.ts
@@ -22,7 +22,7 @@ const multiplatformPath = (dirPath: string): RegExp => {
 export const messages = {
     HOMEDIR: {
         en: (props: { PATH: string }) => `found user's homedir path: ${props.PATH}`,
-        ja: (props: { PATH: string }) => `ユーザーフォームのパスが見つかりました: ${props.PATH}`,
+        ja: (props: { PATH: string }) => `ユーザーホームのパスが見つかりました: ${props.PATH}`,
     },
 };
 

--- a/packages/@secretlint/secretlint-rule-no-homedir/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-no-homedir/src/index.ts
@@ -1,0 +1,111 @@
+import {
+    SecretLintRuleContext,
+    SecretLintRuleCreator,
+    SecretLintRuleMessageTranslate,
+    SecretLintSourceCode,
+} from "@secretlint/types";
+import { matchPatterns } from "@textlint/regexp-string-matcher";
+import escapeStringRegexp from "escape-string-regexp";
+import os from "os";
+
+require("string.prototype.matchall").shim();
+
+const multiplatformPath = (dirPath: string): RegExp => {
+    return new RegExp(
+        dirPath
+            .split(/[\/¥]/)
+            .map((pathinfo) => escapeStringRegexp(pathinfo))
+            .join("[/¥]"),
+        "g"
+    );
+};
+export const messages = {
+    HOMEDIR: {
+        en: (props: { PATH: string }) => `found user's homedir path: ${props.PATH}`,
+        ja: (props: { PATH: string }) => `ユーザーフォームのパスが見つかりました: ${props.PATH}`,
+    },
+};
+
+export type Options = {
+    /**
+     * Define allow pattern written by RegReg-like strings
+     * See https://github.com/textlint/regexp-string-matcher#regexp-like-string
+     **/
+    allows?: string[];
+
+    /**
+     * allow partial match like "/path/to/Users/exampleuser/"
+     * "/Users/exampleuser/" will be secret, but it is partial match.
+     * If you want to allow it, set to true.
+     */
+    allowPartialMatch: boolean;
+    /**
+     * For debug
+     */
+    _debugHomeDir?: string;
+};
+
+function reportIfFoundHomedir({
+    source,
+    options,
+    context,
+    t,
+    getUserHomeDirPattern,
+}: {
+    source: SecretLintSourceCode;
+    options: Required<Omit<Options, "_debugHomeDir">>;
+    context: SecretLintRuleContext;
+    t: SecretLintRuleMessageTranslate<typeof messages>;
+    getUserHomeDirPattern: () => RegExp;
+}) {
+    const homedirPattern = getUserHomeDirPattern();
+    const results = source.content.matchAll(homedirPattern);
+    for (const result of results) {
+        const index = result.index || 0;
+        const match = result[0] || "";
+        const range = [index, index + match.length];
+        const allowedResults = matchPatterns(match, options.allows);
+        if (allowedResults.length > 0) {
+            continue;
+        }
+        context.report({
+            message: t("HOMEDIR", {
+                PATH: match,
+            }),
+            range,
+        });
+    }
+}
+
+export const creator: SecretLintRuleCreator<Options> = {
+    messages,
+    meta: {
+        id: "@secretlint/secretlint-rule-no-homedir",
+        recommended: true,
+        type: "scanner",
+        supportedContentTypes: ["text"],
+        docs: {
+            url:
+                "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-no-homedir/README.md",
+        },
+    },
+    create(context, options) {
+        const t = context.createTranslator(messages);
+        const normalizedOptions = {
+            allows: options.allows || [],
+        };
+        const userHomeDirPattern = multiplatformPath(options._debugHomeDir ?? os.homedir());
+        /**
+         * Clone RegExp to avoid reuse lastIndex
+         */
+        const getUserHomeDirPattern = () => {
+            return new RegExp(userHomeDirPattern.source, userHomeDirPattern.flags);
+        };
+        return {
+            file(source: SecretLintSourceCode) {
+                reportIfFoundHomedir({ source, options: normalizedOptions, context, t, getUserHomeDirPattern });
+            },
+        };
+    },
+};
+export default creator;

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/index.test.ts
@@ -1,0 +1,26 @@
+import { snapshot } from "@secretlint/tester";
+import path from "path";
+import rule from "../src/index";
+
+describe("@secretlint/secretlint-rule-no-homedir", () => {
+    snapshot({
+        defaultConfig: {
+            rules: [
+                {
+                    id: require("../package.json").name,
+                    rule,
+                    options: {},
+                },
+            ],
+        },
+        updateSnapshot: !!process.env.UPDATE_SNAPSHOT,
+        snapshotDirectory: path.join(__dirname, "snapshots"),
+    }).forEach((name, test) => {
+        it(name, async function () {
+            const status = await test();
+            if (status === "skip") {
+                this.skip();
+            }
+        });
+    });
+});

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.homedir/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.homedir/.secretlintrc.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-no-homedir",
+      "options": {
+        "_debugHomeDir": "/Users/exampleuser"
+      }
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.homedir/input.txt
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.homedir/input.txt
@@ -1,0 +1,2 @@
+Homedir: /Users/exampleuser
+Windows: ¥Users¥exampleuser

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.homedir/output.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.homedir/output.json
@@ -1,0 +1,53 @@
+{
+    "filePath": "[SNAPSHOT]/ng.homedir/input.txt",
+    "messages": [
+        {
+            "message": "found user's homedir path: /Users/exampleuser",
+            "range": [
+                9,
+                27
+            ],
+            "ruleId": "@secretlint/secretlint-rule-no-homedir",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            },
+            "severity": "error",
+            "messageId": "HOMEDIR",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-no-homedir/README.md#HOMEDIR",
+            "data": {
+                "PATH": "/Users/exampleuser"
+            }
+        },
+        {
+            "message": "found user's homedir path: ¥Users¥exampleuser",
+            "range": [
+                37,
+                55
+            ],
+            "ruleId": "@secretlint/secretlint-rule-no-homedir",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 9
+                },
+                "end": {
+                    "line": 2,
+                    "column": 27
+                }
+            },
+            "severity": "error",
+            "messageId": "HOMEDIR",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-no-homedir/README.md#HOMEDIR",
+            "data": {
+                "PATH": "¥Users¥exampleuser"
+            }
+        }
+    ]
+}

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.patial-homedir/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.patial-homedir/.secretlintrc.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-no-homedir",
+      "options": {
+        "_debugHomeDir": "/Users/exampleuser"
+      }
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.patial-homedir/input.txt
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.patial-homedir/input.txt
@@ -1,0 +1,2 @@
+Partial match: /path/to/Users/exampleuser
+Partial match: ¥path¥to¥Users¥exampleuser

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.patial-homedir/output.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.patial-homedir/output.json
@@ -1,0 +1,53 @@
+{
+    "filePath": "[SNAPSHOT]/ng.patial-homedir/input.txt",
+    "messages": [
+        {
+            "message": "found user's homedir path: /Users/exampleuser",
+            "range": [
+                23,
+                41
+            ],
+            "ruleId": "@secretlint/secretlint-rule-no-homedir",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 41
+                }
+            },
+            "severity": "error",
+            "messageId": "HOMEDIR",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-no-homedir/README.md#HOMEDIR",
+            "data": {
+                "PATH": "/Users/exampleuser"
+            }
+        },
+        {
+            "message": "found user's homedir path: ¥Users¥exampleuser",
+            "range": [
+                65,
+                83
+            ],
+            "ruleId": "@secretlint/secretlint-rule-no-homedir",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 23
+                },
+                "end": {
+                    "line": 2,
+                    "column": 41
+                }
+            },
+            "severity": "error",
+            "messageId": "HOMEDIR",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-no-homedir/README.md#HOMEDIR",
+            "data": {
+                "PATH": "¥Users¥exampleuser"
+            }
+        }
+    ]
+}

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ok.valid/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ok.valid/.secretlintrc.json
@@ -1,0 +1,10 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-no-homedir",
+      "options": {
+        "_debugHomeDir": "/Users/exampleuser"
+      }
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ok.valid/input.txt
@@ -1,0 +1,3 @@
+/path/to/dir
+It is not path: ~Users~exampleuser
+It is not homedir: /Users/to/dir/exampleuser

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ok.valid/output.json
@@ -1,0 +1,4 @@
+{
+    "filePath": "[SNAPSHOT]/ok.valid/input.txt",
+    "messages": []
+}

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "declaration": false,
+        "noEmit": true
+    },
+    "include": [
+        "../src/**/*",
+        "./**/*"
+    ]
+}

--- a/packages/@secretlint/secretlint-rule-no-homedir/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "newLine": "LF",
+    "outDir": "./lib/",
+    "target": "ES2015",
+    "sourceMap": true,
+    "declaration": true,
+    "jsx": "preserve",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    /* Strict Type-Checking Options */
+    "strict": true,
+    /* Additional Checks */
+    /* Report errors on unused locals. */
+    "noUnusedLocals": true,
+    /* Report errors on unused parameters. */
+    "noUnusedParameters": true,
+    /* Report error when not all code paths in function return a value. */
+    "noImplicitReturns": true,
+    /* Report errors for fallthrough cases in switch statement. */
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    ".git",
+    "node_modules"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1135,6 +1135,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.0.tgz#390ea202539c61c8fa6ba4428b57e05bc36dc47b"
   integrity sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ==
 
+"@types/node@^13.13.4":
+  version "13.13.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.4.tgz#1581d6c16e3d4803eb079c87d4ac893ee7501c2c"
+  integrity sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -2518,6 +2523,11 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-formatter-pretty@^1.3.0:
   version "1.3.0"
@@ -4472,7 +4482,7 @@ mkdirp@0.5.3:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.5, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -4498,6 +4508,36 @@ mocha@^7.0.1, mocha@^7.1.0, mocha@^7.1.1:
     log-symbols "3.0.0"
     minimatch "3.0.4"
     mkdirp "0.5.3"
+    ms "2.1.1"
+    node-environment-flags "1.0.6"
+    object.assign "4.1.0"
+    strip-json-comments "2.0.1"
+    supports-color "6.0.0"
+    which "1.3.1"
+    wide-align "1.1.3"
+    yargs "13.3.2"
+    yargs-parser "13.1.2"
+    yargs-unparser "1.6.0"
+
+mocha@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.1.2.tgz#8e40d198acf91a52ace122cd7599c9ab857b29e6"
+  integrity sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==
+  dependencies:
+    ansi-colors "3.2.3"
+    browser-stdout "1.3.1"
+    chokidar "3.3.0"
+    debug "3.2.6"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    find-up "3.0.0"
+    glob "7.1.3"
+    growl "1.10.5"
+    he "1.2.0"
+    js-yaml "3.13.1"
+    log-symbols "3.0.0"
+    minimatch "3.0.4"
+    mkdirp "0.5.5"
     ms "2.1.1"
     node-environment-flags "1.0.6"
     object.assign "4.1.0"
@@ -5232,6 +5272,11 @@ prettier@^2.0.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
   integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
 
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -5917,6 +5962,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@^0.5.6:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
@@ -6488,6 +6541,17 @@ ts-node@^8.6.2, ts-node@^8.8.1:
     diff "^4.0.1"
     make-error "^1.1.1"
     source-map-support "^0.5.6"
+    yn "3.1.1"
+
+ts-node@^8.9.1:
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.9.1.tgz#2f857f46c47e91dcd28a14e052482eb14cfd65a5"
+  integrity sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
     yn "3.1.1"
 
 tsconfig-loader@^1.1.0:


### PR DESCRIPTION
Implement `secretlint-rule-no-homedir` that disallow to include user homedir in each files.

It will prevent to unexpected expose user's path and user name.

fix #62 
