### PR TITLE
feat(npm): support `npm_` prefix access token

### DIFF
--- a/packages/@secretlint/secretlint-rule-npm/README.md
+++ b/packages/@secretlint/secretlint-rule-npm/README.md
@@ -40,11 +40,21 @@ If you want to use some module as private, please use private registry like npm,
 ### Npmrc_authToken
 > found npmrc authToken: {{TOKEN}}
 
-Disallow to includes `<registry>:_authToken=<TOKEN>` in `.npmrc`.
+Disallow to include `<registry>:_authToken=<TOKEN>` in `.npmrc`.
 
 The `TOKEN` is credential data.
 
 - [npm - Using auth tokens in .npmrc - Stack Overflow](https://stackoverflow.com/questions/53099434/using-auth-tokens-in-npmrc)
+
+### NPM_ACCESS_TOKEN
+> found npm access token: {{TOKEN}}
+
+Disallow to include npm access token.
+
+The `TOKEN` is credential data.
+
+- [About access tokens | npm Docs](https://docs.npmjs.com/about-access-tokens)
+- [Announcing npm’s new access token format | The GitHub Blog](https://github.blog/2021-09-23-announcing-npms-new-access-token-format/)
 
 ## Options
 

--- a/packages/@secretlint/secretlint-rule-npm/test/snapshots/NPM_ACCESS_TOKEN/input.txt
+++ b/packages/@secretlint/secretlint-rule-npm/test/snapshots/NPM_ACCESS_TOKEN/input.txt
@@ -1,0 +1,1 @@
+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

--- a/packages/@secretlint/secretlint-rule-npm/test/snapshots/NPM_ACCESS_TOKEN/output.json
+++ b/packages/@secretlint/secretlint-rule-npm/test/snapshots/NPM_ACCESS_TOKEN/output.json
@@ -1,0 +1,30 @@
+{
+    "filePath": "[SNAPSHOT]/NPM_ACCESS_TOKEN/input.txt",
+    "messages": [
+        {
+            "message": "found npm access token: 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",
+            "range": [
+                0,
+                40
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-npm",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 40
+                }
+            },
+            "severity": "error",
+            "messageId": "NPM_ACCESS_TOKEN",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-npm/README.md#NPM_ACCESS_TOKEN",
+            "data": {
+                "TOKEN": "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"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Support to detect npm access token like `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`.

fix #200 