### PR TITLE
v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Bug Fixes
+
+* **privatekey:** fix report range ([#184](https://github.com/secretlint/secretlint/issues/184)) ([f3226ca](https://github.com/secretlint/secretlint/commit/f3226ca5190faad1b41b8690fc294fc824c20bae))
+
+
+### Features
+
+* **config-loader:** support a rule written by ESM ([#187](https://github.com/secretlint/secretlint/issues/187)) ([590c333](https://github.com/secretlint/secretlint/commit/590c3339f2f10ffeaf2b6d1084f9a907466d7453))
+* **preset:** add @secretlint/secretlint-rule-filter-comments to presets ([#198](https://github.com/secretlint/secretlint/issues/198)) ([7f25af3](https://github.com/secretlint/secretlint/commit/7f25af32977bc4726c8d2e796b08ba046e58f2fc))
+* **secretlint-rule-filter-comments:** secretlint-disable/secretlint-enable comment ([#195](https://github.com/secretlint/secretlint/issues/195)) ([607f361](https://github.com/secretlint/secretlint/commit/607f361bebf75f532ac1966c6939ed5955f3c669))
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/benchmark
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 **Note:** Version bump only for package @secretlint/benchmark

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/benchmark",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "private": true,
     "description": "Internal benchmark for Secretlint",
     "keywords": [
@@ -29,9 +29,9 @@
         "benchmark": "node index.js"
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-preset-canary": "^3.3.0",
+        "@secretlint/secretlint-rule-preset-canary": "^4.0.0",
         "benchmark": "^2.1.4",
-        "secretlint": "^3.3.0"
+        "secretlint": "^4.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/example-cli
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 **Note:** Version bump only for package @secretlint/example-cli

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/example-cli",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "private": true,
     "description": "",
     "homepage": "https://github.com/secretlint/secretlint/tree/master/examples/cli/",
@@ -27,9 +27,9 @@
         "test": "expected-exit-status 1 --command 'secretlint \"**/*\"'"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^3.3.0",
+        "@secretlint/secretlint-rule-preset-recommend": "^4.0.0",
         "expected-exit-status": "^1.0.2",
-        "secretlint": "^3.3.0"
+        "secretlint": "^4.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "packages/@secretlint/*",
     "examples/*"
   ],
-  "version": "3.3.0",
+  "version": "4.0.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "includeMergedTags": true

--- a/packages/@secretlint/config-creator/CHANGELOG.md
+++ b/packages/@secretlint/config-creator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/config-creator
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 **Note:** Version bump only for package @secretlint/config-creator

--- a/packages/@secretlint/config-creator/package.json
+++ b/packages/@secretlint/config-creator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-creator",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "Config file creator for secretlint.",
     "keywords": [
         "secretlint"
@@ -40,7 +40,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0"
+        "@secretlint/types": "^4.0.0"
     },
     "devDependencies": {
         "@types/mocha": "^9.0.0",

--- a/packages/@secretlint/config-loader/CHANGELOG.md
+++ b/packages/@secretlint/config-loader/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Features
+
+* **config-loader:** support a rule written by ESM ([#187](https://github.com/secretlint/secretlint/issues/187)) ([590c333](https://github.com/secretlint/secretlint/commit/590c3339f2f10ffeaf2b6d1084f9a907466d7453))
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 **Note:** Version bump only for package @secretlint/config-loader

--- a/packages/@secretlint/config-loader/package.json
+++ b/packages/@secretlint/config-loader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-loader",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "Config loader for secretlint.",
     "keywords": [
         "secretlint",
@@ -43,15 +43,15 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-validator": "^3.3.0",
-        "@secretlint/profiler": "^3.1.0",
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/config-validator": "^4.0.0",
+        "@secretlint/profiler": "^4.0.0",
+        "@secretlint/types": "^4.0.0",
         "debug": "^4.1.1",
         "rc-config-loader": "^4.0.0",
         "try-resolve": "^1.0.1"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^3.3.0",
+        "@secretlint/secretlint-rule-example": "^4.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "cross-env": "^7.0.3",

--- a/packages/@secretlint/config-validator/CHANGELOG.md
+++ b/packages/@secretlint/config-validator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/config-validator
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/config-validator/package.json
+++ b/packages/@secretlint/config-validator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/config-validator",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": ".secretlintrc config validation library",
     "keywords": [
         "secretlint",
@@ -45,7 +45,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "ajv": "^6.11.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/core/CHANGELOG.md
+++ b/packages/@secretlint/core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/core
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/core/package.json
+++ b/packages/@secretlint/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/core",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "Core library for @secretlint.",
     "keywords": [
         "secretlint"
@@ -40,8 +40,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/profiler": "^3.1.0",
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/profiler": "^4.0.0",
+        "@secretlint/types": "^4.0.0",
         "debug": "^4.1.1",
         "structured-source": "^3.0.2"
     },

--- a/packages/@secretlint/formatter/CHANGELOG.md
+++ b/packages/@secretlint/formatter/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/formatter
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/formatter/package.json
+++ b/packages/@secretlint/formatter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/formatter",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A formatter collection for Secretlint.",
     "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/formatter/",
     "bugs": {
@@ -38,7 +38,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "@textlint/linter-formatter": "^12.0.2",
         "@textlint/types": "^12.0.2",
         "chalk": "^4.1.1",

--- a/packages/@secretlint/messages-to-markdown/CHANGELOG.md
+++ b/packages/@secretlint/messages-to-markdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/messages-to-markdown
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 **Note:** Version bump only for package @secretlint/messages-to-markdown

--- a/packages/@secretlint/messages-to-markdown/package.json
+++ b/packages/@secretlint/messages-to-markdown/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/messages-to-markdown",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "Create Markdown text from rule's messages(ids)",
     "keywords": [
         "secretlint"
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "meow": "^6.1.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/node/CHANGELOG.md
+++ b/packages/@secretlint/node/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Features
+
+* **config-loader:** support a rule written by ESM ([#187](https://github.com/secretlint/secretlint/issues/187)) ([590c333](https://github.com/secretlint/secretlint/commit/590c3339f2f10ffeaf2b6d1084f9a907466d7453))
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/node/package.json
+++ b/packages/@secretlint/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/node",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "Secretlint client library for Node.js",
     "keywords": [
         "secretlint",
@@ -41,16 +41,16 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-loader": "^3.3.0",
-        "@secretlint/core": "^3.3.0",
-        "@secretlint/formatter": "^3.3.0",
-        "@secretlint/profiler": "^3.1.0",
-        "@secretlint/source-creator": "^3.3.0",
+        "@secretlint/config-loader": "^4.0.0",
+        "@secretlint/core": "^4.0.0",
+        "@secretlint/formatter": "^4.0.0",
+        "@secretlint/profiler": "^4.0.0",
+        "@secretlint/source-creator": "^4.0.0",
         "debug": "^4.1.1",
         "p-map": "^4.0.0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^3.3.0",
+        "@secretlint/secretlint-rule-example": "^4.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "cross-env": "^7.0.3",

--- a/packages/@secretlint/profiler/CHANGELOG.md
+++ b/packages/@secretlint/profiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/profiler
+
+
+
+
+
 # [3.1.0](https://github.com/secretlint/secretlint/compare/v3.0.0...v3.1.0) (2021-06-24)
 
 **Note:** Version bump only for package @secretlint/profiler

--- a/packages/@secretlint/profiler/package.json
+++ b/packages/@secretlint/profiler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/profiler",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "description": "Profile manager for Secretlint.",
     "keywords": [
         "secretlint"

--- a/packages/@secretlint/quick-start/CHANGELOG.md
+++ b/packages/@secretlint/quick-start/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/quick-start
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 **Note:** Version bump only for package @secretlint/quick-start

--- a/packages/@secretlint/quick-start/package.json
+++ b/packages/@secretlint/quick-start/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/quick-start",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "Quick Stater CLI for secretlint.",
     "keywords": [
         "secretlint",
@@ -46,8 +46,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^3.3.0",
-        "secretlint": "^3.3.0"
+        "@secretlint/secretlint-rule-preset-recommend": "^4.0.0",
+        "secretlint": "^4.0.0"
     },
     "devDependencies": {
         "@types/mocha": "^9.0.0",

--- a/packages/@secretlint/secretlint-rule-aws/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-aws/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-aws
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-aws/package.json
+++ b/packages/@secretlint/secretlint-rule-aws/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-aws",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A secretlint rule for AWS.",
     "keywords": [
         "secretlint",
@@ -43,12 +43,12 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "regx": "^1.0.4"
     },
     "devDependencies": {
-        "@secretlint/tester": "^3.3.0",
+        "@secretlint/tester": "^4.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "cross-env": "^7.0.3",

--- a/packages/@secretlint/secretlint-rule-basicauth/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-basicauth/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-basicauth
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-basicauth/package.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-basicauth",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A secretlint rule that check Basic Authentication.",
     "keywords": [
         "secretlint",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-example/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-example/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Features
+
+* **secretlint-rule-filter-comments:** secretlint-disable/secretlint-enable comment ([#195](https://github.com/secretlint/secretlint/issues/195)) ([607f361](https://github.com/secretlint/secretlint/commit/607f361bebf75f532ac1966c6939ed5955f3c669))
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-example/package.json
+++ b/packages/@secretlint/secretlint-rule-example/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-example",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "An example rule for secretlint. It it for testing.",
     "keywords": [
         "secretlint",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0"
+        "@secretlint/types": "^4.0.0"
     },
     "devDependencies": {
         "@types/mocha": "^9.0.0",

--- a/packages/@secretlint/secretlint-rule-filter-comments/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-filter-comments/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Features
+
+* **preset:** add @secretlint/secretlint-rule-filter-comments to presets ([#198](https://github.com/secretlint/secretlint/issues/198)) ([7f25af3](https://github.com/secretlint/secretlint/commit/7f25af32977bc4726c8d2e796b08ba046e58f2fc))
+* **secretlint-rule-filter-comments:** secretlint-disable/secretlint-enable comment ([#195](https://github.com/secretlint/secretlint/issues/195)) ([607f361](https://github.com/secretlint/secretlint/commit/607f361bebf75f532ac1966c6939ed5955f3c669))

--- a/packages/@secretlint/secretlint-rule-filter-comments/package.json
+++ b/packages/@secretlint/secretlint-rule-filter-comments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretlint/secretlint-rule-filter-comments",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "secretlint-disable comment directive.",
   "keywords": [
     "secretlint",
@@ -48,7 +48,7 @@
     "trailingComma": "none"
   },
   "devDependencies": {
-    "@secretlint/secretlint-rule-pattern": "^3.3.0",
+    "@secretlint/secretlint-rule-pattern": "^4.0.0",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.9.1",
     "mocha": "^9.1.1",
@@ -65,7 +65,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "dependencies": {
-    "@secretlint/types": "^3.3.0",
+    "@secretlint/types": "^4.0.0",
     "lint-staged": "^11.0.0",
     "prettier": "^2.3.1"
   }

--- a/packages/@secretlint/secretlint-rule-gcp/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-gcp/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Features
+
+* **secretlint-rule-filter-comments:** secretlint-disable/secretlint-enable comment ([#195](https://github.com/secretlint/secretlint/issues/195)) ([607f361](https://github.com/secretlint/secretlint/commit/607f361bebf75f532ac1966c6939ed5955f3c669))
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-gcp/package.json
+++ b/packages/@secretlint/secretlint-rule-gcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-gcp",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A secretlint rule for GCP.",
     "keywords": [
         "rule",
@@ -42,12 +42,12 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0",
         "node-forge": "^0.10.0"
     },
     "devDependencies": {
-        "@secretlint/tester": "^3.3.0",
+        "@secretlint/tester": "^4.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "@types/node-forge": "^0.10.4",

--- a/packages/@secretlint/secretlint-rule-github/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-github/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-github
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-github/package.json
+++ b/packages/@secretlint/secretlint-rule-github/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-github",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A secretlint rule for sendgrid api keys.",
     "keywords": [
         "rule",
@@ -43,11 +43,11 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {
-        "@secretlint/tester": "^3.3.0",
+        "@secretlint/tester": "^4.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-no-dotenv/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-no-dotenv
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-no-dotenv/package.json
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-no-dotenv",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A secretlint rule for dotenv",
     "keywords": [
         "secretlint",
@@ -46,7 +46,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0"
+        "@secretlint/types": "^4.0.0"
     },
     "devDependencies": {
         "@types/mocha": "^9.0.0",

--- a/packages/@secretlint/secretlint-rule-no-homedir/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-no-homedir/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-no-homedir
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-no-homedir/package.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretlint/secretlint-rule-no-homedir",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "A secretlint rule that disallow to include user's homedir path.",
   "keywords": [
     "rule",
@@ -42,7 +42,7 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "@secretlint/types": "^3.3.0",
+    "@secretlint/types": "^4.0.0",
     "escape-string-regexp": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-no-k8s-kind-secret
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 **Note:** Version bump only for package @secretlint/secretlint-rule-no-k8s-kind-secret

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretlint/secretlint-rule-no-k8s-kind-secret",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "A secretlint rule that disallow to use Kind: Secret in Kubernetes repository.",
   "keywords": [
     "rule",
@@ -42,7 +42,7 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "@secretlint/types": "^3.3.0",
+    "@secretlint/types": "^4.0.0",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-npm/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-npm/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-npm
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-npm/package.json
+++ b/packages/@secretlint/secretlint-rule-npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-npm",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A secretlint rule for npm.",
     "keywords": [
         "npm",
@@ -43,7 +43,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-pattern/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-pattern/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-pattern
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-pattern/package.json
+++ b/packages/@secretlint/secretlint-rule-pattern/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-pattern",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A secretlint rule that checks for regex patterns stored in configuration.",
     "keywords": [
         "secretlint",
@@ -43,8 +43,8 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/tester": "^3.3.0",
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/tester": "^4.0.0",
+        "@secretlint/types": "^4.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/secretlint-rule-preset-canary/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-preset-canary/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Bug Fixes
+
+* **privatekey:** fix report range ([#184](https://github.com/secretlint/secretlint/issues/184)) ([f3226ca](https://github.com/secretlint/secretlint/commit/f3226ca5190faad1b41b8690fc294fc824c20bae))
+
+
+### Features
+
+* **preset:** add @secretlint/secretlint-rule-filter-comments to presets ([#198](https://github.com/secretlint/secretlint/issues/198)) ([7f25af3](https://github.com/secretlint/secretlint/commit/7f25af32977bc4726c8d2e796b08ba046e58f2fc))
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@secretlint/secretlint-rule-preset-canary",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "Canary rule preset of secretlint.",
   "keywords": [
     "secretlint",
@@ -44,15 +44,15 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "@secretlint/secretlint-rule-aws": "^3.3.0",
-    "@secretlint/secretlint-rule-basicauth": "^3.3.0",
-    "@secretlint/secretlint-rule-gcp": "^3.3.0",
-    "@secretlint/secretlint-rule-github": "^3.3.0",
-    "@secretlint/secretlint-rule-npm": "^3.3.0",
-    "@secretlint/secretlint-rule-privatekey": "^3.3.0",
-    "@secretlint/secretlint-rule-sendgrid": "^3.3.0",
-    "@secretlint/secretlint-rule-slack": "^3.3.0",
-    "@secretlint/secretlint-rule-filter-comments": "^3.3.0"
+    "@secretlint/secretlint-rule-aws": "^4.0.0",
+    "@secretlint/secretlint-rule-basicauth": "^4.0.0",
+    "@secretlint/secretlint-rule-filter-comments": "^4.0.0",
+    "@secretlint/secretlint-rule-gcp": "^4.0.0",
+    "@secretlint/secretlint-rule-github": "^4.0.0",
+    "@secretlint/secretlint-rule-npm": "^4.0.0",
+    "@secretlint/secretlint-rule-privatekey": "^4.0.0",
+    "@secretlint/secretlint-rule-sendgrid": "^4.0.0",
+    "@secretlint/secretlint-rule-slack": "^4.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.2",

--- a/packages/@secretlint/secretlint-rule-preset-recommend/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Bug Fixes
+
+* **privatekey:** fix report range ([#184](https://github.com/secretlint/secretlint/issues/184)) ([f3226ca](https://github.com/secretlint/secretlint/commit/f3226ca5190faad1b41b8690fc294fc824c20bae))
+
+
+### Features
+
+* **preset:** add @secretlint/secretlint-rule-filter-comments to presets ([#198](https://github.com/secretlint/secretlint/issues/198)) ([7f25af3](https://github.com/secretlint/secretlint/commit/7f25af32977bc4726c8d2e796b08ba046e58f2fc))
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-preset-recommend/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-preset-recommend",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "Recommended rule preset of secretlint.",
     "keywords": [
         "secretlint",
@@ -45,15 +45,15 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-aws": "^3.3.0",
-        "@secretlint/secretlint-rule-basicauth": "^3.3.0",
-        "@secretlint/secretlint-rule-gcp": "^3.3.0",
-        "@secretlint/secretlint-rule-github": "^3.3.0",
-        "@secretlint/secretlint-rule-npm": "^3.3.0",
-        "@secretlint/secretlint-rule-privatekey": "^3.3.0",
-        "@secretlint/secretlint-rule-sendgrid": "^3.3.0",
-        "@secretlint/secretlint-rule-slack": "^3.3.0",
-        "@secretlint/secretlint-rule-filter-comments": "^3.3.0"
+        "@secretlint/secretlint-rule-aws": "^4.0.0",
+        "@secretlint/secretlint-rule-basicauth": "^4.0.0",
+        "@secretlint/secretlint-rule-filter-comments": "^4.0.0",
+        "@secretlint/secretlint-rule-gcp": "^4.0.0",
+        "@secretlint/secretlint-rule-github": "^4.0.0",
+        "@secretlint/secretlint-rule-npm": "^4.0.0",
+        "@secretlint/secretlint-rule-privatekey": "^4.0.0",
+        "@secretlint/secretlint-rule-sendgrid": "^4.0.0",
+        "@secretlint/secretlint-rule-slack": "^4.0.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^11.0.2",

--- a/packages/@secretlint/secretlint-rule-privatekey/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-privatekey/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Bug Fixes
+
+* **privatekey:** fix report range ([#184](https://github.com/secretlint/secretlint/issues/184)) ([f3226ca](https://github.com/secretlint/secretlint/commit/f3226ca5190faad1b41b8690fc294fc824c20bae))
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-privatekey",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A secretlint rule for PrivateKey.",
     "keywords": [
         "secretlint",
@@ -47,7 +47,7 @@
     },
     "devDependencies": {
         "@secretlint/secretlint-scripts": "^2.1.1",
-        "@secretlint/tester": "^3.3.0",
+        "@secretlint/tester": "^4.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-secp256k1-privatekey
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-secp256k1-privatekey",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A secretlint rule that checks for secp256k1 private keys.",
     "keywords": [
         "secretlint",
@@ -48,7 +48,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "@types/bn.js": "^5.1.0",
         "@types/secp256k1": "^4.0.3",
         "bn.js": "^5.1.1",

--- a/packages/@secretlint/secretlint-rule-sendgrid/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-sendgrid/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-sendgrid
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-sendgrid/package.json
+++ b/packages/@secretlint/secretlint-rule-sendgrid/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-sendgrid",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A secretlint rule for sendgrid api keys.",
     "keywords": [
         "rule",
@@ -43,11 +43,11 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {
-        "@secretlint/tester": "^3.3.0",
+        "@secretlint/tester": "^4.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-slack/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-slack/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-slack
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/secretlint-rule-slack/package.json
+++ b/packages/@secretlint/secretlint-rule-slack/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/secretlint-rule-slack",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A secretlint rule for slack.",
     "keywords": [
         "rule",
@@ -43,11 +43,11 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "@textlint/regexp-string-matcher": "^1.1.0"
     },
     "devDependencies": {
-        "@secretlint/tester": "^3.3.0",
+        "@secretlint/tester": "^4.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/source-creator/CHANGELOG.md
+++ b/packages/@secretlint/source-creator/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/source-creator
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 **Note:** Version bump only for package @secretlint/source-creator

--- a/packages/@secretlint/source-creator/package.json
+++ b/packages/@secretlint/source-creator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/source-creator",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "Create SecretLintRawSource from content.",
     "keywords": [
         "secretlint",
@@ -42,7 +42,7 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/types": "^3.3.0",
+        "@secretlint/types": "^4.0.0",
         "istextorbinary": "^3.3.0"
     },
     "devDependencies": {

--- a/packages/@secretlint/tester/CHANGELOG.md
+++ b/packages/@secretlint/tester/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Features
+
+* **config-loader:** support a rule written by ESM ([#187](https://github.com/secretlint/secretlint/issues/187)) ([590c333](https://github.com/secretlint/secretlint/commit/590c3339f2f10ffeaf2b6d1084f9a907466d7453))
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/tester/package.json
+++ b/packages/@secretlint/tester/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/tester",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A testing library for secretlint rule",
     "keywords": [
         "secretlint",
@@ -41,10 +41,10 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-loader": "^3.3.0",
-        "@secretlint/core": "^3.3.0",
-        "@secretlint/source-creator": "^3.3.0",
-        "@secretlint/types": "^3.3.0"
+        "@secretlint/config-loader": "^4.0.0",
+        "@secretlint/core": "^4.0.0",
+        "@secretlint/source-creator": "^4.0.0",
+        "@secretlint/types": "^4.0.0"
     },
     "devDependencies": {
         "@types/mocha": "^9.0.0",

--- a/packages/@secretlint/types/CHANGELOG.md
+++ b/packages/@secretlint/types/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+**Note:** Version bump only for package @secretlint/types
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/@secretlint/types/package.json
+++ b/packages/@secretlint/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@secretlint/types",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "A typing package for @secretlint",
     "keywords": [
         "secretlint"

--- a/packages/secretlint/CHANGELOG.md
+++ b/packages/secretlint/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Bug Fixes
+
+* **privatekey:** fix report range ([#184](https://github.com/secretlint/secretlint/issues/184)) ([f3226ca](https://github.com/secretlint/secretlint/commit/f3226ca5190faad1b41b8690fc294fc824c20bae))
+
+
+
+
+
 # [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
 
 

--- a/packages/secretlint/package.json
+++ b/packages/secretlint/package.json
@@ -1,6 +1,6 @@
 {
     "name": "secretlint",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "description": "Secretlint CLI that scan secret/credential data.",
     "keywords": [
         "secretlint",
@@ -45,18 +45,18 @@
         "tabWidth": 4
     },
     "dependencies": {
-        "@secretlint/config-creator": "^3.3.0",
-        "@secretlint/formatter": "^3.3.0",
-        "@secretlint/node": "^3.3.0",
-        "@secretlint/profiler": "^3.1.0",
+        "@secretlint/config-creator": "^4.0.0",
+        "@secretlint/formatter": "^4.0.0",
+        "@secretlint/node": "^4.0.0",
+        "@secretlint/profiler": "^4.0.0",
         "debug": "^4.1.1",
         "globby": "^11.0.0",
         "meow": "^9.0.0",
         "read-pkg": "^5.2.0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^3.3.0",
-        "@secretlint/secretlint-rule-preset-recommend": "^3.3.0",
+        "@secretlint/secretlint-rule-example": "^4.0.0",
+        "@secretlint/secretlint-rule-preset-recommend": "^4.0.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "cross-env": "^7.0.3",


### PR DESCRIPTION
## Features

### ESM rule support #187 

Secretlint allow to load secretlint rule as ESM(ECMAScript modules).
You can write secretlint rule as ESM.

For more details, pleases see document.

- https://github.com/secretlint/secretlint/blob/master/docs/secretlint-rule.md

### Support `secretlint-disable` directive #96 #195 

[@secretlint/secretlint-rule-filter-comments](https://www.npmjs.com/package/@secretlint/secretlint-rule-filter-comments) support disable comment like `secretlint-disable`.

This rule is included in [@secretlint/secretlint-rule-preset-recommend](./packages/@secretlint/secretlint-rule-preset-recommend).

```
// secretlint-disable -- disable all rules

THIS IS SECRET A
THIS IS SECRET B
THIS IS SECRET C

// secretlint-enable -- enable again

// secretlint-disable-next-line @secretlint/secretlint-rule-secret-alphabet -- disable specific rule in next line
THIS IS SECRET D
THIS IS SECRET E // secretlint-disable-line -- disable current line
```

If you want to use this directive in shellscript, you can use `# secretlint-disable`.

```bash
# secretlint-disable-next-line
echo "THIS IS SECRET, BUT IT WILL BE IGNORED"
```

For more details, see <https://github.com/secretlint/secretlint/blob/master/docs/configuration.md>

## Breaking Changes

### use `export cosnt creator` instead of `export default` #190 

Secretlint rule should use named export insteadof default export.
It is caused is thatDynamic Import in CommonJS is broken https://github.com/secretlint/secretlint/issues/190

If you have a secretlint rule, please change following.

```diff
- export default creator;
+ export { creator }
```

### Require Node.js 12 and update `engines` #193

Now, Secretlint requires Node.js 12+
It aims to support ECMAScript modules.

