### PR TITLE
Update node-forge

### DIFF
--- a/packages/@secretlint/secretlint-rule-gcp/package.json
+++ b/packages/@secretlint/secretlint-rule-gcp/package.json
@@ -44,13 +44,13 @@
     "dependencies": {
         "@secretlint/types": "^4.1.3",
         "@textlint/regexp-string-matcher": "^1.1.0",
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.2.1"
     },
     "devDependencies": {
         "@secretlint/tester": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "@types/node-forge": "^0.10.4",
+        "@types/node-forge": "^1.0.0",
         "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,10 +1140,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.0.0.tgz#3205bcd15ada9bc681ac20bef64e9e6df88fd297"
   integrity sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==
 
-"@types/node-forge@^0.10.4":
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-0.10.4.tgz#f30025cc2da0177393b9deaefbf3b9edd55b807b"
-  integrity sha512-RpP7JCxlPA32n8FE0kjOpCsCrsX6VjiD0fjOCo4NwIn8IdcicHi4B2e+votWuOpOmwzUjMwRLqVIF95epGd5nA==
+"@types/node-forge@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-1.0.0.tgz#0b4e9507209485945115a4db4879f39632230593"
+  integrity sha512-h0bgwPKq5u99T9Gor4qtV1lCZ41xNkai0pie1n/a2mh2/4+jENWOlo7AJ4YKxTZAnSZ8FRurUpdIN7ohaPPuHA==
   dependencies:
     "@types/node" "*"
 
@@ -3979,10 +3979,10 @@ node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.2.tgz#986996818b73785e47b1965cc34eb093a1d464d0"
   integrity sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.1.tgz#82794919071ef2eb5c509293325cec8afd0fd53c"
+  integrity sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==
 
 node-gyp-build@^4.2.0:
   version "4.3.0"


### PR DESCRIPTION
I noticed the this package contains this low vulnerability:

```
% npm audit
# npm audit report

node-forge  <1.0.0
Prototype Pollution in node-forge debug API. - https://github.com/advisories/GHSA-5rrq-pxf6-6jx5
fix available via `npm audit fix --force`
Will install @secretlint/secretlint-rule-preset-recommend@0.4.2, which is a breaking change
node_modules/node-forge
  @secretlint/secretlint-rule-gcp  *
  Depends on vulnerable versions of node-forge
  node_modules/@secretlint/secretlint-rule-gcp
    @secretlint/secretlint-rule-preset-recommend  >=0.5.0
    Depends on vulnerable versions of @secretlint/secretlint-rule-gcp
    node_modules/@secretlint/secretlint-rule-preset-recommend
```

So updated the latest version of node-forge.