### PR TITLE
fix(secretlint): fix handling for non-ascii file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   "prettier": {
     "singleQuote": false,
     "printWidth": 120,
-    "tabWidth": 4
+    "tabWidth": 4,
+    "trailingComma": "none"
   },
   "husky": {
     "hooks": {

--- a/packages/secretlint/src/search.ts
+++ b/packages/secretlint/src/search.ts
@@ -8,7 +8,7 @@ const DEFAULT_IGNORE_PATTERNS = Object.freeze([
     "**/node_modules/**",
     "**/.secretlintrc/**",
     "**/.secretlintrc.{json,yaml,yml,js}/**",
-    "**/.secretlintignore*/**"
+    "**/.secretlintignore*/**",
 ]);
 export type SearchFilesOptions = {
     cwd: string;
@@ -49,7 +49,7 @@ export const searchFiles = async (patterns: string[], options: SearchFilesOption
             const ignored = fs
                 .readFileSync(normalizeIgnoreFilePath, "utf-8")
                 .split(/\r?\n/)
-                .filter(line => !/^\s*$/.test(line) && !/^\s*#/.test(line))
+                .filter((line) => !/^\s*$/.test(line) && !/^\s*#/.test(line))
                 .map(mapGitIgnorePatternTo(baseDir));
             debug("ignored: %o", ignored);
             ignoredPatterns.push(...ignored);
@@ -60,12 +60,13 @@ export const searchFiles = async (patterns: string[], options: SearchFilesOption
     const searchResultItems = await globby(patterns, {
         cwd: options.cwd,
         ignore: ignoredPatterns,
-        dot: true
+        dot: true,
+        absolute: true,
     });
     if (searchResultItems.length > 0) {
         return {
             ok: true,
-            items: searchResultItems
+            items: searchResultItems,
         };
     }
     /**
@@ -78,11 +79,11 @@ export const searchFiles = async (patterns: string[], options: SearchFilesOption
         (
             await globby(patterns, {
                 cwd: options.cwd,
-                dot: true
+                dot: true,
             })
         ).length > 0;
     return {
         ok: isEmptyResultIsHappenByIgnoring,
-        items: []
+        items: [],
     };
 };

--- a/packages/secretlint/test/snapshots/non-ascii-file/input-non-ascii-file-日本語.md
+++ b/packages/secretlint/test/snapshots/non-ascii-file/input-non-ascii-file-日本語.md
@@ -1,0 +1,1 @@
+Include non-ascii character in file name. 

--- a/packages/secretlint/test/snapshots/non-ascii-file/options.ts
+++ b/packages/secretlint/test/snapshots/non-ascii-file/options.ts
@@ -1,0 +1,4 @@
+import { cli } from "../../../src/cli";
+
+export const inputs: string[] = ["input-non-ascii-file-*.md"];
+export const options: Partial<typeof cli.flags> = {};

--- a/packages/secretlint/test/snapshots/non-ascii-file/output.json
+++ b/packages/secretlint/test/snapshots/non-ascii-file/output.json
@@ -1,0 +1,10 @@
+{
+    "exitStatus": 0,
+    "stdout": [
+        {
+            "filePath": "[SNAPSHOT]/non-ascii-file/input-non-ascii-file-日本語.md",
+            "messages": []
+        }
+    ],
+    "stderr": null
+}


### PR DESCRIPTION
I've noticed that secretlint can not handle non-ascii file name like `non-asciii-日本語ファイル.md`.

It will throw an error if you check a non-ascii file with secretlint.

> Error: ENAMETOOLONG: name too long,


This problem is caused by globby/fast-glob result, I think.

- ascii file: absolute path
- non-ascii file: file name only(not relative path)


I've add `absolute` option explicitly as workaround.