### PR TITLE
fix(config-loader)!: secretlint rule should `export { creator }`

### DIFF
--- a/docs/secretlint-rule.md
+++ b/docs/secretlint-rule.md
@@ -31,8 +31,11 @@ export const messages = {
     }
 };
 
+// export named `creator`
 export const creator: SecretLintRuleCreator = {
+    // required `messages` property
     messages,
+    // meta object for rule
     meta: {
         // rule.meta.id should be same with package.json name
         id: "@secretlint/secretlint-rule-example",
@@ -73,8 +76,6 @@ export const creator: SecretLintRuleCreator = {
         };
     }
 };
-// export it as default
-export default creator;
 ```
 
 ### Test: `@secretlint/secretlint-rule-example`
@@ -89,9 +90,9 @@ It is template for testing.
 `test/index.test.ts`
 
 ```ts
-import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { snapshot } from "@secretlint/tester";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-basicauth", () => {
     snapshot({

--- a/docs/secretlint-rule.md
+++ b/docs/secretlint-rule.md
@@ -16,9 +16,22 @@ This secretllint rule just do following:
 
 - Found `"secret"` word and report it
 
-Implementation(TypeScript version):
+Implementation:
 
-- `@secretlint/types` package includes type definition for secretlint rule
+- A rule should export `creator` object
+  - `messages`: MessageIds
+  - `meta`: meta information for the rule
+    - `id`: `id` should be equal to `package.json`'s `name`
+    - `recommended`(optional): recommended to use 
+    - `type`: `"scanner"`
+    - `supportedContentTypes`: "text" or "binary" or "all"
+      - If specified `["text"]`, secretlint pass the content of text to the rule. 
+      - In other words, secretlint does not pass binary content
+    - `docs`
+      - `url`: document base url. secretlint show `{docs.url}#{MessageId}` in results.
+  - `create`: main logic of the rule
+
+`@secretlint/types` package includes type definition for secretlint rule.
 
 ```ts
 import { SecretLintRuleCreator, SecretLintSourceCode } from "@secretlint/types";

--- a/packages/@secretlint/config-loader/package.json
+++ b/packages/@secretlint/config-loader/package.json
@@ -46,7 +46,6 @@
         "@secretlint/config-validator": "^3.3.0",
         "@secretlint/profiler": "^3.1.0",
         "@secretlint/types": "^3.3.0",
-        "@textlint/module-interop": "^1.0.2",
         "debug": "^4.1.1",
         "rc-config-loader": "^3.0.0",
         "try-resolve": "^1.0.1"

--- a/packages/@secretlint/config-loader/src/index.ts
+++ b/packages/@secretlint/config-loader/src/index.ts
@@ -122,10 +122,11 @@ export const loadPackagesFromRawConfig = async (
                     return id === configDescriptorRule.id;
                 });
             // TODO: any to be remove
-            const moduleExports = await _importDynamic(moduleResolver.resolveRulePackageName(configDescriptorRule.id));
             const ruleModule: any = replacedDefinition
                 ? replacedDefinition.rule
-                : importSecretlintCreator(moduleExports);
+                : importSecretlintCreator(
+                      await _importDynamic(moduleResolver.resolveRulePackageName(configDescriptorRule.id))
+                  );
             const secretLintConfigDescriptorRules: SecretLintCoreDescriptorRule[] | undefined =
                 "rules" in configDescriptorRule && Array.isArray(configDescriptorRule.rules)
                     ? (configDescriptorRule.rules.filter(

--- a/packages/@secretlint/config-loader/test/fixtures/valid-config-esm/modules/example/index.mjs
+++ b/packages/@secretlint/config-loader/test/fixtures/valid-config-esm/modules/example/index.mjs
@@ -37,4 +37,3 @@ export const creator = {
         };
     }
 };
-export default creator;

--- a/packages/@secretlint/config-loader/test/index.test.ts
+++ b/packages/@secretlint/config-loader/test/index.test.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import assert from "assert";
-import { loadConfig } from "../src";
-import { moduleInterop } from "@textlint/module-interop";
+import { loadConfig, importSecretlintCreator } from "../src";
 import { SecretLintCoreDescriptorUnionRule } from "@secretlint/types";
 
 const removeUndefined = (o: { [index: string]: any }) => {
@@ -28,11 +27,11 @@ describe("@secretlint/config-loader", function () {
                     rules: [
                         {
                             id: "example",
-                            rule: moduleInterop(require("@secretlint/secretlint-rule-example")),
+                            rule: importSecretlintCreator(require("@secretlint/secretlint-rule-example")),
                         },
                         {
                             id: "example-2",
-                            rule: moduleInterop(require("@secretlint/secretlint-rule-example")),
+                            rule: importSecretlintCreator(require("@secretlint/secretlint-rule-example")),
                             disabled: true,
                         },
                     ],

--- a/packages/@secretlint/core/test/fixtures/secretlint-rule-example.ts
+++ b/packages/@secretlint/core/test/fixtures/secretlint-rule-example.ts
@@ -36,4 +36,3 @@ export const creator: SecretLintRuleCreator = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/core/test/index.test.ts
+++ b/packages/@secretlint/core/test/index.test.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { lintSource } from "../src";
 import { SecretLintRawSource } from "@secretlint/types";
-import example from "./fixtures/secretlint-rule-example";
+import { creator as example } from "./fixtures/secretlint-rule-example";
 import { assertJsonEqual } from "assert-json-equal";
 
 describe("lintSource", function () {

--- a/packages/@secretlint/secretlint-rule-aws/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-aws/src/index.ts
@@ -178,4 +178,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-aws/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-aws/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-aws", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-basicauth/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-basicauth/src/index.ts
@@ -77,4 +77,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-basicauth/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-basicauth/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-basicauth", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-example/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-example/src/index.ts
@@ -39,4 +39,3 @@ export const creator: SecretLintRuleCreator = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-example/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-example/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-example", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-gcp/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-gcp/src/index.ts
@@ -122,4 +122,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-gcp/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-gcp/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-gcp", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-github/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-github/src/index.ts
@@ -106,4 +106,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-github/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-github/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-github", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-no-dotenv/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/src/index.ts
@@ -44,5 +44,3 @@ export const creator: SecretLintRuleCreator = {
         };
     },
 };
-
-export default creator;

--- a/packages/@secretlint/secretlint-rule-no-dotenv/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-no-dotenv", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-no-homedir/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-no-homedir/src/index.ts
@@ -98,4 +98,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-no-homedir/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-no-homedir/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-no-homedir", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/src/index.ts
@@ -68,4 +68,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-no-k8s-kind-secret", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-npm/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-npm/src/index.ts
@@ -127,4 +127,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-npm/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-npm/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("Snapshot Testing", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-pattern/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-pattern/src/index.ts
@@ -78,4 +78,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-pattern/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-pattern/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-patttern", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
@@ -23,4 +23,3 @@ export const creator: SecretLintRulePresetCreator<Options> = {
         });
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
@@ -1,12 +1,12 @@
 import { SecretLintRulePresetCreator } from "@secretlint/types";
-import ruleAWS from "@secretlint/secretlint-rule-aws";
-import ruleGCP from "@secretlint/secretlint-rule-gcp";
-import ruleNpm from "@secretlint/secretlint-rule-npm";
-import ruleSlack from "@secretlint/secretlint-rule-slack";
-import ruleBasicAuth from "@secretlint/secretlint-rule-basicauth";
-import rulePrivateKey from "@secretlint/secretlint-rule-privatekey";
-import ruleSendgrid from "@secretlint/secretlint-rule-sendgrid";
-import ruleGitHub from "@secretlint/secretlint-rule-github";
+import { creator as ruleAWS } from "@secretlint/secretlint-rule-aws";
+import { creator as ruleGCP } from "@secretlint/secretlint-rule-gcp";
+import { creator as ruleNpm } from "@secretlint/secretlint-rule-npm";
+import { creator as ruleSlack } from "@secretlint/secretlint-rule-slack";
+import { creator as ruleBasicAuth } from "@secretlint/secretlint-rule-basicauth";
+import { creator as rulePrivateKey } from "@secretlint/secretlint-rule-privatekey";
+import { creator as ruleSendgrid } from "@secretlint/secretlint-rule-sendgrid";
+import { creator as ruleGitHub } from "@secretlint/secretlint-rule-github";
 
 export const rules = [ruleAWS, ruleGCP, rulePrivateKey, ruleNpm, ruleBasicAuth, ruleSlack, ruleSendgrid, ruleGitHub];
 export type Options = {};

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("Snapshot Testing", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-preset-recommend/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/src/index.ts
@@ -23,4 +23,3 @@ export const creator: SecretLintRulePresetCreator<Options> = {
         });
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-preset-recommend/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/src/index.ts
@@ -1,12 +1,12 @@
 import { SecretLintRulePresetCreator } from "@secretlint/types";
-import ruleAWS from "@secretlint/secretlint-rule-aws";
-import ruleGCP from "@secretlint/secretlint-rule-gcp";
-import ruleNpm from "@secretlint/secretlint-rule-npm";
-import ruleSlack from "@secretlint/secretlint-rule-slack";
-import ruleBasicAuth from "@secretlint/secretlint-rule-basicauth";
-import rulePrivateKey from "@secretlint/secretlint-rule-privatekey";
-import ruleSendgrid from "@secretlint/secretlint-rule-sendgrid";
-import ruleGitHub from "@secretlint/secretlint-rule-github";
+import { creator as ruleAWS } from "@secretlint/secretlint-rule-aws";
+import { creator as ruleGCP } from "@secretlint/secretlint-rule-gcp";
+import { creator as ruleNpm } from "@secretlint/secretlint-rule-npm";
+import { creator as ruleSlack } from "@secretlint/secretlint-rule-slack";
+import { creator as ruleBasicAuth } from "@secretlint/secretlint-rule-basicauth";
+import { creator as rulePrivateKey } from "@secretlint/secretlint-rule-privatekey";
+import { creator as ruleSendgrid } from "@secretlint/secretlint-rule-sendgrid";
+import { creator as ruleGitHub } from "@secretlint/secretlint-rule-github";
 
 export const rules = [ruleAWS, ruleGCP, rulePrivateKey, ruleNpm, ruleBasicAuth, ruleSlack, ruleSendgrid, ruleGitHub];
 export type Options = {};

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("Snapshot Testing", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-privatekey/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-privatekey/src/index.ts
@@ -76,4 +76,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-privatekey/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-privatekey/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("Snapshot Testing", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/src/index.ts
@@ -56,4 +56,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-secp256k1", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-sendgrid/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-sendgrid/src/index.ts
@@ -74,4 +74,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-sendgrid/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-sendgrid/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-sendgrid", () => {
     snapshot({

--- a/packages/@secretlint/secretlint-rule-slack/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-slack/src/index.ts
@@ -126,4 +126,3 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/secretlint-rule-slack/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-slack/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "@secretlint/tester";
 import path from "path";
-import rule from "../src/index";
+import { creator as rule } from "../src/index";
 
 describe("@secretlint/secretlint-rule-slack", () => {
     snapshot({

--- a/packages/@secretlint/tester/test/fixtures/secretlint-rule-example.ts
+++ b/packages/@secretlint/tester/test/fixtures/secretlint-rule-example.ts
@@ -36,4 +36,3 @@ export const creator: SecretLintRuleCreator = {
         };
     },
 };
-export default creator;

--- a/packages/@secretlint/tester/test/index.test.ts
+++ b/packages/@secretlint/tester/test/index.test.ts
@@ -1,6 +1,6 @@
 import { snapshot } from "../src";
 import path from "path";
-import rule from "./fixtures/secretlint-rule-example";
+import { creator as rule } from "./fixtures/secretlint-rule-example";
 
 describe("@secretlint/tester", () => {
     snapshot({

--- a/packages/@secretlint/types/src/SecretLintCore.ts
+++ b/packages/@secretlint/types/src/SecretLintCore.ts
@@ -72,7 +72,10 @@ export type SecretLintUnionRuleCreator<Options = SecretLintRuleCreatorOptions | 
 export type SecretLintCoreDescriptorUnionRule<
     Options = SecretLintRuleCreatorOptions | SecretLintRulePresetCreatorOptions
 > = SecretLintCoreDescriptorRule<Options> | SecretLintCoreDescriptorRulePreset<Options>;
-
+// module export named `creator`
+export type SecretLintRuleModule = {
+    creator: SecretLintUnionRuleCreator;
+};
 export type SecretLintCoreDescriptor = {
     sharedOptions?: SecretlintCoreSharedOptions;
     rules: SecretLintCoreDescriptorUnionRule[];

--- a/packages/@secretlint/types/src/index.ts
+++ b/packages/@secretlint/types/src/index.ts
@@ -6,6 +6,7 @@ export {
     SecretLintCoreResult,
     SecretLintCoreResultMessage,
     SecretLintCoreDescriptor,
+    SecretLintRuleModule,
     // union
     SecretLintUnionRuleCreator,
     SecretLintCoreDescriptorUnionRule,

--- a/yarn.lock
+++ b/yarn.lock
@@ -974,7 +974,7 @@
     try-resolve "^1.0.1"
     xml-escape "^1.1.0"
 
-"@textlint/module-interop@^1.0.2", "@textlint/module-interop@^1.2.5":
+"@textlint/module-interop@^1.2.5":
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@textlint/module-interop/-/module-interop-1.2.5.tgz#f10582e66e0633ac1aea228f30c5b3f5d8463f45"
   integrity sha512-+yEluCSbj6oxk9ENFojVcSxURvXOg7AU3vBiVHPjPEShaqbzZZ6tcut6gbDcIYhEDUkegZGmGwyfOe+wNABhKw==


### PR DESCRIPTION
## Breaking Changes

- `export const creator = { ... }` instead of `export deafult creator`

There is no 3rd-party secretlint rules https://github.com/search?q=secretlint-rule&type=Repositories
So, This is not affect to any users.

## Updates

- Update rule docs

fix #190 