### PR TITLE
perf: introduce turborepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Turborepo
+.turbo
+
 ### https://raw.github.com/github/gitignore/d2c1bb2b9c72ead618c9f6a48280ebc7a8e0dff6/Node.gitignore
 
 # Logs

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
         "dependsOn": [
           "build"
         ]
+      },
+      "ci": {
+        "dependsOn": ["build", "test", "secretlint"]
       }
     }
   },
@@ -71,7 +74,7 @@
     "updateSnapshot": "UPDATE_SNAPSHOT=1 turbo run test",
     "test": "turbo run test",
     "secretlint": "secretlint \"**/*\"",
-    "ci": "npm run build && npm run test && npm run secretlint",
+    "ci": "turbo run ci",
     "clean": "lerna run clean",
     "prepare": "git config --local core.hooksPath .githooks",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\""

--- a/package.json
+++ b/package.json
@@ -49,9 +49,6 @@
         "dependsOn": [
           "build"
         ]
-      },
-      "ci": {
-        "dependsOn": ["build", "test", "secretlint"]
       }
     }
   },
@@ -74,7 +71,7 @@
     "updateSnapshot": "UPDATE_SNAPSHOT=1 turbo run test",
     "test": "turbo run test",
     "secretlint": "secretlint \"**/*\"",
-    "ci": "turbo run ci",
+    "ci": "turbo run build test secretlint",
     "clean": "lerna run clean",
     "prepare": "git config --local core.hooksPath .githooks",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\""

--- a/package.json
+++ b/package.json
@@ -39,7 +39,17 @@
       },
       "test": {
         "dependsOn": [
-          "build"
+          "build",
+          "$UPDATE_SNAPSHOT"
+        ],
+        "outputs": [
+          "snapshots/**"
+        ]
+      },
+      "updateSnapshot": {
+        "dependsOn": [
+          "build",
+          "$UPDATE_SNAPSHOT"
         ],
         "outputs": [
           "snapshots/**"
@@ -68,7 +78,7 @@
     "release-ci": "yarn run build && lerna publish from-package --yes --no-verify-access",
     "build": "turbo run build",
     "build:withoutrule": "lerna run build --ignore \"@secretlint/*-rule-*\"",
-    "updateSnapshot": "UPDATE_SNAPSHOT=1 turbo run test",
+    "updateSnapshot": "turbo run updateSnapshot",
     "test": "turbo run test",
     "secretlint": "secretlint \"**/*\"",
     "ci": "turbo run build test secretlint",
@@ -80,7 +90,7 @@
     "lerna": "^4.0.0",
     "lint-staged": "^11.0.0",
     "prettier": "^2.3.1",
-    "turbo": "^1.0.28"
+    "turbo": "^1.0.27"
   },
   "prettier": {
     "singleQuote": false,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
       "test": {
         "dependsOn": [
           "build"
+        ],
+        "outputs": [
+          "snapshots/**"
         ]
       },
       "secretlint": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,30 @@
     "packages/@secretlint/*",
     "examples/*"
   ],
+  "turbo": {
+    "baseBranch": "origin/master",
+    "pipeline": {
+      "build": {
+        "dependsOn": [
+          "^build"
+        ],
+        "outputs": [
+          "lib/**",
+          "module/**"
+        ]
+      },
+      "test": {
+        "dependsOn": [
+          "build"
+        ]
+      },
+      "secretlint": {
+        "dependsOn": [
+          "build"
+        ]
+      }
+    }
+  },
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "versionup": "lerna version --no-push --no-git-tag-version --conventional-commits",
@@ -39,10 +63,10 @@
     "commit-version": "git add . && git commit -m \"chore(release): v`node -p 'require(\"./lerna.json\").version'`\"",
     "release": "lerna publish from-package",
     "release-ci": "yarn run build && lerna publish from-package --yes --no-verify-access",
-    "build": "lerna run build",
+    "build": "turbo run build",
     "build:withoutrule": "lerna run build --ignore \"@secretlint/*-rule-*\"",
-    "updateSnapshot": "UPDATE_SNAPSHOT=1 lerna run test",
-    "test": "lerna run test",
+    "updateSnapshot": "UPDATE_SNAPSHOT=1 turbo run test",
+    "test": "turbo run test",
     "secretlint": "secretlint \"**/*\"",
     "ci": "npm run build && npm run test && npm run secretlint",
     "clean": "lerna run clean",
@@ -52,7 +76,8 @@
   "devDependencies": {
     "lerna": "^4.0.0",
     "lint-staged": "^11.0.0",
-    "prettier": "^2.3.1"
+    "prettier": "^2.3.1",
+    "turbo": "^1.0.28"
   },
   "prettier": {
     "singleQuote": false,

--- a/packages/@secretlint/config-creator/package.json
+++ b/packages/@secretlint/config-creator/package.json
@@ -27,7 +27,7 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
@@ -45,7 +45,6 @@
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.3",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/config-loader/package.json
+++ b/packages/@secretlint/config-loader/package.json
@@ -51,7 +51,7 @@
         "try-resolve": "^1.0.1"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-example": "^4.1.3",
+        "@secretlint/secretlint-rule-internal-test-pure-deps": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "cross-env": "^7.0.3",

--- a/packages/@secretlint/config-loader/package.json
+++ b/packages/@secretlint/config-loader/package.json
@@ -30,7 +30,7 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
@@ -54,7 +54,6 @@
         "@secretlint/secretlint-rule-internal-test-pure-deps": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.3",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/config-loader/test/fixtures/valid-config/example-2.js
+++ b/packages/@secretlint/config-loader/test/fixtures/valid-config/example-2.js
@@ -1,1 +1,1 @@
-module.exports = require("@secretlint/secretlint-rule-example");
+module.exports = require("@secretlint/secretlint-rule-internal-test-pure-deps");

--- a/packages/@secretlint/config-loader/test/fixtures/valid-config/example.js
+++ b/packages/@secretlint/config-loader/test/fixtures/valid-config/example.js
@@ -1,1 +1,1 @@
-module.exports = require("@secretlint/secretlint-rule-example");
+module.exports = require("@secretlint/secretlint-rule-internal-test-pure-deps");

--- a/packages/@secretlint/config-loader/test/index.test.ts
+++ b/packages/@secretlint/config-loader/test/index.test.ts
@@ -13,11 +13,11 @@ const removeUndefined = (o: { [index: string]: any }) => {
     }
     return o;
 };
-describe("@secretlint/config-loader", function () {
+describe("@secretlint/config-loader", function() {
     it("should load .secretlintrc.json", async () => {
         const config = await loadConfig({
             cwd: path.join(__dirname, "fixtures/valid-config"),
-            node_moduleDir: path.join(__dirname, "fixtures/valid-config"),
+            node_moduleDir: path.join(__dirname, "fixtures/valid-config")
         });
         assert.deepStrictEqual(
             removeUndefined(config),
@@ -27,23 +27,23 @@ describe("@secretlint/config-loader", function () {
                     rules: [
                         {
                             id: "example",
-                            rule: importSecretlintCreator(require("@secretlint/secretlint-rule-example")),
+                            rule: importSecretlintCreator(require("@secretlint/secretlint-rule-internal-test-pure-deps"))
                         },
                         {
                             id: "example-2",
-                            rule: importSecretlintCreator(require("@secretlint/secretlint-rule-example")),
-                            disabled: true,
-                        },
-                    ],
+                            rule: importSecretlintCreator(require("@secretlint/secretlint-rule-internal-test-pure-deps")),
+                            disabled: true
+                        }
+                    ]
                 },
-                configFilePath: path.join(__dirname, "fixtures/valid-config/.secretlintrc.json"),
+                configFilePath: path.join(__dirname, "fixtures/valid-config/.secretlintrc.json")
             })
         );
     });
     it("should load .secretlintrc.json with ESM rule", async () => {
         const config = await loadConfig({
             cwd: path.join(__dirname, "fixtures/valid-config-esm"),
-            node_moduleDir: path.join(__dirname, "fixtures/valid-config-esm/modules"),
+            node_moduleDir: path.join(__dirname, "fixtures/valid-config-esm/modules")
         });
         const rule = config.config.rules[0] as SecretLintCoreDescriptorUnionRule;
         assert.strictEqual(rule.id, "example");
@@ -53,7 +53,7 @@ describe("@secretlint/config-loader", function () {
     });
     it("should return errors if rule module is not found in .secretlintrc.json", async () => {
         return loadConfig({
-            cwd: path.join(__dirname, "fixtures/missing-rule-config"),
+            cwd: path.join(__dirname, "fixtures/missing-rule-config")
         })
             .then(() => assert.fail("should not be called"))
             .catch((error: unknown) => {
@@ -62,7 +62,7 @@ describe("@secretlint/config-loader", function () {
     });
     it("should return errors if .secretlintrc.json is invalid format", async () => {
         return loadConfig({
-            cwd: path.join(__dirname, "fixtures/invalid-config"),
+            cwd: path.join(__dirname, "fixtures/invalid-config")
         })
             .then(() => assert.fail("should not be called"))
             .catch((error: Error) => {

--- a/packages/@secretlint/config-validator/package.json
+++ b/packages/@secretlint/config-validator/package.json
@@ -28,10 +28,10 @@
         "src/"
     ],
     "scripts": {
-        "create-validation": "ts-node src/create-validation.ts",
         "prebuild": "npm run create-validation",
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
+        "create-validation": "ts-node src/create-validation.ts",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
         "pretest": "npm run create-validation",
@@ -51,7 +51,6 @@
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.3",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/core/package.json
+++ b/packages/@secretlint/core/package.json
@@ -27,7 +27,7 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
@@ -50,7 +50,6 @@
         "@types/node": "^16.9.1",
         "@types/structured-source": "^3.0.0",
         "assert-json-equal": "^1.0.1",
-        "cross-env": "^7.0.3",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/formatter/package.json
+++ b/packages/@secretlint/formatter/package.json
@@ -24,7 +24,7 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
@@ -53,7 +53,6 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "@types/pluralize": "0.0.29",
-        "cross-env": "^7.0.3",
         "escape-string-regexp": "^2.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",

--- a/packages/@secretlint/messages-to-markdown/package.json
+++ b/packages/@secretlint/messages-to-markdown/package.json
@@ -30,7 +30,7 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
@@ -49,7 +49,6 @@
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.3",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/node/package.json
+++ b/packages/@secretlint/node/package.json
@@ -28,7 +28,7 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
@@ -53,7 +53,6 @@
         "@secretlint/secretlint-rule-example": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.3",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/profiler/package.json
+++ b/packages/@secretlint/profiler/package.json
@@ -28,7 +28,7 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
@@ -43,7 +43,6 @@
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.3",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/quick-start/package.json
+++ b/packages/@secretlint/quick-start/package.json
@@ -33,7 +33,7 @@
         "config/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
@@ -52,7 +52,6 @@
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.3",
         "expected-exit-status": "^1.0.2",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",

--- a/packages/@secretlint/secretlint-rule-aws/package.json
+++ b/packages/@secretlint/secretlint-rule-aws/package.json
@@ -29,12 +29,12 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -51,7 +51,6 @@
         "@secretlint/tester": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.3",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-basicauth/package.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/package.json
@@ -29,12 +29,12 @@
     "src/"
   ],
   "scripts": {
-    "build": "cross-env NODE_ENV=production tsc -p .",
+    "build": "tsc -p .",
     "clean": "rimraf lib/",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
     "prepublish": "npm run --if-present build",
-    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
     "test": "mocha \"test/**/*.ts\"",
+    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
     "watch": "tsc -p . --watch"
   },
   "prettier": {
@@ -50,7 +50,6 @@
     "@secretlint/tester": "^4.1.3",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.9.1",
-    "cross-env": "^7.0.3",
     "mocha": "^9.0.1",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-basicauth/package.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/package.json
@@ -1,66 +1,67 @@
 {
-    "name": "@secretlint/secretlint-rule-basicauth",
-    "version": "4.1.3",
-    "description": "A secretlint rule that check Basic Authentication.",
-    "keywords": [
-        "secretlint",
-        "rule",
-        "url"
-    ],
-    "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-basicauth/",
-    "bugs": {
-        "url": "https://github.com/secretlint/secretlint/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/secretlint/secretlint.git"
-    },
-    "license": "MIT",
-    "author": "azu",
-    "main": "lib/index.js",
-    "types": "lib/index.d.ts",
-    "directories": {
-        "lib": "lib",
-        "test": "test"
-    },
-    "files": [
-        "bin/",
-        "lib/",
-        "src/"
-    ],
-    "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
-        "clean": "rimraf lib/",
-        "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
-        "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
-        "test": "mocha \"test/**/*.ts\"",
-        "watch": "tsc -p . --watch"
-    },
-    "prettier": {
-        "printWidth": 120,
-        "singleQuote": false,
-        "tabWidth": 4
-    },
-    "dependencies": {
-        "@secretlint/types": "^4.1.3",
-        "@textlint/regexp-string-matcher": "^1.1.0"
-    },
-    "devDependencies": {
-        "@types/mocha": "^9.0.0",
-        "@types/node": "^16.9.1",
-        "cross-env": "^7.0.3",
-        "mocha": "^9.0.1",
-        "prettier": "^2.3.1",
-        "rimraf": "^3.0.2",
-        "ts-node": "^10.0.0",
-        "ts-node-test-register": "^10.0.0",
-        "typescript": "^4.3.4"
-    },
-    "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@secretlint/secretlint-rule-basicauth",
+  "version": "4.1.3",
+  "description": "A secretlint rule that check Basic Authentication.",
+  "keywords": [
+    "secretlint",
+    "rule",
+    "url"
+  ],
+  "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-basicauth/",
+  "bugs": {
+    "url": "https://github.com/secretlint/secretlint/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/secretlint/secretlint.git"
+  },
+  "license": "MIT",
+  "author": "azu",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "src/"
+  ],
+  "scripts": {
+    "build": "cross-env NODE_ENV=production tsc -p .",
+    "clean": "rimraf lib/",
+    "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+    "prepublish": "npm run --if-present build",
+    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
+    "test": "mocha \"test/**/*.ts\"",
+    "watch": "tsc -p . --watch"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": false,
+    "tabWidth": 4
+  },
+  "dependencies": {
+    "@secretlint/types": "^4.1.3",
+    "@textlint/regexp-string-matcher": "^1.1.0"
+  },
+  "devDependencies": {
+    "@secretlint/tester": "^4.1.3",
+    "@types/mocha": "^9.0.0",
+    "@types/node": "^16.9.1",
+    "cross-env": "^7.0.3",
+    "mocha": "^9.0.1",
+    "prettier": "^2.3.1",
+    "rimraf": "^3.0.2",
+    "ts-node": "^10.0.0",
+    "ts-node-test-register": "^10.0.0",
+    "typescript": "^4.3.4"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/@secretlint/secretlint-rule-example/package.json
+++ b/packages/@secretlint/secretlint-rule-example/package.json
@@ -46,6 +46,7 @@
         "@secretlint/types": "^4.1.3"
     },
     "devDependencies": {
+        "@secretlint/tester": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "cross-env": "^7.0.3",

--- a/packages/@secretlint/secretlint-rule-example/package.json
+++ b/packages/@secretlint/secretlint-rule-example/package.json
@@ -29,12 +29,12 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -49,7 +49,6 @@
         "@secretlint/tester": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.3",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-filter-comments/package.json
+++ b/packages/@secretlint/secretlint-rule-filter-comments/package.json
@@ -33,19 +33,24 @@
     "src/"
   ],
   "scripts": {
+    "build": "tsc -p .",
+    "clean": "rimraf lib/ module/",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+    "prepublishOnly": "npm run clean && npm run build",
     "test": "mocha \"test/**/*.ts\"",
     "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
-    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
-    "build": "tsc -p .",
-    "watch": "tsc -p . --watch",
-    "clean": "rimraf lib/ module/",
-    "prepublishOnly": "npm run clean && npm run build"
+    "watch": "tsc -p . --watch"
   },
   "prettier": {
     "printWidth": 120,
     "singleQuote": false,
     "tabWidth": 4,
     "trailingComma": "none"
+  },
+  "dependencies": {
+    "@secretlint/types": "^4.1.3",
+    "lint-staged": "^11.0.0",
+    "prettier": "^2.3.1"
   },
   "devDependencies": {
     "@secretlint/secretlint-rule-pattern": "^4.1.3",
@@ -58,15 +63,10 @@
     "ts-node-test-register": "^10.0.0",
     "typescript": "^4.4.3"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
-  "dependencies": {
-    "@secretlint/types": "^4.1.3",
-    "lint-staged": "^11.0.0",
-    "prettier": "^2.3.1"
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/@secretlint/secretlint-rule-gcp/package.json
+++ b/packages/@secretlint/secretlint-rule-gcp/package.json
@@ -28,12 +28,12 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -51,7 +51,6 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "@types/node-forge": "^1.0.0",
-        "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-github/package.json
+++ b/packages/@secretlint/secretlint-rule-github/package.json
@@ -29,12 +29,12 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -50,7 +50,6 @@
         "@secretlint/tester": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-internal-test-pure-deps/CHANGELOG.md
+++ b/packages/@secretlint/secretlint-rule-internal-test-pure-deps/CHANGELOG.md
@@ -1,0 +1,214 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [4.1.3](https://github.com/secretlint/secretlint/compare/v4.1.1...v4.1.3) (2021-10-13)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+# [4.0.0](https://github.com/secretlint/secretlint/compare/v3.3.0...v4.0.0) (2021-09-15)
+
+
+### Features
+
+* **secretlint-rule-filter-comments:** secretlint-disable/secretlint-enable comment ([#195](https://github.com/secretlint/secretlint/issues/195)) ([607f361](https://github.com/secretlint/secretlint/commit/607f361bebf75f532ac1966c6939ed5955f3c669))
+
+
+
+
+
+# [3.3.0](https://github.com/secretlint/secretlint/compare/v3.2.0...v3.3.0) (2021-07-05)
+
+
+### Features
+
+* **core:** add `maskSecrets` option ([#177](https://github.com/secretlint/secretlint/issues/177)) ([658db4b](https://github.com/secretlint/secretlint/commit/658db4b1f0526006bec0448f9cba9a02bc8edd4a))
+
+
+
+
+
+# [3.1.0](https://github.com/secretlint/secretlint/compare/v3.0.0...v3.1.0) (2021-06-24)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+# [3.0.0](https://github.com/secretlint/secretlint/compare/v2.2.0...v3.0.0) (2021-05-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+# [2.2.0](https://github.com/secretlint/secretlint/compare/v2.1.1...v2.2.0) (2021-05-27)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+## [2.1.1](https://github.com/secretlint/secretlint/compare/v2.1.0...v2.1.1) (2020-11-04)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+# [2.1.0](https://github.com/secretlint/secretlint/compare/v2.0.0...v2.1.0) (2020-06-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+# [2.0.0](https://github.com/secretlint/secretlint/compare/v1.1.0...v2.0.0) (2020-04-27)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+# [1.1.0](https://github.com/secretlint/secretlint/compare/v1.0.5...v1.1.0) (2020-04-04)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+## [1.0.5](https://github.com/secretlint/secretlint/compare/v1.0.4...v1.0.5) (2020-04-03)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+## [1.0.4](https://github.com/secretlint/secretlint/compare/v1.0.3...v1.0.4) (2020-03-31)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+## [1.0.3](https://github.com/secretlint/secretlint/compare/v1.0.2...v1.0.3) (2020-03-30)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+## [1.0.1](https://github.com/secretlint/secretlint/compare/v1.0.0...v1.0.1) (2020-03-29)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+# [1.0.0](https://github.com/secretlint/secretlint/compare/v0.10.1...v1.0.0) (2020-03-18)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+## [0.10.1](https://github.com/secretlint/secretlint/compare/v0.10.0...v0.10.1) (2020-03-18)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+# [0.10.0](https://github.com/secretlint/secretlint/compare/v0.9.2...v0.10.0) (2020-03-18)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+## [0.9.2](https://github.com/secretlint/secretlint/compare/v0.9.1...v0.9.2) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+## [0.9.1](https://github.com/secretlint/secretlint/compare/v0.9.0...v0.9.1) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+# [0.9.0](https://github.com/secretlint/secretlint/compare/v0.7.3...v0.9.0) (2020-03-16)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+
+
+
+
+# [0.7.0](https://github.com/secretlint/secretlint/compare/v0.6.0...v0.7.0) (2020-03-01)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+# [0.6.0](https://github.com/secretlint/secretlint/compare/v0.5.0...v0.6.0) (2020-02-29)
+
+### Features
+
+-   support terminalLink ([#65](https://github.com/secretlint/secretlint/issues/65)) ([a28ef9e](https://github.com/secretlint/secretlint/commit/a28ef9eb9b3803984ec37bbbd9cdf35e7d4b67a6))
+
+# [0.5.0](https://github.com/secretlint/secretlint/compare/v0.4.2...v0.5.0) (2020-02-28)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+## [0.4.1](https://github.com/secretlint/secretlint/compare/v0.4.0...v0.4.1) (2020-02-28)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+# [0.4.0](https://github.com/secretlint/secretlint/compare/v0.3.0...v0.4.0) (2020-02-28)
+
+### Features
+
+-   **core:** support "disabledMessages" options ([17de33e](https://github.com/secretlint/secretlint/commit/17de33eaef2408c63cbaeecb4038c8878a292ca0))
+-   **types:** rule require `messages` ([412803e](https://github.com/secretlint/secretlint/commit/412803eeebe7f14ce67f1c33c2ba16eac2acf9a5))
+
+# [0.3.0](https://github.com/secretlint/secretlint/compare/v0.2.0...v0.3.0) (2020-02-27)
+
+**Note:** Version bump only for package @secretlint/secretlint-rule-example
+
+# [0.2.0](https://github.com/secretlint/secretlint/compare/v0.1.2...v0.2.0) (2020-02-23)
+
+### Features
+
+-   **rule:** add `supportedContentTypes` to rule `meta` ([#39](https://github.com/secretlint/secretlint/issues/39)) ([3883c75](https://github.com/secretlint/secretlint/commit/3883c7578de38854aba2d1d20b8f167c8275f1c9))
+
+# 0.1.0 (2020-02-16)
+
+### Features
+
+-   **core:** support Localization ([845f24a](https://github.com/secretlint/secretlint/commit/845f24a2a5ba1af39a3da8c2b5d487f3f4e6c313))
+-   **secretlint-rule-preset-recommend:** implement secretlint-rule-preset-recommend ([2728140](https://github.com/secretlint/secretlint/commit/27281404717565a6bcea4749bb047cf0d6b777ed))
+-   **tester:** support .secretlintrc options via file ([c137c00](https://github.com/secretlint/secretlint/commit/c137c00829d6ee903d0e81894e0d343fff94f089))
+-   preset ([868ac0f](https://github.com/secretlint/secretlint/commit/868ac0f2526217e04a774a48c26d90a89937cee2))

--- a/packages/@secretlint/secretlint-rule-internal-test-pure-deps/LICENSE
+++ b/packages/@secretlint/secretlint-rule-internal-test-pure-deps/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@secretlint/secretlint-rule-internal-test-pure-deps/README.md
+++ b/packages/@secretlint/secretlint-rule-internal-test-pure-deps/README.md
@@ -1,0 +1,49 @@
+# @secretlint/secretlint-rule-internal-test-pure-deps
+
+Internal Example Package.
+
+- Pure Deps
+  - Prevent Dependency cycles
+- ALWAYS MATCH "SECRET" string.
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install @secretlint/secretlint-rule-internal-test-pure-deps
+
+## MessageIDs
+
+### EXAMPLE_MESSAGE
+> found secret: {{ID}}
+
+An example error message.
+
+## Changelog
+
+See [Releases page](https://github.com/secretlint/secretlint/releases).
+
+## Running tests
+
+No Test to avoid Dependency cycles.
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/secretlint/secretlint/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## Author
+
+- [github/azu](https://github.com/azu)
+- [twitter/azu_re](https://twitter.com/azu_re)
+
+## License
+
+MIT © azu

--- a/packages/@secretlint/secretlint-rule-internal-test-pure-deps/package.json
+++ b/packages/@secretlint/secretlint-rule-internal-test-pure-deps/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@secretlint/secretlint-rule-internal-test-pure-deps",
+  "version": "4.1.3",
+  "description": "An example rule for secretlint. It it for testing.",
+  "keywords": [
+    "secretlint",
+    "testing",
+    "rule"
+  ],
+  "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-internal-test-pure-deps/",
+  "bugs": {
+    "url": "https://github.com/secretlint/secretlint/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/secretlint/secretlint.git"
+  },
+  "license": "MIT",
+  "author": "azu",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "src/"
+  ],
+  "scripts": {
+    "build": "tsc -p .",
+    "clean": "rimraf lib/",
+    "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+    "prepublish": "npm run --if-present build",
+    "watch": "tsc -p . --watch"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": false,
+    "tabWidth": 4
+  },
+  "dependencies": {
+    "@secretlint/types": "^4.1.3"
+  },
+  "devDependencies": {
+    "typescript": "^4.3.4"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@secretlint/secretlint-rule-internal-test-pure-deps/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-internal-test-pure-deps/src/index.ts
@@ -1,11 +1,13 @@
+import { SecretLintRuleCreator, SecretLintSourceCode } from "@secretlint/types";
+
 export const messages = {
     EXAMPLE_MESSAGE: {
-        en: (props) => `found secret: ${props.ID}`,
-        ja: (props) => `secret: ${props.ID} がみつかりました`
-    }
+        en: (props: { ID: string }) => `found secret: ${props.ID}`,
+        ja: (props: { ID: string }) => `secret: ${props.ID} がみつかりました`,
+    },
 };
 
-export const creator = {
+export const creator: SecretLintRuleCreator = {
     messages,
     meta: {
         id: "@secretlint/secretlint-rule-internal-test-pure-deps",
@@ -13,14 +15,14 @@ export const creator = {
         type: "scanner",
         supportedContentTypes: ["text"],
         docs: {
-            url: "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-internal-test-pure-deps/README.md"
-        }
+            url: "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-internal-example-pure-deps/README.md",
+        },
     },
     create(context) {
         const t = context.createTranslator(messages);
         return {
-            file(source) {
-                const pattern = /secret/gi;
+            file(source: SecretLintSourceCode) {
+                const pattern = /SECRET/g;
                 let match;
                 while ((match = pattern.exec(source.content)) !== null) {
                     const index = match.index || 0;
@@ -28,12 +30,12 @@ export const creator = {
                     const range = [index, index + matchString.length];
                     context.report({
                         message: t("EXAMPLE_MESSAGE", {
-                            ID: matchString
+                            ID: matchString,
                         }),
-                        range
+                        range,
                     });
                 }
-            }
+            },
         };
-    }
+    },
 };

--- a/packages/@secretlint/secretlint-rule-internal-test-pure-deps/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-internal-test-pure-deps/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "newLine": "LF",
+    "outDir": "./lib/",
+    "target": "ES2018",
+    "sourceMap": true,
+    "declaration": true,
+    "jsx": "preserve",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    /* Strict Type-Checking Options */
+    "strict": true,
+    /* Additional Checks */
+    /* Report errors on unused locals. */
+    "noUnusedLocals": true,
+    /* Report errors on unused parameters. */
+    "noUnusedParameters": true,
+    /* Report error when not all code paths in function return a value. */
+    "noImplicitReturns": true,
+    /* Report errors for fallthrough cases in switch statement. */
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    ".git",
+    "node_modules"
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-no-dotenv/package.json
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/package.json
@@ -1,68 +1,69 @@
 {
-    "name": "@secretlint/secretlint-rule-no-dotenv",
-    "version": "4.1.3",
-    "description": "A secretlint rule for dotenv",
-    "keywords": [
-        "secretlint",
-        "rule",
-        "dotenv"
-    ],
-    "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-no-dotenv/",
-    "bugs": {
-        "url": "https://github.com/secretlint/secretlint/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/secretlint/secretlint.git"
-    },
-    "license": "MIT",
-    "author": {
-        "name": "Munieru",
-        "url": "https://github.com/munierujp"
-    },
-    "main": "lib/index.js",
-    "types": "lib/index.d.ts",
-    "directories": {
-        "lib": "lib",
-        "test": "test"
-    },
-    "files": [
-        "bin/",
-        "lib/",
-        "src/"
-    ],
-    "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
-        "clean": "rimraf lib/",
-        "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
-        "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
-        "test": "mocha \"test/**/*.ts\"",
-        "watch": "tsc -p . --watch"
-    },
-    "prettier": {
-        "printWidth": 120,
-        "singleQuote": false,
-        "tabWidth": 4
-    },
-    "dependencies": {
-        "@secretlint/types": "^4.1.3"
-    },
-    "devDependencies": {
-        "@types/mocha": "^9.0.0",
-        "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
-        "mocha": "^9.0.1",
-        "prettier": "^2.3.1",
-        "rimraf": "^3.0.2",
-        "ts-node": "^10.0.0",
-        "ts-node-test-register": "^10.0.0",
-        "typescript": "^4.3.4"
-    },
-    "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@secretlint/secretlint-rule-no-dotenv",
+  "version": "4.1.3",
+  "description": "A secretlint rule for dotenv",
+  "keywords": [
+    "secretlint",
+    "rule",
+    "dotenv"
+  ],
+  "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-no-dotenv/",
+  "bugs": {
+    "url": "https://github.com/secretlint/secretlint/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/secretlint/secretlint.git"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Munieru",
+    "url": "https://github.com/munierujp"
+  },
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "src/"
+  ],
+  "scripts": {
+    "build": "cross-env NODE_ENV=production tsc -p .",
+    "clean": "rimraf lib/",
+    "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+    "prepublish": "npm run --if-present build",
+    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
+    "test": "mocha \"test/**/*.ts\"",
+    "watch": "tsc -p . --watch"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": false,
+    "tabWidth": 4
+  },
+  "dependencies": {
+    "@secretlint/types": "^4.1.3"
+  },
+  "devDependencies": {
+    "@secretlint/tester": "^4.1.3",
+    "@types/mocha": "^9.0.0",
+    "@types/node": "^16.9.1",
+    "cross-env": "^7.0.0",
+    "mocha": "^9.0.1",
+    "prettier": "^2.3.1",
+    "rimraf": "^3.0.2",
+    "ts-node": "^10.0.0",
+    "ts-node-test-register": "^10.0.0",
+    "typescript": "^4.3.4"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/@secretlint/secretlint-rule-no-dotenv/package.json
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/package.json
@@ -32,12 +32,12 @@
     "src/"
   ],
   "scripts": {
-    "build": "cross-env NODE_ENV=production tsc -p .",
+    "build": "tsc -p .",
     "clean": "rimraf lib/",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
     "prepublish": "npm run --if-present build",
-    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
     "test": "mocha \"test/**/*.ts\"",
+    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
     "watch": "tsc -p . --watch"
   },
   "prettier": {
@@ -52,7 +52,6 @@
     "@secretlint/tester": "^4.1.3",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.9.1",
-    "cross-env": "^7.0.0",
     "mocha": "^9.0.1",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-no-homedir/package.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/package.json
@@ -46,6 +46,7 @@
     "escape-string-regexp": "^4.0.0"
   },
   "devDependencies": {
+    "@secretlint/tester": "^4.1.3",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.9.1",
     "cross-env": "^7.0.2",

--- a/packages/@secretlint/secretlint-rule-no-homedir/package.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/package.json
@@ -28,7 +28,7 @@
     "src/"
   ],
   "scripts": {
-    "build": "cross-env NODE_ENV=production tsc -p .",
+    "build": "tsc -p .",
     "clean": "rimraf lib/",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
     "prepublish": "npm run --if-present build",
@@ -49,7 +49,6 @@
     "@secretlint/tester": "^4.1.3",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.9.1",
-    "cross-env": "^7.0.2",
     "mocha": "^9.0.1",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
@@ -28,12 +28,12 @@
     "src/"
   ],
   "scripts": {
-    "build": "cross-env NODE_ENV=production tsc -p .",
+    "build": "tsc -p .",
     "clean": "rimraf lib/",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
     "prepublish": "npm run --if-present build",
-    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
     "test": "mocha \"test/**/*.ts\"",
+    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
     "watch": "tsc -p . --watch"
   },
   "prettier": {
@@ -50,7 +50,6 @@
     "@types/js-yaml": "^4.0.3",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.9.1",
-    "cross-env": "^7.0.2",
     "mocha": "^9.0.1",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
@@ -46,6 +46,7 @@
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
+    "@secretlint/tester": "^4.1.3",
     "@types/js-yaml": "^4.0.3",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.9.1",

--- a/packages/@secretlint/secretlint-rule-npm/package.json
+++ b/packages/@secretlint/secretlint-rule-npm/package.json
@@ -29,12 +29,12 @@
     "src/"
   ],
   "scripts": {
-    "build": "cross-env NODE_ENV=production tsc -p .",
+    "build": "tsc -p .",
     "clean": "rimraf lib/",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
     "prepublish": "npm run --if-present build",
-    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
     "test": "mocha \"test/**/*.ts\"",
+    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
     "watch": "tsc -p . --watch"
   },
   "prettier": {
@@ -50,7 +50,6 @@
     "@secretlint/tester": "^4.1.3",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.9.1",
-    "cross-env": "^7.0.0",
     "mocha": "^9.0.1",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-npm/package.json
+++ b/packages/@secretlint/secretlint-rule-npm/package.json
@@ -1,66 +1,67 @@
 {
-    "name": "@secretlint/secretlint-rule-npm",
-    "version": "4.1.3",
-    "description": "A secretlint rule for npm.",
-    "keywords": [
-        "npm",
-        "secretlint",
-        "rule"
-    ],
-    "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-npm/",
-    "bugs": {
-        "url": "https://github.com/secretlint/secretlint/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/secretlint/secretlint.git"
-    },
-    "license": "MIT",
-    "author": "azu",
-    "main": "lib/index.js",
-    "types": "lib/index.d.ts",
-    "directories": {
-        "lib": "lib",
-        "test": "test"
-    },
-    "files": [
-        "bin/",
-        "lib/",
-        "src/"
-    ],
-    "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
-        "clean": "rimraf lib/",
-        "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
-        "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
-        "test": "mocha \"test/**/*.ts\"",
-        "watch": "tsc -p . --watch"
-    },
-    "prettier": {
-        "printWidth": 120,
-        "singleQuote": false,
-        "tabWidth": 4
-    },
-    "dependencies": {
-        "@secretlint/types": "^4.1.3",
-        "@textlint/regexp-string-matcher": "^1.1.0"
-    },
-    "devDependencies": {
-        "@types/mocha": "^9.0.0",
-        "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
-        "mocha": "^9.0.1",
-        "prettier": "^2.3.1",
-        "rimraf": "^3.0.2",
-        "ts-node": "^10.0.0",
-        "ts-node-test-register": "^10.0.0",
-        "typescript": "^4.3.4"
-    },
-    "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@secretlint/secretlint-rule-npm",
+  "version": "4.1.3",
+  "description": "A secretlint rule for npm.",
+  "keywords": [
+    "npm",
+    "secretlint",
+    "rule"
+  ],
+  "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-npm/",
+  "bugs": {
+    "url": "https://github.com/secretlint/secretlint/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/secretlint/secretlint.git"
+  },
+  "license": "MIT",
+  "author": "azu",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "src/"
+  ],
+  "scripts": {
+    "build": "cross-env NODE_ENV=production tsc -p .",
+    "clean": "rimraf lib/",
+    "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+    "prepublish": "npm run --if-present build",
+    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
+    "test": "mocha \"test/**/*.ts\"",
+    "watch": "tsc -p . --watch"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": false,
+    "tabWidth": 4
+  },
+  "dependencies": {
+    "@secretlint/types": "^4.1.3",
+    "@textlint/regexp-string-matcher": "^1.1.0"
+  },
+  "devDependencies": {
+    "@secretlint/tester": "^4.1.3",
+    "@types/mocha": "^9.0.0",
+    "@types/node": "^16.9.1",
+    "cross-env": "^7.0.0",
+    "mocha": "^9.0.1",
+    "prettier": "^2.3.1",
+    "rimraf": "^3.0.2",
+    "ts-node": "^10.0.0",
+    "ts-node-test-register": "^10.0.0",
+    "typescript": "^4.3.4"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/@secretlint/secretlint-rule-pattern/package.json
+++ b/packages/@secretlint/secretlint-rule-pattern/package.json
@@ -29,12 +29,12 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -50,7 +50,6 @@
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -55,6 +55,7 @@
     "@secretlint/secretlint-rule-slack": "^4.1.3"
   },
   "devDependencies": {
+    "@secretlint/tester": "^4.1.3",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-json": "^4.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",

--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -34,8 +34,8 @@
     "clean": "rimraf lib/",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
     "prepublish": "npm run --if-present build",
-    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
     "test": "mocha \"test/**/*.ts\"",
+    "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
     "watch": "tsc -p . --watch"
   },
   "prettier": {
@@ -55,14 +55,13 @@
     "@secretlint/secretlint-rule-slack": "^4.1.3"
   },
   "devDependencies": {
-    "@secretlint/tester": "^4.1.3",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-json": "^4.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-typescript": "^4.0.0",
+    "@secretlint/tester": "^4.1.3",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.9.1",
-    "cross-env": "^7.0.0",
     "mocha": "^9.0.1",
     "prettier": "^2.3.1",
     "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-preset-recommend/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/package.json
@@ -56,6 +56,7 @@
         "@secretlint/secretlint-rule-slack": "^4.1.3"
     },
     "devDependencies": {
+        "@secretlint/tester": "^4.1.3",
         "@rollup/plugin-commonjs": "^11.0.2",
         "@rollup/plugin-node-resolve": "^7.1.1",
         "@rollup/plugin-typescript": "^4.0.0",

--- a/packages/@secretlint/secretlint-rule-preset-recommend/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/package.json
@@ -29,14 +29,14 @@
         "src/"
     ],
     "scripts": {
-        "cp-canary": "cp ../secretlint-rule-preset-canary/src/index.ts src/ && cp -r ../secretlint-rule-preset-canary/test/ test && npm run updateSnapshot",
         "build": "rollup --config",
         "build:tsc": "tsc -p .",
         "clean": "rimraf lib/",
+        "cp-canary": "cp ../secretlint-rule-preset-canary/src/index.ts src/ && cp -r ../secretlint-rule-preset-canary/test/ test && npm run updateSnapshot",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -56,13 +56,12 @@
         "@secretlint/secretlint-rule-slack": "^4.1.3"
     },
     "devDependencies": {
-        "@secretlint/tester": "^4.1.3",
         "@rollup/plugin-commonjs": "^11.0.2",
         "@rollup/plugin-node-resolve": "^7.1.1",
         "@rollup/plugin-typescript": "^4.0.0",
+        "@secretlint/tester": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/package.json
@@ -29,12 +29,12 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -50,7 +50,6 @@
         "@secretlint/tester": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
@@ -55,6 +55,7 @@
         "secp256k1": "^4.0.0"
     },
     "devDependencies": {
+        "@secretlint/tester": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
         "cross-env": "^7.0.0",

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
@@ -34,12 +34,12 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -58,7 +58,6 @@
         "@secretlint/tester": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-sendgrid/package.json
+++ b/packages/@secretlint/secretlint-rule-sendgrid/package.json
@@ -29,12 +29,12 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -50,7 +50,6 @@
         "@secretlint/tester": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/secretlint-rule-slack/package.json
+++ b/packages/@secretlint/secretlint-rule-slack/package.json
@@ -29,12 +29,12 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -50,7 +50,6 @@
         "@secretlint/tester": "^4.1.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/source-creator/package.json
+++ b/packages/@secretlint/source-creator/package.json
@@ -28,12 +28,12 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -49,7 +49,6 @@
         "@types/istextorbinary": "2.3.1",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/tester/package.json
+++ b/packages/@secretlint/tester/package.json
@@ -28,7 +28,7 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
@@ -49,7 +49,6 @@
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/@secretlint/types/package.json
+++ b/packages/@secretlint/types/package.json
@@ -27,7 +27,7 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
@@ -42,7 +42,6 @@
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.0",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/packages/secretlint/package.json
+++ b/packages/secretlint/package.json
@@ -31,12 +31,12 @@
         "src/"
     ],
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "test": "mocha \"test/**/*.ts\"",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
         "watch": "tsc -p . --watch"
     },
     "prettier": {
@@ -59,7 +59,6 @@
         "@secretlint/secretlint-rule-preset-recommend": "^4.1.4",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.9.1",
-        "cross-env": "^7.0.3",
         "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "rimraf": "^3.0.2",

--- a/publish/binary-compiler/package.json
+++ b/publish/binary-compiler/package.json
@@ -30,7 +30,7 @@
         "test": "test"
     },
     "scripts": {
-        "build": "cross-env NODE_ENV=production tsc -p .",
+        "build": "tsc -p .",
         "dist": "npm run build && node lib/build.js",
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
@@ -46,7 +46,6 @@
     "devDependencies": {
         "@types/mocha": "^7.0.1",
         "@types/node": "^13.7.4",
-        "cross-env": "^7.0.0",
         "mocha": "^7.0.1",
         "prettier": "^1.19.1",
         "rimraf": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5680,7 +5680,7 @@ turbo-windows-64@1.0.28:
   resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.0.28.tgz#7a2ad6f8416f04f20a1445c8b7123b80c6b16583"
   integrity sha512-nT7bgcdl/9QNGBiwCYwTQ2VszcsqJ4NqT4YkE954KFZYxgSwMjjVTdoXcsnXMHpWiMiYfFF7HZLecUNnDm1uUA==
 
-turbo@^1.0.28:
+turbo@^1.0.27:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.0.28.tgz#fb33cecd2d025e3140ddbcc8c274f0ed7328f09d"
   integrity sha512-5xmyVabNYqA0sCAU4VLdUS2A6GwIyy8FTszB/Fx4eNHwHudQwo00F2qORcDFwBHE4MqtnRoBFhL3ZJzo8c9A2w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5620,6 +5620,84 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turbo-darwin-64@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.0.28.tgz#662392368698c4e698b31871f0953836872f7b0e"
+  integrity sha512-uvARrncW6HNTFi7PFe4sq4JqSOKs1vPgWjJjOEyVhsCFwBgYkXxYsJSdDfO8OhvJa3wv+eYFAK5RaUCk80Z8eg==
+
+turbo-darwin-arm64@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.0.28.tgz#3ba1a6f9a960321391b8cf809ed8fab0276a499d"
+  integrity sha512-d/ANU+RIq4Fx/MphkqFThvwOpb+NYDuR+07aV5w8cwI7ljw7hPAe3EW3CSlkPJhvjs6P/oh+F86jhh1Q581mVA==
+
+turbo-freebsd-64@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-64/-/turbo-freebsd-64-1.0.28.tgz#f94e39dc455573c0a42f96f1a84649b252bf0571"
+  integrity sha512-JMJWftuWhJan+Momc39vbbwaLYEcMpYyBxIrumyIrIkQVaiSKs/6oEFzh1YA+KE16kAgzTPJPXFDkmsY3idAQg==
+
+turbo-freebsd-arm64@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-arm64/-/turbo-freebsd-arm64-1.0.28.tgz#5551f5c67a82a16ce1ba3193410764bae0849d1a"
+  integrity sha512-fGJNE8qJUhosaIK5sGBheeve9y074FLWv8KfYuXMyV/6+dxpNV60HoAFvw8tL3q8TNp47pU6x8e8h+u1/rn1wQ==
+
+turbo-linux-32@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-linux-32/-/turbo-linux-32-1.0.28.tgz#742340e6ca7d77c4fb884159bbc8c7faa8d61026"
+  integrity sha512-fE0qIExxYuVFo5WlVWY0DJ1YZ/w+EC9RheT9nc1tU2EK83XPE1CZFW4lFIsWsXnIy9337zUeNDFVoVxOxCBSUQ==
+
+turbo-linux-64@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.0.28.tgz#167acbd2899c0da9252f755ae74d619aaf99efe6"
+  integrity sha512-e+f/O1MlcKCMhJf10q1x+1KSImHwuFUW2+A6DbLk+ekBUW5RELC2qF7hGypCzcpm8xIqtj5A0kP3blFy60AMxw==
+
+turbo-linux-arm64@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.0.28.tgz#785415e2a04125a69c7b1d45073150dbab3985f6"
+  integrity sha512-zN0nQClxp4nP4edinbdTd/9CpPjgNPsULc8LgunuJD+B9A0NRcRP5NCDo8/6ctTWs456sE3UhUF3t2b+uEgDzw==
+
+turbo-linux-arm@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm/-/turbo-linux-arm-1.0.28.tgz#f6de485aa732ba14cc1c851ba30b0f0a901507f3"
+  integrity sha512-PbB/RzN4W9M6sNZTvcjmc3PZ2S4CeFyQv/53tSs82pIlwM7NKVJzxVC0j3xCtoqoDDgXoJBhCpPV7MUEjCARQg==
+
+turbo-linux-mips64le@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-linux-mips64le/-/turbo-linux-mips64le-1.0.28.tgz#4f993f387d90fa99037ad9592e98648fdb9ca608"
+  integrity sha512-7LKmFS9M+AKW5slTHLz00Y4ovZh2CpjgMUkNNC6qtJB8YyWwXwoU0U7Yz28q3+rNVkcEiqWWx4l1Tj1AotTlaA==
+
+turbo-linux-ppc64le@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-linux-ppc64le/-/turbo-linux-ppc64le-1.0.28.tgz#053163e9042790102ceb1d299a3b79b1aa197be4"
+  integrity sha512-R382Op75XxcIiY1pWPnVnefxOeVbrVAeABIHLL1hKetbu9UPNzKAnQKqJYGzKIdTRKtPh5CQuErEFzs/Ky2ZgA==
+
+turbo-windows-32@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-windows-32/-/turbo-windows-32-1.0.28.tgz#b2b735fa56182aaf4095c9e4555fcf39ba050561"
+  integrity sha512-SjDgimlD5TMvkrFRtsJb4uVP7T44gwr0HqiIpAuWj1m5d8Pz/OisOoUkM/ISPKqVycIU5JF8wx0+CTnxC7YNhQ==
+
+turbo-windows-64@1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.0.28.tgz#7a2ad6f8416f04f20a1445c8b7123b80c6b16583"
+  integrity sha512-nT7bgcdl/9QNGBiwCYwTQ2VszcsqJ4NqT4YkE954KFZYxgSwMjjVTdoXcsnXMHpWiMiYfFF7HZLecUNnDm1uUA==
+
+turbo@^1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.0.28.tgz#fb33cecd2d025e3140ddbcc8c274f0ed7328f09d"
+  integrity sha512-5xmyVabNYqA0sCAU4VLdUS2A6GwIyy8FTszB/Fx4eNHwHudQwo00F2qORcDFwBHE4MqtnRoBFhL3ZJzo8c9A2w==
+  optionalDependencies:
+    turbo-darwin-64 "1.0.28"
+    turbo-darwin-arm64 "1.0.28"
+    turbo-freebsd-64 "1.0.28"
+    turbo-freebsd-arm64 "1.0.28"
+    turbo-linux-32 "1.0.28"
+    turbo-linux-64 "1.0.28"
+    turbo-linux-arm "1.0.28"
+    turbo-linux-arm64 "1.0.28"
+    turbo-linux-mips64le "1.0.28"
+    turbo-linux-ppc64le "1.0.28"
+    turbo-windows-32 "1.0.28"
+    turbo-windows-64 "1.0.28"
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,13 +1952,6 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-env@^7.0.0, cross-env@^7.0.2, cross-env@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
-  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
-  dependencies:
-    cross-spawn "^7.0.1"
-
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"


### PR DESCRIPTION
Use https://turborepo.org/ instead of `lerna run`.

Make local running fast.

## Differnces with lerna run

- Local Cache/Remote Cache
- Strict dependencies. lerna + yarn hoist dependencies, and It is Eventual consistency.
  - This PR fixes missing devDeps that is found by turbo
- `ENV_A=1 turbo run build` does not pass `ENV_A` to each `npm run build`
  - Use `turbo run updateSnapshot` instead of `UPDATE_SNAPSHOT=1 turbo run test` 
- Turbo does not tell me Dependency cycles. It is just to be hangging. lerna show Circular reference warning

## Publishing

We will still use `lerana publish`.