### PR TITLE
chore(release): v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+
+### Features
+
+* **preset-recommend:** add GitHub to preset ([#164](https://github.com/secretlint/secretlint/issues/164)) ([c5fb277](https://github.com/secretlint/secretlint/commit/c5fb2778961b784be255549519a27d920a0278dd))
+
+
+### BREAKING CHANGES
+
+* **preset-recommend:** secretlint-rule-preset-recommend has been changed
+
+- It includes "@secretlint/secretlint-rule-github" by default
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 

--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/benchmark
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/benchmark

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@secretlint/benchmark",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Internal benchmark for Secretlint",
     "keywords": [
         "secretlint",
@@ -32,8 +32,8 @@
         "access": "public"
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-preset-canary": "^2.2.0",
+        "@secretlint/secretlint-rule-preset-canary": "^3.0.0",
         "benchmark": "^2.1.4",
-        "secretlint": "^2.2.0"
+        "secretlint": "^3.0.0"
     }
 }

--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/example-cli
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/example-cli

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@secretlint/example-cli",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "",
     "homepage": "https://github.com/secretlint/secretlint/tree/master/examples/cli/",
     "bugs": {
@@ -27,9 +27,9 @@
         "test": "expected-exit-status 1 --command 'secretlint \"**/*\"'"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^2.2.0",
+        "@secretlint/secretlint-rule-preset-recommend": "^3.0.0",
         "expected-exit-status": "^1.0.2",
-        "secretlint": "^2.2.0"
+        "secretlint": "^3.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "packages/@secretlint/*",
     "examples/*"
   ],
-  "version": "2.2.0",
+  "version": "3.0.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "includeMergedTags": true

--- a/packages/@secretlint/config-creator/CHANGELOG.md
+++ b/packages/@secretlint/config-creator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/config-creator
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/config-creator

--- a/packages/@secretlint/config-creator/package.json
+++ b/packages/@secretlint/config-creator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-creator",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Config file creator for secretlint.",
     "keywords": [
         "secretlint"
@@ -40,7 +40,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0"
+        "@secretlint/types": "^3.0.0"
     },
     "devDependencies": {
         "@types/mocha": "^8.2.2",

--- a/packages/@secretlint/config-loader/CHANGELOG.md
+++ b/packages/@secretlint/config-loader/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/config-loader
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/config-loader

--- a/packages/@secretlint/config-loader/package.json
+++ b/packages/@secretlint/config-loader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-loader",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Config loader for secretlint.",
     "keywords": [
         "secretlint",
@@ -43,16 +43,16 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-validator": "^2.2.0",
-        "@secretlint/profiler": "^2.2.0",
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/config-validator": "^3.0.0",
+        "@secretlint/profiler": "^3.0.0",
+        "@secretlint/types": "^3.0.0",
         "@textlint/module-interop": "^1.0.2",
         "debug": "^4.1.1",
         "rc-config-loader": "^3.0.0",
         "try-resolve": "^1.0.1"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^2.2.0",
+        "@secretlint/secretlint-rule-example": "^3.0.0",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.41",
         "cross-env": "^7.0.3",

--- a/packages/@secretlint/config-validator/CHANGELOG.md
+++ b/packages/@secretlint/config-validator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/config-validator
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/config-validator

--- a/packages/@secretlint/config-validator/package.json
+++ b/packages/@secretlint/config-validator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-validator",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": ".secretlintrc config validation library",
     "keywords": [
         "secretlint",
@@ -45,7 +45,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "ajv": "^6.11.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/core/CHANGELOG.md
+++ b/packages/@secretlint/core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/core
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/core

--- a/packages/@secretlint/core/package.json
+++ b/packages/@secretlint/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/core",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Core library for @secretlint.",
     "keywords": [
         "secretlint"
@@ -40,8 +40,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/profiler": "^2.2.0",
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/profiler": "^3.0.0",
+        "@secretlint/types": "^3.0.0",
         "debug": "^4.1.1",
         "structured-source": "^3.0.2"
     },

--- a/packages/@secretlint/formatter/CHANGELOG.md
+++ b/packages/@secretlint/formatter/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/formatter
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/formatter

--- a/packages/@secretlint/formatter/package.json
+++ b/packages/@secretlint/formatter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/formatter",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A formatter collection for Secretlint.",
     "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/formatter/",
     "bugs": {
@@ -38,7 +38,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "@textlint/linter-formatter": "^3.1.12",
         "@textlint/types": "^1.3.1",
         "debug": "^4.1.1",

--- a/packages/@secretlint/messages-to-markdown/CHANGELOG.md
+++ b/packages/@secretlint/messages-to-markdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/messages-to-markdown
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/messages-to-markdown

--- a/packages/@secretlint/messages-to-markdown/package.json
+++ b/packages/@secretlint/messages-to-markdown/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/messages-to-markdown",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Create Markdown text from rule's messages(ids)",
     "keywords": [
         "secretlint"
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "meow": "^6.1.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/node/CHANGELOG.md
+++ b/packages/@secretlint/node/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/node
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/node

--- a/packages/@secretlint/node/package.json
+++ b/packages/@secretlint/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/node",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Secretlint client library for Node.js",
     "keywords": [
         "secretlint",
@@ -41,16 +41,16 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-loader": "^2.2.0",
-        "@secretlint/core": "^2.2.0",
-        "@secretlint/formatter": "^2.2.0",
-        "@secretlint/profiler": "^2.2.0",
-        "@secretlint/source-creator": "^2.2.0",
+        "@secretlint/config-loader": "^3.0.0",
+        "@secretlint/core": "^3.0.0",
+        "@secretlint/formatter": "^3.0.0",
+        "@secretlint/profiler": "^3.0.0",
+        "@secretlint/source-creator": "^3.0.0",
         "debug": "^4.1.1",
         "p-map": "^4.0.0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^2.2.0",
+        "@secretlint/secretlint-rule-example": "^3.0.0",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.41",
         "cross-env": "^7.0.3",

--- a/packages/@secretlint/profiler/CHANGELOG.md
+++ b/packages/@secretlint/profiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/profiler
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/profiler

--- a/packages/@secretlint/profiler/package.json
+++ b/packages/@secretlint/profiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/profiler",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Profile manager for Secretlint.",
     "keywords": [
         "secretlint"

--- a/packages/@secretlint/quick-start/CHANGELOG.md
+++ b/packages/@secretlint/quick-start/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/quick-start
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/quick-start

--- a/packages/@secretlint/quick-start/package.json
+++ b/packages/@secretlint/quick-start/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/quick-start",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Quick Stater CLI for secretlint.",
     "keywords": [
         "secretlint",
@@ -46,8 +46,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^2.2.0",
-        "secretlint": "^2.2.0"
+        "@secretlint/secretlint-rule-preset-recommend": "^3.0.0",
+        "secretlint": "^3.0.0"
     },
     "devDependencies": {
         "@types/mocha": "^8.2.2",

--- a/packages/@secretlint/secretlint-rule-aws/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-aws/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-aws
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-aws

--- a/packages/@secretlint/secretlint-rule-aws/package.json
+++ b/packages/@secretlint/secretlint-rule-aws/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-aws",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A secretlint rule for AWS.",
     "keywords": [
         "secretlint",
@@ -43,12 +43,12 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "regx": "^1.0.4"
     },
     "devDependencies": {
-        "@secretlint/tester": "^2.2.0",
+        "@secretlint/tester": "^3.0.0",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.41",
         "cross-env": "^7.0.3",

--- a/packages/@secretlint/secretlint-rule-basicauth/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-basicauth/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-basicauth
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-basicauth

--- a/packages/@secretlint/secretlint-rule-basicauth/package.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-basicauth",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A secretlint rule that check Basic Authentication.",
     "keywords": [
         "secretlint",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-example/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-example/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-example

--- a/packages/@secretlint/secretlint-rule-example/package.json
+++ b/packages/@secretlint/secretlint-rule-example/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-example",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "An example rule for secretlint. It it for testing.",
     "keywords": [
         "secretlint",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0"
+        "@secretlint/types": "^3.0.0"
     },
     "devDependencies": {
         "@types/mocha": "^8.2.2",

--- a/packages/@secretlint/secretlint-rule-gcp/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-gcp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-gcp
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-gcp

--- a/packages/@secretlint/secretlint-rule-gcp/package.json
+++ b/packages/@secretlint/secretlint-rule-gcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-gcp",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A secretlint rule for GCP.",
     "keywords": [
         "rule",
@@ -42,7 +42,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "node-forge": "^0.10.0"
     },

--- a/packages/@secretlint/secretlint-rule-github/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-github/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-github
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 

--- a/packages/@secretlint/secretlint-rule-github/package.json
+++ b/packages/@secretlint/secretlint-rule-github/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-github",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A secretlint rule for sendgrid api keys.",
     "keywords": [
         "rule",
@@ -43,11 +43,11 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {
-        "@secretlint/tester": "^2.2.0",
+        "@secretlint/tester": "^3.0.0",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.41",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-no-dotenv/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-no-dotenv
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-no-dotenv

--- a/packages/@secretlint/secretlint-rule-no-dotenv/package.json
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-no-dotenv",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A secretlint rule for dotenv",
     "keywords": [
         "secretlint",
@@ -46,7 +46,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0"
+        "@secretlint/types": "^3.0.0"
     },
     "devDependencies": {
         "@types/mocha": "^8.2.2",

--- a/packages/@secretlint/secretlint-rule-no-homedir/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-no-homedir/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-no-homedir
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-no-homedir

--- a/packages/@secretlint/secretlint-rule-no-homedir/package.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretlint/secretlint-rule-no-homedir",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "A secretlint rule that disallow to include user's homedir path.",
   "keywords": [
     "rule",
@@ -42,7 +42,7 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "@secretlint/types": "^2.2.0",
+    "@secretlint/types": "^3.0.0",
     "escape-string-regexp": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-no-k8s-kind-secret
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-no-k8s-kind-secret

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretlint/secretlint-rule-no-k8s-kind-secret",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "A secretlint rule that disallow to use Kind: Secret in Kubernetes repository.",
   "keywords": [
     "rule",
@@ -42,7 +42,7 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "@secretlint/types": "^2.2.0",
+    "@secretlint/types": "^3.0.0",
     "js-yaml": "^3.13.1"
   },
   "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-npm/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-npm/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-npm
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-npm

--- a/packages/@secretlint/secretlint-rule-npm/package.json
+++ b/packages/@secretlint/secretlint-rule-npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-npm",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A secretlint rule for npm.",
     "keywords": [
         "npm",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-pattern/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-pattern/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-pattern
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-pattern

--- a/packages/@secretlint/secretlint-rule-pattern/package.json
+++ b/packages/@secretlint/secretlint-rule-pattern/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-pattern",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A secretlint rule that checks for regex patterns stored in configuration.",
     "keywords": [
         "secretlint",
@@ -43,8 +43,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/tester": "^2.2.0",
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/tester": "^3.0.0",
+        "@secretlint/types": "^3.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-preset-canary/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-preset-canary/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+
+### Features
+
+* **preset-recommend:** add GitHub to preset ([#164](https://github.com/secretlint/secretlint/issues/164)) ([c5fb277](https://github.com/secretlint/secretlint/commit/c5fb2778961b784be255549519a27d920a0278dd))
+
+
+### BREAKING CHANGES
+
+* **preset-recommend:** secretlint-rule-preset-recommend has been changed
+
+- It includes "@secretlint/secretlint-rule-github" by default
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-preset-canary

--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretlint/secretlint-rule-preset-canary",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Canary rule preset of secretlint.",
   "keywords": [
     "secretlint",
@@ -44,14 +44,14 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "@secretlint/secretlint-rule-aws": "^2.2.0",
-    "@secretlint/secretlint-rule-basicauth": "^2.2.0",
-    "@secretlint/secretlint-rule-gcp": "^2.2.0",
-    "@secretlint/secretlint-rule-npm": "^2.2.0",
-    "@secretlint/secretlint-rule-privatekey": "^2.2.0",
-    "@secretlint/secretlint-rule-sendgrid": "^2.2.0",
-    "@secretlint/secretlint-rule-slack": "^2.2.0",
-    "@secretlint/secretlint-rule-github": "^2.2.0"
+    "@secretlint/secretlint-rule-aws": "^3.0.0",
+    "@secretlint/secretlint-rule-basicauth": "^3.0.0",
+    "@secretlint/secretlint-rule-gcp": "^3.0.0",
+    "@secretlint/secretlint-rule-github": "^3.0.0",
+    "@secretlint/secretlint-rule-npm": "^3.0.0",
+    "@secretlint/secretlint-rule-privatekey": "^3.0.0",
+    "@secretlint/secretlint-rule-sendgrid": "^3.0.0",
+    "@secretlint/secretlint-rule-slack": "^3.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.2",

--- a/packages/@secretlint/secretlint-rule-preset-recommend/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+
+### Features
+
+* **preset-recommend:** add GitHub to preset ([#164](https://github.com/secretlint/secretlint/issues/164)) ([c5fb277](https://github.com/secretlint/secretlint/commit/c5fb2778961b784be255549519a27d920a0278dd))
+
+
+### BREAKING CHANGES
+
+* **preset-recommend:** secretlint-rule-preset-recommend has been changed
+
+- It includes "@secretlint/secretlint-rule-github" by default
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-preset-recommend

--- a/packages/@secretlint/secretlint-rule-preset-recommend/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-preset-recommend",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Recommended rule preset of secretlint.",
     "keywords": [
         "secretlint",
@@ -45,14 +45,14 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-aws": "^2.2.0",
-        "@secretlint/secretlint-rule-basicauth": "^2.2.0",
-        "@secretlint/secretlint-rule-gcp": "^2.2.0",
-        "@secretlint/secretlint-rule-npm": "^2.2.0",
-        "@secretlint/secretlint-rule-privatekey": "^2.2.0",
-        "@secretlint/secretlint-rule-sendgrid": "^2.2.0",
-        "@secretlint/secretlint-rule-slack": "^2.2.0",
-        "@secretlint/secretlint-rule-github": "^2.2.0"
+        "@secretlint/secretlint-rule-aws": "^3.0.0",
+        "@secretlint/secretlint-rule-basicauth": "^3.0.0",
+        "@secretlint/secretlint-rule-gcp": "^3.0.0",
+        "@secretlint/secretlint-rule-github": "^3.0.0",
+        "@secretlint/secretlint-rule-npm": "^3.0.0",
+        "@secretlint/secretlint-rule-privatekey": "^3.0.0",
+        "@secretlint/secretlint-rule-sendgrid": "^3.0.0",
+        "@secretlint/secretlint-rule-slack": "^3.0.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^11.0.2",

--- a/packages/@secretlint/secretlint-rule-privatekey/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-privatekey/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-privatekey
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-privatekey

--- a/packages/@secretlint/secretlint-rule-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-privatekey",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A secretlint rule for PrivateKey.",
     "keywords": [
         "secretlint",
@@ -47,7 +47,7 @@
     },
     "devDependencies": {
         "@secretlint/secretlint-scripts": "^2.1.1",
-        "@secretlint/tester": "^2.2.0",
+        "@secretlint/tester": "^3.0.0",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.41",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-secp256k1-privatekey
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-secp256k1-privatekey

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-secp256k1-privatekey",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A secretlint rule that checks for secp256k1 private keys.",
     "keywords": [
         "secretlint",
@@ -48,7 +48,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "@types/bn.js": "^4.11.6",
         "@types/secp256k1": "^3.5.3",
         "bn.js": "^5.1.1",

--- a/packages/@secretlint/secretlint-rule-sendgrid/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-sendgrid/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-sendgrid
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-sendgrid

--- a/packages/@secretlint/secretlint-rule-sendgrid/package.json
+++ b/packages/@secretlint/secretlint-rule-sendgrid/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-sendgrid",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A secretlint rule for sendgrid api keys.",
     "keywords": [
         "rule",
@@ -43,11 +43,11 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {
-        "@secretlint/tester": "^2.2.0",
+        "@secretlint/tester": "^3.0.0",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.41",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-slack/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-slack/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-slack
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-slack

--- a/packages/@secretlint/secretlint-rule-slack/package.json
+++ b/packages/@secretlint/secretlint-rule-slack/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-slack",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A secretlint rule for slack.",
     "keywords": [
         "rule",
@@ -43,11 +43,11 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {
-        "@secretlint/tester": "^2.2.0",
+        "@secretlint/tester": "^3.0.0",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.41",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/source-creator/CHANGELOG.md
+++ b/packages/@secretlint/source-creator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/source-creator
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/source-creator

--- a/packages/@secretlint/source-creator/package.json
+++ b/packages/@secretlint/source-creator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/source-creator",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Create SecretLintRawSource from content.",
     "keywords": [
         "secretlint",
@@ -42,7 +42,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^2.2.0",
+        "@secretlint/types": "^3.0.0",
         "istextorbinary": "^3.3.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/tester/CHANGELOG.md
+++ b/packages/@secretlint/tester/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/tester
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/tester

--- a/packages/@secretlint/tester/package.json
+++ b/packages/@secretlint/tester/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/tester",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A testing library for secretlint rule",
     "keywords": [
         "secretlint",
@@ -41,10 +41,10 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-loader": "^2.2.0",
-        "@secretlint/core": "^2.2.0",
-        "@secretlint/source-creator": "^2.2.0",
-        "@secretlint/types": "^2.2.0"
+        "@secretlint/config-loader": "^3.0.0",
+        "@secretlint/core": "^3.0.0",
+        "@secretlint/source-creator": "^3.0.0",
+        "@secretlint/types": "^3.0.0"
     },
     "devDependencies": {
         "@types/mocha": "^8.2.2",

--- a/packages/@secretlint/types/CHANGELOG.md
+++ b/packages/@secretlint/types/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/types
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package @secretlint/types

--- a/packages/@secretlint/types/package.json
+++ b/packages/@secretlint/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/types",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "A typing package for @secretlint",
     "keywords": [
         "secretlint"

--- a/packages/secretlint/CHANGELOG.md
+++ b/packages/secretlint/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package secretlint
+
+
+
+
+
 # [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
 
 **Note:** Version bump only for package secretlint

--- a/packages/secretlint/package.json
+++ b/packages/secretlint/package.json
@@ -1,6 +1,6 @@
 {
     "name": "secretlint",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Secretlint CLI that scan secret/credential data.",
     "keywords": [
         "secretlint",
@@ -45,18 +45,18 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-creator": "^2.2.0",
-        "@secretlint/formatter": "^2.2.0",
-        "@secretlint/node": "^2.2.0",
-        "@secretlint/profiler": "^2.2.0",
+        "@secretlint/config-creator": "^3.0.0",
+        "@secretlint/formatter": "^3.0.0",
+        "@secretlint/node": "^3.0.0",
+        "@secretlint/profiler": "^3.0.0",
         "debug": "^4.1.1",
         "globby": "^11.0.0",
         "meow": "^9.0.0",
         "read-pkg": "^5.2.0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^2.2.0",
-        "@secretlint/secretlint-rule-preset-recommend": "^2.2.0",
+        "@secretlint/secretlint-rule-example": "^3.0.0",
+        "@secretlint/secretlint-rule-preset-recommend": "^3.0.0",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.41",
         "cross-env": "^7.0.3",


### PR DESCRIPTION
## 🆕 Updated

### `@secretlint/secretlint-rule-preset-recommend`

- Add `@secretlint/secretlint-rule-github` by default 

## 📝 Docs 

- Update husky + lint-staged integration
	- https://github.com/secretlint/secretlint#husky--lint-staged
- Add comparison to GitHub's [secret scanning](https://docs.github.com/en/code-security/secret-security/about-secret-scanning)
	- https://github.com/secretlint/secretlint#motivation