### PR TITLE
2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+
+### Bug Fixes
+
+* **secretlint:** fix handling for non-ascii file path ([#137](https://github.com/secretlint/secretlint/issues/137)) ([510decf](https://github.com/secretlint/secretlint/commit/510decf4605b202539c7bedf7a6ea22bdd4cc62f))
+
+
+### Features
+
+* **rule:** Creating new rule for SecretLint for using regular expressions ([#139](https://github.com/secretlint/secretlint/issues/139)) ([097921f](https://github.com/secretlint/secretlint/commit/097921f9682b619dbeb5e35068b1c57913bf5df9))
+* **secretlint-rule-no-homedir:** add new rule ([#136](https://github.com/secretlint/secretlint/issues/136)) ([447e2e0](https://github.com/secretlint/secretlint/commit/447e2e0b473e267934ea42ed8788de15dcea9cd8))
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 

--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/benchmark
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/benchmark

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@secretlint/benchmark",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Internal benchmark for Secretlint",
     "keywords": [
         "secretlint",
@@ -32,8 +32,8 @@
         "access": "public"
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-preset-canary": "^2.0.0",
+        "@secretlint/secretlint-rule-preset-canary": "^2.1.0",
         "benchmark": "^2.1.4",
-        "secretlint": "^2.0.0"
+        "secretlint": "^2.1.0"
     }
 }

--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/example-cli
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/example-cli

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@secretlint/example-cli",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "",
     "homepage": "https://github.com/secretlint/secretlint/tree/master/examples/cli/",
     "bugs": {
@@ -27,9 +27,9 @@
         "test": "expected-exit-status 1 --command 'secretlint \"**/*\"'"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^2.0.0",
+        "@secretlint/secretlint-rule-preset-recommend": "^2.1.0",
         "expected-exit-status": "^1.0.2",
-        "secretlint": "^2.0.0"
+        "secretlint": "^2.1.0"
     },
     "publishConfig": {
         "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "packages/@secretlint/*",
     "examples/*"
   ],
-  "version": "2.0.0",
+  "version": "2.1.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "includeMergedTags": true

--- a/packages/@secretlint/config-creator/CHANGELOG.md
+++ b/packages/@secretlint/config-creator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/config-creator
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/config-creator

--- a/packages/@secretlint/config-creator/package.json
+++ b/packages/@secretlint/config-creator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-creator",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Config file creator for secretlint.",
     "keywords": [
         "secretlint"
@@ -40,7 +40,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0"
+        "@secretlint/types": "^2.1.0"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/config-loader/CHANGELOG.md
+++ b/packages/@secretlint/config-loader/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/config-loader
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/config-loader

--- a/packages/@secretlint/config-loader/package.json
+++ b/packages/@secretlint/config-loader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-loader",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Config loader for secretlint.",
     "keywords": [
         "secretlint",
@@ -43,16 +43,16 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-validator": "^2.0.0",
-        "@secretlint/profiler": "^2.0.0",
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/config-validator": "^2.1.0",
+        "@secretlint/profiler": "^2.1.0",
+        "@secretlint/types": "^2.1.0",
         "@textlint/module-interop": "^1.0.2",
         "debug": "^4.1.1",
         "rc-config-loader": "^3.0.0",
         "try-resolve": "^1.0.1"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^2.0.0",
+        "@secretlint/secretlint-rule-example": "^2.1.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.9.3",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/config-validator/CHANGELOG.md
+++ b/packages/@secretlint/config-validator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/config-validator
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/config-validator

--- a/packages/@secretlint/config-validator/package.json
+++ b/packages/@secretlint/config-validator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-validator",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": ".secretlintrc config validation library",
     "keywords": [
         "secretlint",
@@ -45,7 +45,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/types": "^2.1.0",
         "ajv": "^6.11.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/core/CHANGELOG.md
+++ b/packages/@secretlint/core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/core
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 

--- a/packages/@secretlint/core/package.json
+++ b/packages/@secretlint/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/core",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Core library for @secretlint.",
     "keywords": [
         "secretlint"
@@ -40,8 +40,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/profiler": "^2.0.0",
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/profiler": "^2.1.0",
+        "@secretlint/types": "^2.1.0",
         "debug": "^4.1.1",
         "structured-source": "^3.0.2"
     },

--- a/packages/@secretlint/formatter/CHANGELOG.md
+++ b/packages/@secretlint/formatter/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/formatter
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/formatter

--- a/packages/@secretlint/formatter/package.json
+++ b/packages/@secretlint/formatter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/formatter",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A formatter collection for Secretlint.",
     "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/formatter/",
     "bugs": {
@@ -37,7 +37,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/types": "^2.1.0",
         "@textlint/linter-formatter": "^3.1.12",
         "@textlint/types": "^1.3.1",
         "debug": "^4.1.1",

--- a/packages/@secretlint/messages-to-markdown/CHANGELOG.md
+++ b/packages/@secretlint/messages-to-markdown/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+
+### Features
+
+* **secretlint-rule-no-homedir:** add new rule ([#136](https://github.com/secretlint/secretlint/issues/136)) ([447e2e0](https://github.com/secretlint/secretlint/commit/447e2e0b473e267934ea42ed8788de15dcea9cd8))
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 

--- a/packages/@secretlint/messages-to-markdown/package.json
+++ b/packages/@secretlint/messages-to-markdown/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/messages-to-markdown",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Create Markdown text from rule's messages(ids)",
     "keywords": [
         "secretlint"
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/types": "^2.1.0",
         "meow": "^6.1.0",
         "ts-node": "^8.8.1",
         "typescript": "^3.8.2"

--- a/packages/@secretlint/node/CHANGELOG.md
+++ b/packages/@secretlint/node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/node
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/node

--- a/packages/@secretlint/node/package.json
+++ b/packages/@secretlint/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/node",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Secretlint client library for Node.js",
     "keywords": [
         "secretlint",
@@ -41,16 +41,16 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-loader": "^2.0.0",
-        "@secretlint/core": "^2.0.0",
-        "@secretlint/formatter": "^2.0.0",
-        "@secretlint/profiler": "^2.0.0",
-        "@secretlint/source-creator": "^2.0.0",
+        "@secretlint/config-loader": "^2.1.0",
+        "@secretlint/core": "^2.1.0",
+        "@secretlint/formatter": "^2.1.0",
+        "@secretlint/profiler": "^2.1.0",
+        "@secretlint/source-creator": "^2.1.0",
         "debug": "^4.1.1",
         "p-map": "^4.0.0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^2.0.0",
+        "@secretlint/secretlint-rule-example": "^2.1.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.9.3",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/profiler/CHANGELOG.md
+++ b/packages/@secretlint/profiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/profiler
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/profiler

--- a/packages/@secretlint/profiler/package.json
+++ b/packages/@secretlint/profiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/profiler",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Profile manager for Secretlint.",
     "keywords": [
         "secretlint"

--- a/packages/@secretlint/quick-start/CHANGELOG.md
+++ b/packages/@secretlint/quick-start/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/quick-start
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/quick-start

--- a/packages/@secretlint/quick-start/package.json
+++ b/packages/@secretlint/quick-start/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/quick-start",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Quick Stater CLI for secretlint.",
     "keywords": [
         "secretlint",
@@ -46,8 +46,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^2.0.0",
-        "secretlint": "^2.0.0"
+        "@secretlint/secretlint-rule-preset-recommend": "^2.1.0",
+        "secretlint": "^2.1.0"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/secretlint-rule-aws/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-aws/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-aws
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-aws

--- a/packages/@secretlint/secretlint-rule-aws/package.json
+++ b/packages/@secretlint/secretlint-rule-aws/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-aws",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A secretlint rule for AWS.",
     "keywords": [
         "secretlint",
@@ -43,13 +43,13 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/types": "^2.1.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "regx": "^1.0.4",
         "string.prototype.matchall": "^4.0.2"
     },
     "devDependencies": {
-        "@secretlint/tester": "^2.0.0",
+        "@secretlint/tester": "^2.1.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.9.3",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-basicauth/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-basicauth/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-basicauth
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 

--- a/packages/@secretlint/secretlint-rule-basicauth/package.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-basicauth",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A secretlint rule that check Basic Authentication.",
     "keywords": [
         "secretlint",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/types": "^2.1.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "string.prototype.matchall": "^4.0.2"
     },

--- a/packages/@secretlint/secretlint-rule-example/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-example/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-example

--- a/packages/@secretlint/secretlint-rule-example/package.json
+++ b/packages/@secretlint/secretlint-rule-example/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-example",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "An example rule for secretlint. It it for testing.",
     "keywords": [
         "secretlint",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0"
+        "@secretlint/types": "^2.1.0"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/secretlint-rule-gcp/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-gcp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-gcp
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-gcp

--- a/packages/@secretlint/secretlint-rule-gcp/package.json
+++ b/packages/@secretlint/secretlint-rule-gcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-gcp",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A secretlint rule for GCP.",
     "keywords": [
         "rule",
@@ -42,7 +42,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/types": "^2.1.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "node-forge": "^0.9.1"
     },

--- a/packages/@secretlint/secretlint-rule-no-dotenv/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-no-dotenv
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-no-dotenv

--- a/packages/@secretlint/secretlint-rule-no-dotenv/package.json
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-no-dotenv",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A secretlint rule for dotenv",
     "keywords": [
         "secretlint",
@@ -46,7 +46,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0"
+        "@secretlint/types": "^2.1.0"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/secretlint-rule-no-homedir/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-no-homedir/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+
+### Features
+
+* **secretlint-rule-no-homedir:** add new rule ([#136](https://github.com/secretlint/secretlint/issues/136)) ([447e2e0](https://github.com/secretlint/secretlint/commit/447e2e0b473e267934ea42ed8788de15dcea9cd8))

--- a/packages/@secretlint/secretlint-rule-no-homedir/package.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretlint/secretlint-rule-no-homedir",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "description": "A secretlint rule that disallow to include user's homedir path.",
   "keywords": [
     "rule",
@@ -42,8 +42,8 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "escape-string-regexp": "^4.0.0",
-    "@secretlint/types": "^2.0.0"
+    "@secretlint/types": "^2.1.0",
+    "escape-string-regexp": "^4.0.0"
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-no-k8s-kind-secret
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-no-k8s-kind-secret

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretlint/secretlint-rule-no-k8s-kind-secret",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A secretlint rule that disallow to use Kind: Secret in Kubernetes repository.",
   "keywords": [
     "rule",
@@ -42,7 +42,7 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "@secretlint/types": "^2.0.0",
+    "@secretlint/types": "^2.1.0",
     "js-yaml": "^3.13.1"
   },
   "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-npm/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-npm/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-npm
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-npm

--- a/packages/@secretlint/secretlint-rule-npm/package.json
+++ b/packages/@secretlint/secretlint-rule-npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-npm",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A secretlint rule for npm.",
     "keywords": [
         "npm",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/types": "^2.1.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-pattern/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-pattern/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+
+### Features
+
+* **rule:** Creating new rule for SecretLint for using regular expressions ([#139](https://github.com/secretlint/secretlint/issues/139)) ([097921f](https://github.com/secretlint/secretlint/commit/097921f9682b619dbeb5e35068b1c57913bf5df9))
+
+
+
+
+
 # 1.0.0 (2020-06-10)
 
 ### Features

--- a/packages/@secretlint/secretlint-rule-pattern/package.json
+++ b/packages/@secretlint/secretlint-rule-pattern/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-pattern",
-    "version": "1.0.0",
+    "version": "2.1.0",
     "description": "A secretlint rule that checks for regex patterns stored in configuration.",
     "keywords": [
         "secretlint",
@@ -43,8 +43,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/tester": "^2.0.0",
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/tester": "^2.1.0",
+        "@secretlint/types": "^2.1.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "string.prototype.matchall": "^4.0.2"
     },

--- a/packages/@secretlint/secretlint-rule-pattern/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-pattern/src/index.ts
@@ -10,18 +10,21 @@ require("string.prototype.matchall").shim();
 
 export const messages = {
     PATTERN: {
-        en: (props: { PATTERN_NAME: string, CREDENTIAL: string }) => `found matching ${props.PATTERN_NAME}: ${props.CREDENTIAL}`
+        en: (props: { PATTERN_NAME: string; CREDENTIAL: string }) =>
+            `found matching ${props.PATTERN_NAME}: ${props.CREDENTIAL}`,
+        ja: (props: { PATTERN_NAME: string; CREDENTIAL: string }) =>
+            `${props.PATTERN_NAME}にマッチするパターンが見つかりました: ${props.CREDENTIAL}`,
     },
 };
 
 export type PatternType = {
     name: string;
     pattern: string;
-}
+};
 
 export type Options = {
     allows?: string[];
-    patterns?: PatternType[]
+    patterns?: PatternType[];
 };
 
 function reportIfFoundPattern({
@@ -36,23 +39,23 @@ function reportIfFoundPattern({
     t: SecretLintRuleMessageTranslate<typeof messages>;
 }) {
     for (const p of options.patterns) {
-      const results = matchPatterns(source.content, [p.pattern]);
-      for (const result of results) {
-          const index = result.startIndex || 0;
-          const match = result.match || "";
-          const range = [index, index + match.length];
-          const allowedResults = matchPatterns(match, options.allows);
-          if (allowedResults.length > 0) {
-              continue;
-          }
-          context.report({
-              message: t("PATTERN", {
-                  PATTERN_NAME: p.name,
-                  CREDENTIAL: match,
-              }),
-              range,
-          });
-      }
+        const results = matchPatterns(source.content, [p.pattern]);
+        for (const result of results) {
+            const index = result.startIndex || 0;
+            const match = result.match || "";
+            const range = [index, index + match.length];
+            const allowedResults = matchPatterns(match, options.allows);
+            if (allowedResults.length > 0) {
+                continue;
+            }
+            context.report({
+                message: t("PATTERN", {
+                    PATTERN_NAME: p.name,
+                    CREDENTIAL: match,
+                }),
+                range,
+            });
+        }
     }
 }
 
@@ -60,7 +63,7 @@ export const creator: SecretLintRuleCreator<Options> = {
     messages,
     meta: {
         id: "@secretlint/secretlint-rule-pattern",
-        recommended: true,
+        recommended: false,
         type: "scanner",
         supportedContentTypes: ["text"],
     },

--- a/packages/@secretlint/secretlint-rule-preset-canary/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-preset-canary/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-preset-canary
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 

--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-preset-canary",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Canary rule preset of secretlint.",
     "keywords": [
         "secretlint",
@@ -44,13 +44,13 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-aws": "^2.0.0",
-        "@secretlint/secretlint-rule-basicauth": "^2.0.0",
-        "@secretlint/secretlint-rule-gcp": "^2.0.0",
-        "@secretlint/secretlint-rule-npm": "^2.0.0",
-        "@secretlint/secretlint-rule-privatekey": "^2.0.0",
-        "@secretlint/secretlint-rule-sendgrid": "^2.0.0",
-        "@secretlint/secretlint-rule-slack": "^2.0.0"
+        "@secretlint/secretlint-rule-aws": "^2.1.0",
+        "@secretlint/secretlint-rule-basicauth": "^2.1.0",
+        "@secretlint/secretlint-rule-gcp": "^2.1.0",
+        "@secretlint/secretlint-rule-npm": "^2.1.0",
+        "@secretlint/secretlint-rule-privatekey": "^2.1.0",
+        "@secretlint/secretlint-rule-sendgrid": "^2.1.0",
+        "@secretlint/secretlint-rule-slack": "^2.1.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^11.0.2",

--- a/packages/@secretlint/secretlint-rule-preset-recommend/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-preset-recommend
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 

--- a/packages/@secretlint/secretlint-rule-preset-recommend/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-preset-recommend",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Recommended rule preset of secretlint.",
     "keywords": [
         "secretlint",
@@ -45,13 +45,13 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-aws": "^2.0.0",
-        "@secretlint/secretlint-rule-basicauth": "^2.0.0",
-        "@secretlint/secretlint-rule-gcp": "^2.0.0",
-        "@secretlint/secretlint-rule-npm": "^2.0.0",
-        "@secretlint/secretlint-rule-privatekey": "^2.0.0",
-        "@secretlint/secretlint-rule-sendgrid": "^2.0.0",
-        "@secretlint/secretlint-rule-slack": "^2.0.0"
+        "@secretlint/secretlint-rule-aws": "^2.1.0",
+        "@secretlint/secretlint-rule-basicauth": "^2.1.0",
+        "@secretlint/secretlint-rule-gcp": "^2.1.0",
+        "@secretlint/secretlint-rule-npm": "^2.1.0",
+        "@secretlint/secretlint-rule-privatekey": "^2.1.0",
+        "@secretlint/secretlint-rule-sendgrid": "^2.1.0",
+        "@secretlint/secretlint-rule-slack": "^2.1.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^11.0.2",

--- a/packages/@secretlint/secretlint-rule-privatekey/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-privatekey/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-privatekey
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-privatekey

--- a/packages/@secretlint/secretlint-rule-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-privatekey",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A secretlint rule for PrivateKey.",
     "keywords": [
         "secretlint",
@@ -47,8 +47,8 @@
         "string.prototype.matchall": "^4.0.2"
     },
     "devDependencies": {
-        "@secretlint/secretlint-scripts": "^2.0.0",
-        "@secretlint/tester": "^2.0.0",
+        "@secretlint/secretlint-scripts": "^2.1.0",
+        "@secretlint/tester": "^2.1.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-secp256k1-privatekey
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-secp256k1-privatekey

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-secp256k1-privatekey",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A secretlint rule that checks for secp256k1 private keys.",
     "keywords": [
         "secretlint",
@@ -48,7 +48,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/types": "^2.1.0",
         "@types/bn.js": "^4.11.6",
         "@types/secp256k1": "^3.5.3",
         "bn.js": "^5.1.1",

--- a/packages/@secretlint/secretlint-rule-sendgrid/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-sendgrid/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-sendgrid
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 

--- a/packages/@secretlint/secretlint-rule-sendgrid/package.json
+++ b/packages/@secretlint/secretlint-rule-sendgrid/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-sendgrid",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A secretlint rule for sendgrid api keys.",
     "keywords": [
         "rule",
@@ -43,12 +43,12 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/types": "^2.1.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "string.prototype.matchall": "^4.0.2"
     },
     "devDependencies": {
-        "@secretlint/tester": "^2.0.0",
+        "@secretlint/tester": "^2.1.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-slack/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-slack/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-slack
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-slack

--- a/packages/@secretlint/secretlint-rule-slack/package.json
+++ b/packages/@secretlint/secretlint-rule-slack/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-slack",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A secretlint rule for slack.",
     "keywords": [
         "rule",
@@ -43,12 +43,12 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/types": "^2.1.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "string.prototype.matchall": "^4.0.2"
     },
     "devDependencies": {
-        "@secretlint/tester": "^2.0.0",
+        "@secretlint/tester": "^2.1.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-scripts/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-scripts/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-scripts
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-scripts

--- a/packages/@secretlint/secretlint-scripts/package.json
+++ b/packages/@secretlint/secretlint-scripts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-scripts",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Secretlint rule scripts",
     "keywords": [
         "secretlint"

--- a/packages/@secretlint/source-creator/CHANGELOG.md
+++ b/packages/@secretlint/source-creator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/source-creator
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package @secretlint/source-creator

--- a/packages/@secretlint/source-creator/package.json
+++ b/packages/@secretlint/source-creator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/source-creator",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Create SecretLintRawSource from content.",
     "keywords": [
         "secretlint",
@@ -42,7 +42,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.0.0",
+        "@secretlint/types": "^2.1.0",
         "istextorbinary": "^3.3.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/tester/CHANGELOG.md
+++ b/packages/@secretlint/tester/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/tester
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 

--- a/packages/@secretlint/tester/package.json
+++ b/packages/@secretlint/tester/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/tester",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A testing library for secretlint rule",
     "keywords": [
         "secretlint",
@@ -41,10 +41,10 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-loader": "^2.0.0",
-        "@secretlint/core": "^2.0.0",
-        "@secretlint/source-creator": "^2.0.0",
-        "@secretlint/types": "^2.0.0"
+        "@secretlint/config-loader": "^2.1.0",
+        "@secretlint/core": "^2.1.0",
+        "@secretlint/source-creator": "^2.1.0",
+        "@secretlint/types": "^2.1.0"
     },
     "devDependencies": {
         "@types/mocha": "^7.0.1",

--- a/packages/@secretlint/types/CHANGELOG.md
+++ b/packages/@secretlint/types/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/types
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 

--- a/packages/@secretlint/types/package.json
+++ b/packages/@secretlint/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/types",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "A typing package for @secretlint",
     "keywords": [
         "secretlint"

--- a/packages/secretlint/CHANGELOG.md
+++ b/packages/secretlint/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+
+### Bug Fixes
+
+* **secretlint:** fix handling for non-ascii file path ([#137](https://github.com/secretlint/secretlint/issues/137)) ([510decf](https://github.com/secretlint/secretlint/commit/510decf4605b202539c7bedf7a6ea22bdd4cc62f))
+
+
+
+
+
 # [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
 
 **Note:** Version bump only for package secretlint

--- a/packages/secretlint/package.json
+++ b/packages/secretlint/package.json
@@ -1,6 +1,6 @@
 {
     "name": "secretlint",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Secretlint CLI that scan secret/credential data.",
     "keywords": [
         "secretlint",
@@ -45,18 +45,18 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-creator": "^2.0.0",
-        "@secretlint/formatter": "^2.0.0",
-        "@secretlint/node": "^2.0.0",
-        "@secretlint/profiler": "^2.0.0",
+        "@secretlint/config-creator": "^2.1.0",
+        "@secretlint/formatter": "^2.1.0",
+        "@secretlint/node": "^2.1.0",
+        "@secretlint/profiler": "^2.1.0",
         "debug": "^4.1.1",
         "globby": "^11.0.0",
         "meow": "^6.1.0",
         "read-pkg": "^5.2.0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^2.0.0",
-        "@secretlint/secretlint-rule-preset-recommend": "^2.0.0",
+        "@secretlint/secretlint-rule-example": "^2.1.0",
+        "@secretlint/secretlint-rule-preset-recommend": "^2.1.0",
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.9.3",
         "cross-env": "^7.0.0",


### PR DESCRIPTION
## New rules

### [@secretlint/secretlint-rule-no-homedir](https://github.com/secretlint/secretlint/tree/master/packages/%40secretlint/secretlint-rule-no-homedir)

A secretlint rule that disallow to include user's homedir path.

### [@secretlint/secretlint-rule-pattern](https://github.com/secretlint/secretlint/tree/master/packages/%40secretlint/secretlint-rule-pattern)

A secretlint rule that checks for RegEx patterns

Created by @PseudoCoding 

## Fixes

-  fix handling for non-ascii file path (#137)