### PR TITLE
feat(core): add `maskSecrets` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ It is also possible to install Secretlint globally using `npm install --global`.
         --output           [path:String] output file path that is written of reported result.
         --no-color         disable ANSI-color of output.
         --no-terminalLink  disable terminalLink of output.
+        --maskSecrets      enable masking of secret values. replace actual secrets with "***".
         --secretlintrc     [path:String] path to .secretlintrc config file. Default: .secretlintrc.*
         --secretlintignore [path:String] path to .secretlintignore file. Default: .secretlintignore
     

--- a/packages/@secretlint/config-validator/package.json
+++ b/packages/@secretlint/config-validator/package.json
@@ -49,7 +49,6 @@
         "ajv": "^6.11.0"
     },
     "devDependencies": {
-        "@deps/traverse": "^1.0.2",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.41",
         "cross-env": "^7.0.3",

--- a/packages/@secretlint/core/.mocharc.json
+++ b/packages/@secretlint/core/.mocharc.json
@@ -1,5 +1,5 @@
 {
- "require": [
-  "ts-node-test-register"
- ]
+  "require": [
+    "ts-node-test-register"
+  ]
 }

--- a/packages/@secretlint/core/src/RuleContext.ts
+++ b/packages/@secretlint/core/src/RuleContext.ts
@@ -86,6 +86,7 @@ export const createRuleContext = ({
         ignore(descriptor: SecretLintCoreIgnoreDescriptor): void {
             const { message } = descriptor.message;
             contextEvents.ignore({
+                type: "ignore",
                 ruleId: ruleId,
                 ruleParentId,
                 range: descriptor.range,
@@ -101,6 +102,7 @@ export const createRuleContext = ({
             if (ruleParentId) {
                 contextEvents.report({
                     ...descriptor,
+                    type: "message",
                     ruleId: ruleId,
                     ruleParentId,
                     loc: sourceCode.rangeToLocation(descriptor.range),
@@ -113,6 +115,7 @@ export const createRuleContext = ({
             } else {
                 contextEvents.report({
                     ...descriptor,
+                    type: "message",
                     ruleId: ruleId,
                     loc: sourceCode.rangeToLocation(descriptor.range),
                     severity: severityLevel,

--- a/packages/@secretlint/core/src/index.ts
+++ b/packages/@secretlint/core/src/index.ts
@@ -30,6 +30,12 @@ export type SecretLintSourceOptions = {
          */
         locale?: SecretLintRuleLocaleTag;
         /**
+         * If this is true, mask all message's data values
+         * Replace data value with "****" strings
+         * Default: false
+         */
+        maskSecrets?: boolean;
+        /**
          * config present secretlintrc object
          */
         config: SecretLintCoreDescriptor;
@@ -44,6 +50,7 @@ export const lintSource = ({ source, options }: SecretLintSourceOptions): Promis
     debug(`options: %O`, options);
     const rules = options.config.rules;
     const locale = options.locale ?? "en";
+    const maskSecrets = options.maskSecrets ?? false;
     const contextEvents = createContextEvents();
     const runningEvents = createRunningEvents();
     const reportedMessages: SecretLintCoreResultMessage[] = [];
@@ -98,6 +105,7 @@ export const lintSource = ({ source, options }: SecretLintSourceOptions): Promis
                     reportedMessages,
                     ignoredMessages,
                     allowMessageIds: runningEvents.collectAllowMessageIds(),
+                    maskSecrets,
                 }),
             };
         })

--- a/packages/@secretlint/core/src/messages/filter-mask-secrets.ts
+++ b/packages/@secretlint/core/src/messages/filter-mask-secrets.ts
@@ -7,24 +7,35 @@ export type AllowMessage = {
 
 // mask all properties with *** deeply
 // These properties are object, array, or others
-const deepMask = (object: Record<string, any>): Record<string, any> => {
+const deepMask = (object: Record<string, any>, handler: (value: string) => string) => {
     for (const key of Object.keys(object)) {
         if (typeof object[key] === "object") {
-            object[key] = deepMask(object[key]);
+            object[key] = deepMask(object[key], handler);
         } else if (Array.isArray(object[key])) {
-            object[key] = object[key].map(deepMask);
-        } else {
-            object[key] = mask(object[key]);
+            object[key] = object[key].map((item: any) => deepMask(item, handler));
+        } else if (typeof object[key] === "string") {
+            object[key] = handler(object[key]);
         }
     }
     return object;
 };
 
-const mask = <T>(value: T): T => {
-    if (typeof value === "string") {
-        return "*".repeat(value.length) as unknown as T;
+const createMaskValue = (value: string): string => {
+    return "*".repeat(value.length);
+};
+/**
+ * mask all maskedValues with *** in str
+ * it includes false-positive
+ * @param str
+ * @param maskedValues
+ */
+const maskWithValues = (str: string, maskedValues: string[]): string => {
+    let result = str;
+    for (const maskValue of maskedValues) {
+        // TODO: use replaceAll in the future
+        result = result.split(maskValue).join("*".repeat(maskValue.length));
     }
-    return value;
+    return result;
 };
 // mask all data values for hide secret value
 // https://github.com/secretlint/secretlint/issues/176
@@ -33,13 +44,22 @@ export const filterMaskSecretsData = (messages: SecretLintAllMessages[] = []): S
         if (message.type !== "message") {
             return message;
         }
+        const maskedValues: string[] = [];
+        const maskedData = message.data
+            ? deepMask(message.data, (value) => {
+                  maskedValues.push(value);
+                  return createMaskValue(value);
+              })
+            : undefined;
+        // no mask data
+        if (!maskedData) {
+            return message;
+        }
+        const maskedMessage = maskWithValues(message.message, maskedValues);
         return {
             ...message,
-            ...(message.data
-                ? {
-                      data: deepMask(message.data),
-                  }
-                : {}),
+            message: maskedMessage,
+            data: maskedData,
         };
     });
 };

--- a/packages/@secretlint/core/src/messages/filter-mask-secrets.ts
+++ b/packages/@secretlint/core/src/messages/filter-mask-secrets.ts
@@ -1,0 +1,45 @@
+import { SecretLintAllMessages } from "./MessageProcessManager";
+
+export type AllowMessage = {
+    ruleId: string;
+    messageId: string;
+};
+
+// mask all properties with *** deeply
+// These properties are object, array, or others
+const deepMask = (object: Record<string, any>): Record<string, any> => {
+    for (const key of Object.keys(object)) {
+        if (typeof object[key] === "object") {
+            object[key] = deepMask(object[key]);
+        } else if (Array.isArray(object[key])) {
+            object[key] = object[key].map(deepMask);
+        } else {
+            object[key] = mask(object[key]);
+        }
+    }
+    return object;
+};
+
+const mask = <T>(value: T): T => {
+    if (typeof value === "string") {
+        return "*".repeat(value.length - 1) as unknown as T;
+    }
+    return value;
+};
+// mask all data values for hide secret value
+// https://github.com/secretlint/secretlint/issues/176
+export const filterMaskSecretsData = (messages: SecretLintAllMessages[] = []): SecretLintAllMessages[] => {
+    return messages.map((message) => {
+        if (message.type !== "message") {
+            return message;
+        }
+        return {
+            ...message,
+            ...(message.data
+                ? {
+                      data: deepMask(message.data),
+                  }
+                : {}),
+        };
+    });
+};

--- a/packages/@secretlint/core/src/messages/filter-mask-secrets.ts
+++ b/packages/@secretlint/core/src/messages/filter-mask-secrets.ts
@@ -24,8 +24,19 @@ const createMaskValue = (value: string): string => {
     return "*".repeat(value.length);
 };
 /**
- * mask all maskedValues with *** in str
- * it includes false-positive
+ * = Masking logics
+ * secretlint mask simple string replacement.
+ * If a secretlint rule report `"TOKEN_STRING"` as message data, replace all `TOKEN_STRING` with `**********` in messages.
+ * ```
+ * context.report({
+ *   message: t("MESSAGE", {
+ *       TOKEN: "TOKEN_STRING", // => replace all "TOKEN_STRING" with  `**********`.
+ *   }),
+ *   range,
+ * });
+ * ```
+ * This logics may includes false-positve.
+ * This is similar to CI logs like Travis CI or GitHub Actions.
  * @param str
  * @param maskedValues
  */

--- a/packages/@secretlint/core/src/messages/filter-mask-secrets.ts
+++ b/packages/@secretlint/core/src/messages/filter-mask-secrets.ts
@@ -22,7 +22,7 @@ const deepMask = (object: Record<string, any>): Record<string, any> => {
 
 const mask = <T>(value: T): T => {
     if (typeof value === "string") {
-        return "*".repeat(value.length - 1) as unknown as T;
+        return "*".repeat(value.length) as unknown as T;
     }
     return value;
 };

--- a/packages/@secretlint/core/src/messages/index.ts
+++ b/packages/@secretlint/core/src/messages/index.ts
@@ -4,6 +4,7 @@ import { createMessageProcessor } from "./MessageProcessManager";
 import { filterDuplicatedMessages } from "./filter-duplicated-process";
 import { sortMessagesByLocation } from "./sort-messages-process";
 import { filterByAllowMessageIds } from "./filter-message-id";
+import { filterMaskSecretsData } from "./filter-mask-secrets";
 
 export type cleanupMessagesOptions = {
     reportedMessages: SecretLintCoreResultMessage[];
@@ -12,6 +13,7 @@ export type cleanupMessagesOptions = {
         ruleId: string;
         messageId: string;
     }[];
+    maskSecrets: boolean;
 };
 /**
  * Cleanup messages
@@ -24,6 +26,9 @@ export type cleanupMessagesOptions = {
 export const cleanupMessages = (options: cleanupMessagesOptions): SecretLintCoreResultMessage[] => {
     const reportedMessages = filterIgnoredMessages(options);
     const reportedMessagesWithoutAllowMessageIds = filterByAllowMessageIds(reportedMessages, options.allowMessageIds);
-    const filterProcess = createMessageProcessor([filterDuplicatedMessages]);
+    const filters = options.maskSecrets
+        ? [filterDuplicatedMessages, filterMaskSecretsData]
+        : [filterDuplicatedMessages];
+    const filterProcess = createMessageProcessor(filters);
     return sortMessagesByLocation(filterProcess.process(reportedMessagesWithoutAllowMessageIds));
 };

--- a/packages/@secretlint/core/src/messages/index.ts
+++ b/packages/@secretlint/core/src/messages/index.ts
@@ -16,9 +16,10 @@ export type cleanupMessagesOptions = {
     maskSecrets: boolean;
 };
 /**
- * Cleanup messages
+ * Post cleanup messages
  * - filter ignored range
  * - filter disabled message
+ * - [masSecrets] mask secrets message
  * - filter duplicated messages
  * - sort messages by range
  * @param options

--- a/packages/@secretlint/core/test/index.test.ts
+++ b/packages/@secretlint/core/test/index.test.ts
@@ -32,6 +32,7 @@ describe("lintSource", function () {
                 data: {
                     ID: "SECRET",
                 },
+                type: "message",
                 message: "found secret: SECRET",
                 messageId: "EXAMPLE_MESSAGE",
                 range: [8, 14],

--- a/packages/@secretlint/core/test/messages/create-messages-utils.ts
+++ b/packages/@secretlint/core/test/messages/create-messages-utils.ts
@@ -4,11 +4,13 @@ export const createMessageFromRange = ({
     range,
     ruleId = "example",
     message = "message",
+    messageId = "message-id",
     data,
 }: {
     range: number[];
     ruleId?: string;
     message?: string;
+    messageId?: string;
     data?: object;
 }): SecretLintCoreResultMessage => {
     return {
@@ -27,7 +29,7 @@ export const createMessageFromRange = ({
             },
         },
         message: message,
-        messageId: message,
+        messageId: messageId,
         ...(data ? { data } : {}),
     };
 };

--- a/packages/@secretlint/core/test/messages/create-messages-utils.ts
+++ b/packages/@secretlint/core/test/messages/create-messages-utils.ts
@@ -1,14 +1,21 @@
 import { SecretLintCoreIgnoreMessage, SecretLintCoreResultMessage } from "@secretlint/types";
 
-export const createMessageFromRange = (
-    range: number[],
+export const createMessageFromRange = ({
+    range,
     ruleId = "example",
-    message = "message"
-): SecretLintCoreResultMessage => {
+    message = "message",
+    data,
+}: {
+    range: number[];
+    ruleId?: string;
+    message?: string;
+    data?: object;
+}): SecretLintCoreResultMessage => {
     return {
         range: range,
         ruleId: ruleId,
         severity: "error",
+        type: "message",
         loc: {
             start: {
                 line: 1,
@@ -21,12 +28,14 @@ export const createMessageFromRange = (
         },
         message: message,
         messageId: message,
+        ...(data ? { data } : {}),
     };
 };
 export const createIgnoredMessageFromRange = (range: number[], targetRuleId = "*"): SecretLintCoreIgnoreMessage => {
     return {
         range: range,
         ruleId: "ignore",
+        type: "ignore",
         targetRuleId: targetRuleId,
         loc: {
             start: {

--- a/packages/@secretlint/core/test/messages/filter-duplicated-process.test.ts
+++ b/packages/@secretlint/core/test/messages/filter-duplicated-process.test.ts
@@ -12,35 +12,41 @@ describe("message-filter", function () {
     });
     context("when only lint messages", function () {
         it("should not change messages", function () {
-            const messages = [createMessageFromRange([0, 1])];
+            const messages = [createMessageFromRange({ range: [0, 1] })];
             assert.deepStrictEqual(filterDuplicatedMessages(messages), messages);
         });
     });
     context("when contain duplicated messages", function () {
         it("should filter to be one", function () {
-            const messages = [createMessageFromRange([0, 1]), createMessageFromRange([0, 1])];
+            const messages = [createMessageFromRange({ range: [0, 1] }), createMessageFromRange({ range: [0, 1] })];
             assert.strictEqual(filterDuplicatedMessages(messages).length, 1);
         });
         it("should filter 3 -> 1", function () {
             const messages = [
-                createMessageFromRange([0, 1]),
-                createMessageFromRange([0, 1]),
-                createMessageFromRange([0, 1]),
+                createMessageFromRange({ range: [0, 1] }),
+                createMessageFromRange({ range: [0, 1] }),
+                createMessageFromRange({ range: [0, 1] }),
             ];
             assert.strictEqual(filterDuplicatedMessages(messages).length, 1);
         });
     });
     context("when duplicated message, but ruleId is difference", function () {
         it("should filter messages", function () {
-            const messages = [createMessageFromRange([0, 1], "a"), createMessageFromRange([0, 1], "b")];
+            const messages = [
+                createMessageFromRange({
+                    range: [0, 1],
+                    ruleId: "a",
+                }),
+                createMessageFromRange({ range: [0, 1], ruleId: "b" }),
+            ];
             assert.strictEqual(filterDuplicatedMessages(messages).length, 1);
         });
     });
     context("when duplicated ruleId, but message is difference", function () {
         it("should not filter messages", function () {
             const messages = [
-                createMessageFromRange([0, 1], "a", "message a"),
-                createMessageFromRange([0, 1], "a", "message b"),
+                createMessageFromRange({ range: [0, 1], ruleId: "a", message: "message a" }),
+                createMessageFromRange({ range: [0, 1], ruleId: "a", message: "message b" }),
             ];
             assert.strictEqual(filterDuplicatedMessages(messages).length, 2);
         });

--- a/packages/@secretlint/core/test/messages/filter-ignored-process.test.ts
+++ b/packages/@secretlint/core/test/messages/filter-ignored-process.test.ts
@@ -18,7 +18,7 @@ describe("message-filter", function () {
     });
     context("when only lint messages", function () {
         it("should not change messages", function () {
-            const messages = [createMessageFromRange([0, 1])];
+            const messages = [createMessageFromRange({ range: [0, 1] })];
             const actual = {
                 reportedMessages: messages,
                 ignoredMessages: [],
@@ -28,7 +28,7 @@ describe("message-filter", function () {
     });
     context("when contain ignore messages", function () {
         it("should not filtered, if index < ignore's range start ", function () {
-            const reportedMessages = [createMessageFromRange([10, 15])];
+            const reportedMessages = [createMessageFromRange({ range: [10, 15] })];
             const ignoredMessaged = [createIgnoredMessageFromRange([0, 1])];
             assert.equal(
                 filterIgnoredMessages({
@@ -40,10 +40,10 @@ describe("message-filter", function () {
         });
         it("should filtered, if start <= index <= end ", function () {
             const reportedMessages = [
-                createMessageFromRange([0, 1]),
-                createMessageFromRange([1, 2]),
-                createMessageFromRange([2, 3]),
-                createMessageFromRange([3, 4]),
+                createMessageFromRange({ range: [0, 1] }),
+                createMessageFromRange({ range: [1, 2] }),
+                createMessageFromRange({ range: [2, 3] }),
+                createMessageFromRange({ range: [3, 4] }),
             ];
             const ignoredMessages = [createIgnoredMessageFromRange([0, 2])];
             assert.deepStrictEqual(
@@ -51,11 +51,14 @@ describe("message-filter", function () {
                     reportedMessages,
                     ignoredMessages,
                 }),
-                [createMessageFromRange([2, 3]), createMessageFromRange([3, 4])]
+                [createMessageFromRange({ range: [2, 3] }), createMessageFromRange({ range: [3, 4] })]
             );
         });
         it("should remove ignore message it-self", function () {
-            const reportedMessages = [createMessageFromRange([0, 1]), createMessageFromRange([1, 100])];
+            const reportedMessages = [
+                createMessageFromRange({ range: [0, 1] }),
+                createMessageFromRange({ range: [1, 100] }),
+            ];
             const ignoredMessages = [createIgnoredMessageFromRange([0, 100])];
             assert.deepStrictEqual(
                 filterIgnoredMessages({
@@ -69,9 +72,9 @@ describe("message-filter", function () {
     context("when the message has targetRuleId", function () {
         it("should only filter messages that are matched the ruleId", function () {
             const reportedMessages = [
-                createMessageFromRange([1, 10], "a"),
-                createMessageFromRange([1, 10], "b"),
-                createMessageFromRange([1, 10], "c"),
+                createMessageFromRange({ range: [1, 10], ruleId: "a" }),
+                createMessageFromRange({ range: [1, 10], ruleId: "b" }),
+                createMessageFromRange({ range: [1, 10], ruleId: "c" }),
             ];
             const ignoredMessages = [
                 createIgnoredMessageFromRange([0, 10], "a"),
@@ -82,7 +85,7 @@ describe("message-filter", function () {
                     reportedMessages,
                     ignoredMessages,
                 }),
-                [createMessageFromRange([1, 10], "c")]
+                [createMessageFromRange({ range: [1, 10], ruleId: "c" })]
             );
         });
     });

--- a/packages/@secretlint/core/test/messages/filter-message-secrets.ts
+++ b/packages/@secretlint/core/test/messages/filter-message-secrets.ts
@@ -1,0 +1,75 @@
+import { createMessageFromRange } from "./create-messages-utils";
+import { filterMaskSecretsData } from "../../src/messages/filter-mask-secrets";
+import * as assert from "assert";
+
+describe("filter-mask-secrets", function () {
+    it("should not mask if data is not defined", () => {
+        const message = createMessageFromRange({
+            range: [0, 1],
+        });
+        const [filteredMessage] = filterMaskSecretsData([message]);
+        assert.deepStrictEqual(filteredMessage, {
+            range: [0, 1],
+            ruleId: "example",
+            severity: "error",
+            type: "message",
+            loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+            message: "message",
+            messageId: "message",
+        });
+    });
+    it("mask all data", () => {
+        const message = createMessageFromRange({
+            range: [0, 1],
+            data: {
+                key: "secret value",
+            },
+        });
+        const [filteredMessage] = filterMaskSecretsData([message]);
+        assert.deepStrictEqual(filteredMessage, {
+            range: [0, 1],
+            ruleId: "example",
+            severity: "error",
+            type: "message",
+            loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+            message: "message",
+            messageId: "message",
+            data: { key: "***********" },
+        });
+    });
+    it("mask deep value", () => {
+        const message = createMessageFromRange({
+            range: [0, 1],
+            data: {
+                key: "secret value",
+                nest: [
+                    "secret array item",
+                    {
+                        deep: "secret values",
+                    },
+                ],
+                n: 1,
+            },
+        });
+        const [filteredMessage] = filterMaskSecretsData([message]);
+        assert.deepStrictEqual(filteredMessage, {
+            range: [0, 1],
+            ruleId: "example",
+            severity: "error",
+            type: "message",
+            loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+            message: "message",
+            messageId: "message",
+            data: {
+                key: "***********",
+                nest: [
+                    "****************",
+                    {
+                        deep: "************",
+                    },
+                ],
+                n: 1,
+            },
+        });
+    });
+});

--- a/packages/@secretlint/core/test/messages/filter-message-secrets.ts
+++ b/packages/@secretlint/core/test/messages/filter-message-secrets.ts
@@ -34,7 +34,7 @@ describe("filter-mask-secrets", function () {
             loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
             message: "message",
             messageId: "message",
-            data: { key: "***********" },
+            data: { key: "************" },
         });
     });
     it("mask deep value", () => {
@@ -61,11 +61,11 @@ describe("filter-mask-secrets", function () {
             message: "message",
             messageId: "message",
             data: {
-                key: "***********",
+                key: "************",
                 nest: [
-                    "****************",
+                    "*****************",
                     {
-                        deep: "************",
+                        deep: "*************",
                     },
                 ],
                 n: 1,

--- a/packages/@secretlint/core/test/messages/sort-messages-process.test.ts
+++ b/packages/@secretlint/core/test/messages/sort-messages-process.test.ts
@@ -12,29 +12,29 @@ describe("sort-message", function () {
     });
     context("when reverse line", function () {
         it("should sort by range", function () {
-            const message = [createMessageFromRange([0, 1]), createMessageFromRange([2, 3])];
-            const expected = [createMessageFromRange([0, 1]), createMessageFromRange([2, 3])];
+            const message = [createMessageFromRange({ range: [0, 1] }), createMessageFromRange({ range: [2, 3] })];
+            const expected = [createMessageFromRange({ range: [0, 1] }), createMessageFromRange({ range: [2, 3] })];
             assert.deepStrictEqual(sortMessagesByLocation(message), expected);
         });
     });
     context("when reverse column", function () {
         it("should sort by range", function () {
-            const message = [createMessageFromRange([2, 3]), createMessageFromRange([0, 1])];
-            const expected = [createMessageFromRange([0, 1]), createMessageFromRange([2, 3])];
+            const message = [createMessageFromRange({ range: [2, 3] }), createMessageFromRange({ range: [0, 1] })];
+            const expected = [createMessageFromRange({ range: [0, 1] }), createMessageFromRange({ range: [2, 3] })];
             assert.deepStrictEqual(sortMessagesByLocation(message), expected);
         });
     });
     context("when reverse both", function () {
         it("should sort by range", function () {
             const message = [
-                createMessageFromRange([3, 4]),
-                createMessageFromRange([0, 1]),
-                createMessageFromRange([2, 3]),
+                createMessageFromRange({ range: [3, 4] }),
+                createMessageFromRange({ range: [0, 1] }),
+                createMessageFromRange({ range: [2, 3] }),
             ];
             const expected = [
-                createMessageFromRange([0, 1]),
-                createMessageFromRange([2, 3]),
-                createMessageFromRange([3, 4]),
+                createMessageFromRange({ range: [0, 1] }),
+                createMessageFromRange({ range: [2, 3] }),
+                createMessageFromRange({ range: [3, 4] }),
             ];
             assert.deepStrictEqual(sortMessagesByLocation(message), expected);
         });
@@ -42,14 +42,14 @@ describe("sort-message", function () {
     context("when same start index", function () {
         it("should sort by end index", function () {
             const message = [
-                createMessageFromRange([0, 4]),
-                createMessageFromRange([0, 1]),
-                createMessageFromRange([0, 3]),
+                createMessageFromRange({ range: [0, 4] }),
+                createMessageFromRange({ range: [0, 1] }),
+                createMessageFromRange({ range: [0, 3] }),
             ];
             const expected = [
-                createMessageFromRange([0, 1]),
-                createMessageFromRange([0, 3]),
-                createMessageFromRange([0, 4]),
+                createMessageFromRange({ range: [0, 1] }),
+                createMessageFromRange({ range: [0, 3] }),
+                createMessageFromRange({ range: [0, 4] }),
             ];
             assert.deepStrictEqual(sortMessagesByLocation(message), expected);
         });

--- a/packages/@secretlint/formatter/test/snapshots/input.ts
+++ b/packages/@secretlint/formatter/test/snapshots/input.ts
@@ -9,6 +9,7 @@ export const results: SecretLintCoreResult[] = [
                 data: {
                     ID: "SECRET",
                 },
+                type: "message",
                 message: "warning found secret: SECRET",
                 messageId: "message-id",
                 range: [8, 14],
@@ -29,6 +30,7 @@ export const results: SecretLintCoreResult[] = [
                 data: {
                     ID: "SECRET",
                 },
+                type: "message",
                 message: "error found secret: SECRET",
                 messageId: "message-id",
                 range: [8, 14],
@@ -49,6 +51,7 @@ export const results: SecretLintCoreResult[] = [
                 data: {
                     ID: "SECRET",
                 },
+                type: "message",
                 message: "error found secret: SECRET",
                 messageId: "message-id",
                 range: [8, 14],

--- a/packages/@secretlint/node/src/index.ts
+++ b/packages/@secretlint/node/src/index.ts
@@ -39,6 +39,14 @@ export type SecretLintEngineOptionsBase = {
      * locale for rule message
      */
     locale?: SecretLintRuleLocaleTag;
+
+    /**
+     * If maskSecrets is true, mask secret values with "***".
+     * If you want to hide actual secret values, set true
+     * https://github.com/secretlint/secretlint/issues/176
+     * Default: false
+     */
+    maskSecrets?: boolean;
 };
 export type SecretLintEngineOptionsConfigFilePath = SecretLintEngineOptionsBase & {
     /**
@@ -59,12 +67,20 @@ export type SecretLintEngineOptions = SecretLintEngineOptionsConfigFilePath | Se
 const isConfigFileJSON = (v: any): v is SecretLintEngineOptionsConfigFileJSON => {
     return "configFileJSON" in v && v.configFileJSON !== undefined;
 };
-const lintFile = async (filePath: string, config: SecretLintCoreDescriptor, options: SecretLintEngineOptions) => {
+const lintFile = async ({
+    filePath,
+    config,
+    options,
+}: {
+    filePath: string;
+    config: SecretLintCoreDescriptor;
+    options: SecretLintEngineOptions;
+}) => {
     const rawSource = await createRawSource(filePath);
     return lintSource({
         source: rawSource,
         options: {
-            locale: options.locale,
+            ...options,
             config: config,
         },
     });
@@ -94,7 +110,7 @@ const executeOnContent = async ({
             contentType: "text",
         },
         options: {
-            locale: options.locale,
+            ...options,
             config,
         },
     });
@@ -128,7 +144,7 @@ const executeOnFiles = async ({
 }) => {
     const mapper = async (filePath: string) => {
         debug("executeOnFiles file: %s", filePath);
-        const result = await lintFile(filePath, config, options);
+        const result = await lintFile({ filePath: filePath, config: config, options: options });
         debug("executeOnFiles result: %o", result);
         return result;
     };

--- a/packages/@secretlint/node/test/index.test.ts
+++ b/packages/@secretlint/node/test/index.test.ts
@@ -60,4 +60,29 @@ describe("createEngine", function () {
 `
         );
     });
+    it("should hide secret values when enable maskSecrets", async () => {
+        const engine = await createEngine({
+            color: false,
+            cwd: path.join(__dirname, "fixtures/valid-config"),
+            formatter: "stylish",
+            maskSecrets: true,
+        });
+        const filePath = path.join(__dirname, "fixtures/SECRET.txt");
+        const content = fs.readFileSync(filePath, "utf-8");
+        const result = await engine.executeOnContent({
+            content,
+            filePath,
+        });
+        assert.strictEqual(result.ok, false);
+        const normalizedOutput = normalizeFilePath(result.output);
+        assert.strictEqual(
+            normalizedOutput,
+            `
+[TEST_DIR]/fixtures/SECRET.txt
+  1:8  error  [EXAMPLE_MESSAGE] found secret: ******  @secretlint/secretlint-rule-example
+
+✖ 1 problem (1 error, 0 warnings)
+`
+        );
+    });
 });

--- a/packages/@secretlint/secretlint-rule-aws/test/snapshots/ng.AWS Access Key ID/output.json
+++ b/packages/@secretlint/secretlint-rule-aws/test/snapshots/ng.AWS Access Key ID/output.json
@@ -7,6 +7,7 @@
                 27,
                 47
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-aws",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-aws/test/snapshots/ng.AWS Account ID/output.json
+++ b/packages/@secretlint/secretlint-rule-aws/test/snapshots/ng.AWS Account ID/output.json
@@ -7,6 +7,7 @@
                 0,
                 32
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-aws",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-aws/test/snapshots/ng.AWS Secret Access Key/output.json
+++ b/packages/@secretlint/secretlint-rule-aws/test/snapshots/ng.AWS Secret Access Key/output.json
@@ -7,6 +7,7 @@
                 0,
                 40
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-aws",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-basicauth/test/snapshots/ng.basic-auth-ftp-url/output.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/test/snapshots/ng.basic-auth-ftp-url/output.json
@@ -7,6 +7,7 @@
                 10,
                 37
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-basicauth",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-basicauth/test/snapshots/ng.basic-auth-http-url/output.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/test/snapshots/ng.basic-auth-http-url/output.json
@@ -7,6 +7,7 @@
                 10,
                 39
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-basicauth",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-basicauth/test/snapshots/ng.basic-auth-in-markdown/output.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/test/snapshots/ng.basic-auth-in-markdown/output.json
@@ -7,6 +7,7 @@
                 8,
                 37
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-basicauth",
             "loc": {
                 "start": {
@@ -31,6 +32,7 @@
                 56,
                 85
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-basicauth",
             "loc": {
                 "start": {
@@ -55,6 +57,7 @@
                 108,
                 137
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-basicauth",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-example/test/snapshots/ng.secret/output.json
+++ b/packages/@secretlint/secretlint-rule-example/test/snapshots/ng.secret/output.json
@@ -7,6 +7,7 @@
                 8,
                 14
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-example",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-gcp/test/snapshots/ng.privatekey-json/output.json
+++ b/packages/@secretlint/secretlint-rule-gcp/test/snapshots/ng.privatekey-json/output.json
@@ -7,6 +7,7 @@
                 0,
                 1755
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-gcp",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-gcp/test/snapshots/ng.privatekey-p12/output.json
+++ b/packages/@secretlint/secretlint-rule-gcp/test/snapshots/ng.privatekey-p12/output.json
@@ -7,6 +7,7 @@
                 0,
                 2301
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-gcp",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-github/test/snapshots/ng.apikey/output.json
+++ b/packages/@secretlint/secretlint-rule-github/test/snapshots/ng.apikey/output.json
@@ -7,6 +7,7 @@
                 0,
                 40
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-github",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-no-dotenv/test/snapshots/ng.match/output.json
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/test/snapshots/ng.match/output.json
@@ -7,6 +7,7 @@
                 0,
                 8
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-no-dotenv",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.homedir/output.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.homedir/output.json
@@ -7,6 +7,7 @@
                 9,
                 27
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-no-homedir",
             "loc": {
                 "start": {
@@ -31,6 +32,7 @@
                 37,
                 55
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-no-homedir",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.patial-homedir/output.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/snapshots/ng.patial-homedir/output.json
@@ -7,6 +7,7 @@
                 23,
                 41
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-no-homedir",
             "loc": {
                 "start": {
@@ -31,6 +32,7 @@
                 65,
                 83
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-no-homedir",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-npm/test/snapshots/npmrc-_authToken/output.json
+++ b/packages/@secretlint/secretlint-rule-npm/test/snapshots/npmrc-_authToken/output.json
@@ -7,6 +7,7 @@
                 22,
                 59
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-npm",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-npm/test/snapshots/package-lock.json-has-x-oauth-basic/output.json
+++ b/packages/@secretlint/secretlint-rule-npm/test/snapshots/package-lock.json-has-x-oauth-basic/output.json
@@ -7,6 +7,7 @@
                 165,
                 204
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-npm",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-npm/test/snapshots/package.json-has-x-oauth-basic/output.json
+++ b/packages/@secretlint/secretlint-rule-npm/test/snapshots/package.json-has-x-oauth-basic/output.json
@@ -7,6 +7,7 @@
                 180,
                 219
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-npm",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.basic-test/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.basic-test/output.json
@@ -7,6 +7,7 @@
                 0,
                 21
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-pattern",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/aws/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/aws/output.json
@@ -7,6 +7,7 @@
                 0,
                 32
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-aws",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/basicauth/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/basicauth/output.json
@@ -7,6 +7,7 @@
                 5,
                 34
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-basicauth",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/gcp/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/gcp/output.json
@@ -7,6 +7,7 @@
                 0,
                 1755
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-gcp",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {
@@ -32,6 +33,7 @@
                 142,
                 1755
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-privatekey",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/github/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/github/output.json
@@ -7,6 +7,7 @@
                 4,
                 44
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-github",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/privatekey/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/privatekey/output.json
@@ -7,6 +7,7 @@
                 0,
                 887
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-privatekey",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-secp256k1-privatekey/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-secp256k1-privatekey/output.json
@@ -7,6 +7,7 @@
                 0,
                 887
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-privatekey",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/sendgrid/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/sendgrid/output.json
@@ -7,6 +7,7 @@
                 84,
                 153
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-sendgrid",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {
@@ -32,6 +33,7 @@
                 157,
                 232
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-sendgrid",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/slack/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/slack/output.json
@@ -7,6 +7,7 @@
                 48,
                 78
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {
@@ -32,6 +33,7 @@
                 79,
                 109
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {
@@ -57,6 +59,7 @@
                 110,
                 140
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/aws/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/aws/output.json
@@ -7,6 +7,7 @@
                 0,
                 32
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-aws",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/basicauth/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/basicauth/output.json
@@ -7,6 +7,7 @@
                 5,
                 34
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-basicauth",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/gcp/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/gcp/output.json
@@ -7,6 +7,7 @@
                 0,
                 1755
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-gcp",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {
@@ -32,6 +33,7 @@
                 142,
                 1755
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-privatekey",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/github/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/github/output.json
@@ -7,6 +7,7 @@
                 4,
                 44
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-github",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/privatekey/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/privatekey/output.json
@@ -7,6 +7,7 @@
                 0,
                 887
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-privatekey",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-secp256k1-privatekey/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-secp256k1-privatekey/output.json
@@ -7,6 +7,7 @@
                 0,
                 887
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-privatekey",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/sendgrid/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/sendgrid/output.json
@@ -7,6 +7,7 @@
                 84,
                 153
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-sendgrid",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {
@@ -32,6 +33,7 @@
                 157,
                 232
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-sendgrid",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/slack/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/slack/output.json
@@ -7,6 +7,7 @@
                 48,
                 78
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {
@@ -32,6 +33,7 @@
                 79,
                 109
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {
@@ -57,6 +59,7 @@
                 110,
                 140
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
             "loc": {

--- a/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/ECDSA/output.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/ECDSA/output.json
@@ -7,6 +7,7 @@
                 0,
                 288
             ],
+            "type": "message",
             "ruleId": "secretlint-rule-privatekey",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/ecdsa-256/output.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/ecdsa-256/output.json
@@ -7,6 +7,7 @@
                 0,
                 513
             ],
+            "type": "message",
             "ruleId": "secretlint-rule-privatekey",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/ed25519-256/output.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/ed25519-256/output.json
@@ -7,6 +7,7 @@
                 0,
                 419
             ],
+            "type": "message",
             "ruleId": "secretlint-rule-privatekey",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/private-key-pem/output.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/private-key-pem/output.json
@@ -7,6 +7,7 @@
                 0,
                 1694
             ],
+            "type": "message",
             "ruleId": "secretlint-rule-privatekey",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/rsa-4096/output.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/rsa-4096/output.json
@@ -7,6 +7,7 @@
                 0,
                 3389
             ],
+            "type": "message",
             "ruleId": "secretlint-rule-privatekey",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/rsa/output.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/test/snapshots/rsa/output.json
@@ -7,6 +7,7 @@
                 0,
                 887
             ],
+            "type": "message",
             "ruleId": "secretlint-rule-privatekey",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/snapshots/ng.privkey/output.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/snapshots/ng.privkey/output.json
@@ -7,6 +7,7 @@
                 36,
                 100
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-secp256k1-privatekey",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-sendgrid/test/snapshots/ng.apikey/output.json
+++ b/packages/@secretlint/secretlint-rule-sendgrid/test/snapshots/ng.apikey/output.json
@@ -7,6 +7,7 @@
                 84,
                 153
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-sendgrid",
             "loc": {
                 "start": {
@@ -31,6 +32,7 @@
                 157,
                 232
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-sendgrid",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-slack/test/snapshots/ng.IncomingWebhook/output.json
+++ b/packages/@secretlint/secretlint-rule-slack/test/snapshots/ng.IncomingWebhook/output.json
@@ -7,6 +7,7 @@
                 0,
                 57
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "loc": {
                 "start": {
@@ -31,6 +32,7 @@
                 65,
                 141
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "loc": {
                 "start": {

--- a/packages/@secretlint/secretlint-rule-slack/test/snapshots/ng.found-slack-token/output.json
+++ b/packages/@secretlint/secretlint-rule-slack/test/snapshots/ng.found-slack-token/output.json
@@ -7,6 +7,7 @@
                 48,
                 78
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "loc": {
                 "start": {
@@ -31,6 +32,7 @@
                 85,
                 115
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "loc": {
                 "start": {
@@ -55,6 +57,7 @@
                 122,
                 152
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "loc": {
                 "start": {
@@ -79,6 +82,7 @@
                 160,
                 190
             ],
+            "type": "message",
             "ruleId": "@secretlint/secretlint-rule-slack",
             "loc": {
                 "start": {

--- a/packages/@secretlint/tester/README.md
+++ b/packages/@secretlint/tester/README.md
@@ -10,7 +10,7 @@ Install with [npm](https://www.npmjs.com/):
 
 ## Usage
 
-- [ ] Write usage instructions
+See <https://github.com/secretlint/secretlint/blob/master/docs/secretlint-rule.md#test-secretlintsecretlint-rule-example>
 
 ## Changelog
 

--- a/packages/@secretlint/tester/test/fixtures/snapshots/has-secret/output.json
+++ b/packages/@secretlint/tester/test/fixtures/snapshots/has-secret/output.json
@@ -7,6 +7,7 @@
                 8,
                 14
             ],
+            "type": "message",
             "ruleId": "secretlint-rule-example",
             "loc": {
                 "start": {

--- a/packages/@secretlint/types/src/SecretLintCore.ts
+++ b/packages/@secretlint/types/src/SecretLintCore.ts
@@ -83,6 +83,7 @@ export type SecretLintCoreResult = {
     messages: SecretLintCoreResultMessage[];
 };
 export type SecretLintCoreResultMessage = {
+    type: "message";
     ruleId: string;
     ruleParentId?: string;
     message: string;
@@ -98,6 +99,7 @@ export type SecretLintCoreResultMessage = {
     data?: {};
 };
 export type SecretLintCoreIgnoreMessage = {
+    type: "ignore";
     ruleId: string;
     ruleParentId?: string;
     /**

--- a/packages/secretlint/src/cli.ts
+++ b/packages/secretlint/src/cli.ts
@@ -22,6 +22,7 @@ export const cli = meow(
       --output           [path:String] output file path that is written of reported result.
       --no-color         disable ANSI-color of output.
       --no-terminalLink  disable terminalLink of output.
+      --maskSecrets      enable masking of secret values. replace actual secrets with "***".
       --secretlintrc     [path:String] path to .secretlintrc config file. Default: .secretlintrc.*
       --secretlintignore [path:String] path to .secretlintignore file. Default: .secretlintignore
 
@@ -75,6 +76,10 @@ export const cli = meow(
             terminalLink: {
                 type: "boolean",
                 default: true,
+            },
+            maskSecrets: {
+                type: "boolean",
+                default: false,
             },
             profile: {
                 type: "boolean",
@@ -132,6 +137,7 @@ export const run = (
                   color: flags.color,
                   terminalLink: flags.terminalLink,
                   locale: flags.locale,
+                  maskSecrets: flags.maskSecrets,
               }
             : {
                   configFilePath: flags.secretlintrc,
@@ -140,6 +146,7 @@ export const run = (
                   color: flags.color,
                   terminalLink: flags.terminalLink,
                   locale: flags.locale,
+                  maskSecrets: flags.maskSecrets,
               },
     }).finally(async () => {
         secretLintProfiler.mark({

--- a/packages/secretlint/test/snapshots/--format=json/output.json
+++ b/packages/secretlint/test/snapshots/--format=json/output.json
@@ -10,6 +10,7 @@
                         8,
                         14
                     ],
+                    "type": "message",
                     "ruleId": "@secretlint/secretlint-rule-example",
                     "loc": {
                         "start": {

--- a/packages/secretlint/test/snapshots/--locale=ja/output.json
+++ b/packages/secretlint/test/snapshots/--locale=ja/output.json
@@ -10,6 +10,7 @@
                         8,
                         14
                     ],
+                    "type": "message",
                     "ruleId": "@secretlint/secretlint-rule-example",
                     "loc": {
                         "start": {

--- a/packages/secretlint/test/snapshots/--secretlintignore=ignore/output.json
+++ b/packages/secretlint/test/snapshots/--secretlintignore=ignore/output.json
@@ -10,6 +10,7 @@
                         8,
                         14
                     ],
+                    "type": "message",
                     "ruleId": "@secretlint/secretlint-rule-example",
                     "loc": {
                         "start": {

--- a/packages/secretlint/test/snapshots/basic/output.json
+++ b/packages/secretlint/test/snapshots/basic/output.json
@@ -10,6 +10,7 @@
                         8,
                         14
                     ],
+                    "type": "message",
                     "ruleId": "@secretlint/secretlint-rule-example",
                     "loc": {
                         "start": {

--- a/packages/secretlint/test/snapshots/preset-rule-severity-warning/output.json
+++ b/packages/secretlint/test/snapshots/preset-rule-severity-warning/output.json
@@ -10,6 +10,7 @@
                         0,
                         906
                     ],
+                    "type": "message",
                     "ruleId": "@secretlint/secretlint-rule-privatekey",
                     "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
                     "loc": {

--- a/packages/secretlint/test/snapshots/rule-severity-warning/output.json
+++ b/packages/secretlint/test/snapshots/rule-severity-warning/output.json
@@ -10,6 +10,7 @@
                         8,
                         14
                     ],
+                    "type": "message",
                     "ruleId": "@secretlint/secretlint-rule-example",
                     "loc": {
                         "start": {

--- a/packages/secretlint/test/snapshots/secretlintignore/output.json
+++ b/packages/secretlint/test/snapshots/secretlintignore/output.json
@@ -10,6 +10,7 @@
                         8,
                         14
                     ],
+                    "type": "message",
                     "ruleId": "@secretlint/secretlint-rule-example",
                     "loc": {
                         "start": {


### PR DESCRIPTION
## Feature

Add `maskSecrets` options

It mask acutal secrets values in `message` and `data` properties.
As a results, `$ secretlint --maskSecrets` show `***` instead of actual secret values.

### Masking logics

masking of secretlint is simple string replacement.

If a secretlint rule reports `"TOKEN_STRING"`, replace all `TOKEN_STRING` with `**********` in messages.
This is similar to CI logs like Travis CI or GitHub Actions.

```
        context.report({
            message: t("MESSAGE", {
                TOKEN: "TOKEN_STRING", // => repace all "TOKEN_STRING" with  `**********`.
            }),
            range,
        })
```

📝 masking should be implemented in pre-process, but We have not pre-process for `t("message")` .

> Although, I don't think it should be part of the translator helper :)
> https://github.com/secretlint/secretlint/issues/176#issuecomment-869517023

I agree this. So, I've implemented masking logic as post-process.

- [x] **core**: add `maskSecrets` options
- [x] **node**: add `maskSecrets` options
- [x] **cli**: add `--maskSecrets` flag

close #176 