### PR TITLE
feat(sarif): add @secretlint/secretlint-formatter-sarif

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,5 @@ fabric.properties
 # Customize
 
 lib/
+module/
 dist/

--- a/packages/@secretlint/formatter/src/formatters/table.ts
+++ b/packages/@secretlint/formatter/src/formatters/table.ts
@@ -1,11 +1,9 @@
 "use strict";
-import { FormatterOptions } from "../types";
-import { SecretLintCoreResult, SecretLintCoreResultMessage } from "@secretlint/types";
+import { SecretLintCoreResult, SecretLintCoreResultMessage, SecretLintFormatter } from "@secretlint/types";
 
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
-
 import chalk from "chalk";
 import { table } from "table";
 import stripAnsi from "strip-ansi";
@@ -105,13 +103,13 @@ function drawReport(results: SecretLintCoreResult[]): string {
 // Public Interface
 //------------------------------------------------------------------------------
 
-function formatter(report: SecretLintCoreResult[], options: FormatterOptions) {
+const formatter: SecretLintFormatter = (results, options) => {
     const useColor = options.color ?? true;
     let output = "";
     let errorCount = 0;
     let warningCount = 0;
 
-    report.forEach((fileReport) => {
+    results.forEach((fileReport) => {
         fileReport.messages.forEach((message) => {
             if (message.severity === "warning") {
                 warningCount += 1;
@@ -122,7 +120,7 @@ function formatter(report: SecretLintCoreResult[], options: FormatterOptions) {
     });
 
     if (errorCount || warningCount) {
-        output = drawReport(report);
+        output = drawReport(results);
     }
 
     output +=
@@ -149,6 +147,6 @@ function formatter(report: SecretLintCoreResult[], options: FormatterOptions) {
         return stripAnsi(output);
     }
     return output;
-}
+};
 
 export default formatter;

--- a/packages/@secretlint/formatter/src/index.ts
+++ b/packages/@secretlint/formatter/src/index.ts
@@ -132,7 +132,7 @@ export function secretlintCreateFormatter(formatterConfig: FormatterConfig) {
         } else if (isFile(`${path.join(__dirname, "formatters/", formatterName)}.ts`)) {
             formatterPath = `${path.join(__dirname, "formatters/", formatterName)}.ts`;
         } else {
-            const pkgPath = tryResolve(`secretlint-formatter-${formatterName}`) || tryResolve(formatterName);
+            const pkgPath = tryResolve(formatterName) || tryResolve(`secretlint-formatter-${formatterName}`);
             if (pkgPath) {
                 formatterPath = pkgPath;
             }

--- a/packages/@secretlint/formatter/src/types.ts
+++ b/packages/@secretlint/formatter/src/types.ts
@@ -1,8 +1,5 @@
-export interface FormatterConfig {
-    formatterName: string;
-    color?: boolean;
-}
+import { SecretLintFormatterOptions } from "@secretlint/types";
 
-export interface FormatterOptions {
-    color?: boolean;
-}
+export type FormatterConfig = {
+    formatterName: string;
+} & SecretLintFormatterOptions;

--- a/packages/@secretlint/secretlint-formatter-sarif/.mocharc.json
+++ b/packages/@secretlint/secretlint-formatter-sarif/.mocharc.json
@@ -1,0 +1,5 @@
+{
+    "require": [
+        "ts-node-test-register"
+    ]
+}

--- a/packages/@secretlint/secretlint-formatter-sarif/LICENSE
+++ b/packages/@secretlint/secretlint-formatter-sarif/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2022 azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@secretlint/secretlint-formatter-sarif/README.md
+++ b/packages/@secretlint/secretlint-formatter-sarif/README.md
@@ -1,0 +1,47 @@
+# @secretlint/secretlint-formatter-sarif
+
+A secretlint formatter for SARIF format
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install @secretlint/secretlint-formatter-sarif
+
+## Usage
+
+```
+npm install @secretlint/secretlint-formatter-sarif --save-dev
+secretlint --format @secretlint/secretlint-formatter-sarif "**/*"
+# output as sarif format
+```
+
+## Changelog
+
+See [Releases page](https://github.com/secretlint/secretlint/releases).
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm test
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/secretlint/secretlint/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## Author
+
+- azu: [GitHub](https://github.com/azu), [Twitter](https://twitter.com/azu_re)
+
+## License
+
+MIT © azu

--- a/packages/@secretlint/secretlint-formatter-sarif/package.json
+++ b/packages/@secretlint/secretlint-formatter-sarif/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@secretlint/secretlint-formatter-sarif",
+  "version": "1.0.0",
+  "description": "A secretlint formatter for SARIF format",
+  "keywords": [
+    "sarif",
+    "secretlint",
+    "formatter"
+  ],
+  "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-formatter-sarif/",
+  "bugs": {
+    "url": "https://github.com/secretlint/secretlint/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/secretlint/secretlint.git"
+  },
+  "license": "MIT",
+  "author": "azu",
+  "sideEffects": false,
+  "main": "lib/secretlint-formatter-sarif.js",
+  "module": "module/secretlint-formatter-sarif.js",
+  "types": "lib/secretlint-formatter-sarif.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "module/",
+    "src/"
+  ],
+  "scripts": {
+    "build": "tsc -p . && tsc -p ./tsconfig.module.json",
+    "clean": "rimraf lib/ module/",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+    "prepublishOnly": "npm run clean && npm run build",
+    "test": "mocha \"test/**/*.ts\"",
+    "watch": "tsc -p . --watch"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": false,
+    "tabWidth": 4,
+    "trailingComma": "none"
+  },
+  "devDependencies": {
+    "@types/mocha": "^9.1.0",
+    "@types/node": "^17.0.21",
+    "@secretlint/types": "^4.1.3",
+    "mocha": "^9.2.1",
+    "prettier": "^2.5.1",
+    "rimraf": "^3.0.2",
+    "ts-node": "^10.5.0",
+    "ts-node-test-register": "^10.0.0",
+    "typescript": "^4.5.5"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "node-sarif-builder": "^2.0.2"
+  }
+}

--- a/packages/@secretlint/secretlint-formatter-sarif/src/index.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/src/index.ts
@@ -1,0 +1,73 @@
+import { SecretLintCoreResult, SecretLintFormatter } from "@secretlint/types";
+import { SarifBuilder, SarifResultBuilder, SarifRuleBuilder, SarifRunBuilder } from "node-sarif-builder";
+import path from "path";
+
+function buildSarifResult(lintResults: SecretLintCoreResult[]) {
+    // SARIF builder
+    const sarifBuilder = new SarifBuilder();
+    // SARIF Run builder
+    const sarifRunBuilder = new SarifRunBuilder().initSimple({
+        toolDriverName: "secretlint-formatter-sarif",
+        toolDriverVersion: "1.0.0",
+        url: "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-formatter-sarif/"
+    });
+    // SARIF rules
+    const addedRuleSet = new Set<string>();
+    lintResults.forEach((result) => {
+        result.messages.forEach((message) => {
+            const ruleId = message.ruleParentId ? `${message.ruleParentId} > ${message.ruleId}` : message.ruleId;
+            if (addedRuleSet.has(ruleId)) {
+                return;
+            }
+            addedRuleSet.add(ruleId);
+            const sarifRuleBuiler = new SarifRuleBuilder().initSimple({
+                ruleId: ruleId,
+                shortDescriptionText: `secretlint rule(${ruleId}) error`,
+                helpUri: message?.docsUrl
+            });
+            sarifRunBuilder.addRule(sarifRuleBuiler);
+        });
+    });
+    // Add SARIF results (individual errors)
+    lintResults.forEach((result) => {
+        result.messages.forEach((message) => {
+            const sarifResultBuilder = new SarifResultBuilder();
+            const ruleId = message.ruleParentId ? `${message.ruleParentId} > ${message.ruleId}` : message.ruleId;
+            const sarifResultInit = {
+                level: message.severity === "info" ? "note" : message.severity, // Other values can be "warning" or "error"
+                messageText: message.message,
+                ruleId: ruleId,
+                fileUri: process.env.SARIF_URI_ABSOLUTE
+                    ? "file:///" + result.filePath.replace(/\\/g, "/")
+                    : path.relative(process.cwd(), result.filePath),
+                startLine: fixLine(message.loc.start.line),
+                startColumn: fixCol(message.loc.start.column),
+                endLine: fixLine(message.loc.end.line),
+                endColumn: fixCol(message.loc.end.column)
+            } as const;
+            sarifResultBuilder.initSimple(sarifResultInit);
+            sarifRunBuilder.addResult(sarifResultBuilder);
+        });
+    });
+    sarifBuilder.addRun(sarifRunBuilder);
+    return sarifBuilder.buildSarifJsonString({ indent: true });
+}
+
+function fixLine(val: number) {
+    if (val === null) {
+        return undefined;
+    }
+    return val === 0 ? 1 : val;
+}
+
+function fixCol(val: number) {
+    if (val === null) {
+        return undefined;
+    }
+    return val === 0 ? 1 : val + 1;
+}
+
+const formatter: SecretLintFormatter = (results) => {
+    return buildSarifResult(results);
+};
+export default formatter;

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -1,0 +1,33 @@
+import fs from "fs";
+import path from "path";
+import assert from "assert";
+import { results } from "./snapshots/input";
+import formatter from "../src/index";
+
+const escapeStringRegexp = require("escape-string-regexp");
+const snapshotsDir = path.join(__dirname, "snapshots");
+const snapshotReplace = (value: string) => {
+    return value.replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]");
+};
+
+describe("@secretlint/secretlint-formatter-sarif", function () {
+    it(`snapshot testing`, async function () {
+        const fixtureDir = snapshotsDir;
+        const actual = snapshotReplace(
+            formatter(results, {
+                color: true
+            })
+        );
+        const expectedFilePath = path.join(fixtureDir, `output.sarif`);
+        // Usage: update snapshots
+        // UPDATE_SNAPSHOT=1 npm test
+        if (!fs.existsSync(expectedFilePath) || process.env.UPDATE_SNAPSHOT) {
+            fs.writeFileSync(expectedFilePath, actual);
+            this.skip(); // skip when updating snapshots
+            return;
+        }
+        // compare input and output
+        const expected = fs.readFileSync(expectedFilePath, "utf-8");
+        assert.strictEqual(actual, expected);
+    });
+});

--- a/packages/@secretlint/secretlint-formatter-sarif/test/snapshots/input.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/snapshots/input.ts
@@ -1,0 +1,81 @@
+import { SecretLintCoreResult } from "@secretlint/types";
+import path from "path";
+
+export const results: SecretLintCoreResult[] = [
+    {
+        filePath: path.join(__dirname, "input.txt"),
+        messages: [
+            {
+                data: {
+                    ID: "SECRET"
+                },
+                type: "message",
+                message: "warning found secret: SECRET",
+                messageId: "message-id",
+                range: [8, 14],
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 8
+                    },
+                    end: {
+                        line: 1,
+                        column: 14
+                    }
+                },
+                ruleId: "example",
+                severity: "warning",
+                docsUrl: "https://example.com/example"
+            },
+            {
+                data: {
+                    ID: "SECRET"
+                },
+                type: "message",
+                message: "error found secret: SECRET",
+                messageId: "message-id",
+                range: [8, 14],
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 8
+                    },
+                    end: {
+                        line: 1,
+                        column: 14
+                    }
+                },
+                ruleId: "example",
+                severity: "error",
+                docsUrl: "https://example.com/example"
+            },
+            {
+                data: {
+                    ID: "SECRET"
+                },
+                type: "message",
+                message: "error found secret: SECRET",
+                messageId: "message-id",
+                range: [8, 14],
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 8
+                    },
+                    end: {
+                        line: 1,
+                        column: 14
+                    }
+                },
+                ruleId: "example",
+                ruleParentId: "parent",
+                severity: "error",
+                docsUrl: "https://example.com/example"
+            }
+        ]
+    },
+    {
+        filePath: path.join(__dirname, "input.no-secret.txt"),
+        messages: []
+    }
+];

--- a/packages/@secretlint/secretlint-formatter-sarif/test/snapshots/output.sarif
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/snapshots/output.sarif
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "secretlint-formatter-sarif",
+          "rules": [
+            {
+              "id": "example",
+              "shortDescription": {
+                "text": "secretlint rule(example) error"
+              },
+              "helpUri": "https://example.com/example"
+            },
+            {
+              "id": "parent > example",
+              "shortDescription": {
+                "text": "secretlint rule(parent > example) error"
+              },
+              "helpUri": "https://example.com/example"
+            }
+          ],
+          "version": "1.0.0",
+          "informationUri": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-formatter-sarif/"
+        }
+      },
+      "results": [
+        {
+          "level": "warning",
+          "message": {
+            "text": "warning found secret: SECRET"
+          },
+          "ruleId": "example",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "test/snapshots/input.txt",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 9,
+                  "endLine": 1,
+                  "endColumn": 15
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "level": "error",
+          "message": {
+            "text": "error found secret: SECRET"
+          },
+          "ruleId": "example",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "test/snapshots/input.txt",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 9,
+                  "endLine": 1,
+                  "endColumn": 15
+                }
+              }
+            }
+          ],
+          "ruleIndex": 0
+        },
+        {
+          "level": "error",
+          "message": {
+            "text": "error found secret: SECRET"
+          },
+          "ruleId": "parent > example",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "test/snapshots/input.txt",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 9,
+                  "endLine": 1,
+                  "endColumn": 15
+                }
+              }
+            }
+          ],
+          "ruleIndex": 1
+        }
+      ],
+      "artifacts": [
+        {
+          "sourceLanguage": "Text",
+          "location": {
+            "uri": "test/snapshots/input.txt"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-formatter-sarif/test/tsconfig.json
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "declaration": false,
+        "noEmit": true
+    },
+    "include": [
+        "../src/**/*",
+        "./**/*"
+    ]
+}

--- a/packages/@secretlint/secretlint-formatter-sarif/tsconfig.json
+++ b/packages/@secretlint/secretlint-formatter-sarif/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "newLine": "LF",
+    "outDir": "./lib/",
+    "target": "es5",
+    "sourceMap": true,
+    "declaration": true,
+    "jsx": "preserve",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    /* Strict Type-Checking Options */
+    "strict": true,
+    /* Additional Checks */
+    /* Report errors on unused locals. */
+    "noUnusedLocals": true,
+    /* Report errors on unused parameters. */
+    "noUnusedParameters": true,
+    /* Report error when not all code paths in function return a value. */
+    "noImplicitReturns": true,
+    /* Report errors for fallthrough cases in switch statement. */
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    ".git",
+    "node_modules"
+  ]
+}

--- a/packages/@secretlint/secretlint-formatter-sarif/tsconfig.module.json
+++ b/packages/@secretlint/secretlint-formatter-sarif/tsconfig.module.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./module/",
+  }
+}

--- a/packages/@secretlint/types/src/SecretLintFormatter.ts
+++ b/packages/@secretlint/types/src/SecretLintFormatter.ts
@@ -1,0 +1,12 @@
+import { SecretLintCoreResult } from "./SecretLintCore";
+
+export type SecretLintFormatterOptions = {
+    /**
+     * Default: true
+     */
+    color?: boolean;
+};
+export type SecretLintFormatter = (
+    results: SecretLintCoreResult[],
+    formatterConfig: SecretLintFormatterOptions
+) => string;

--- a/packages/@secretlint/types/src/index.ts
+++ b/packages/@secretlint/types/src/index.ts
@@ -57,3 +57,5 @@ export {
     SecretLintConfigDescriptorRule,
     SecretLintConfigDescriptorRulePreset,
 } from "./SecretLintConfigDescriptor";
+// Formatter
+export { SecretLintFormatterOptions, SecretLintFormatter } from "./SecretLintFormatter";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1135,7 +1135,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/mocha@^9.0.0":
+"@types/mocha@^9.0.0", "@types/mocha@^9.1.0":
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.0.tgz#baf17ab2cca3fcce2d322ebc30454bff487efad5"
   integrity sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==
@@ -1156,6 +1156,11 @@
   version "16.11.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.22.tgz#e704150225bfc4195f8ce68a7ac8da02b753549a"
   integrity sha512-DYNtJWauMQ9RNpesl4aVothr97/tIJM8HbyOXJ0AYT1Z2bEjLHyfjOBPAQQVMLf8h3kSShYfNk8Wnto8B2zHUA==
+
+"@types/node@^17.0.21":
+  version "17.0.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
+  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1178,6 +1183,11 @@
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/sarif@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@types/sarif/-/sarif-2.1.4.tgz#471c5788199d22f572f255de9a8166a30abf1245"
+  integrity sha512-4xKHMdg3foh3Va1fxTzY1qt8QVqmaJpGWsVvtjQrJBn+/bkig2pWFKJ4FPI2yLI4PAj0SUKiPO4Vd7ggYIMZjQ==
 
 "@types/secp256k1@^4.0.3":
   version "4.0.3"
@@ -2465,6 +2475,15 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+fs-extra@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.1.tgz#27de43b4320e833f6867cc044bfce29fdf0ef3b8"
+  integrity sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^9.1.0:
   version "9.1.0"
@@ -3930,6 +3949,36 @@ mocha@^9.0.1, mocha@^9.1.1:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+mocha@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.2.1.tgz#a1abb675aa9a8490798503af57e8782a78f1338e"
+  integrity sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==
+  dependencies:
+    "@ungap/promise-all-settled" "1.1.2"
+    ansi-colors "4.1.1"
+    browser-stdout "1.3.1"
+    chokidar "3.5.3"
+    debug "4.3.3"
+    diff "5.0.0"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "7.2.0"
+    growl "1.10.5"
+    he "1.2.0"
+    js-yaml "4.1.0"
+    log-symbols "4.1.0"
+    minimatch "3.0.4"
+    ms "2.1.3"
+    nanoid "3.2.0"
+    serialize-javascript "6.0.0"
+    strip-json-comments "3.1.1"
+    supports-color "8.1.1"
+    which "2.0.2"
+    workerpool "6.2.0"
+    yargs "16.2.0"
+    yargs-parser "20.2.4"
+    yargs-unparser "2.0.0"
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
@@ -4035,6 +4084,14 @@ node-gyp@^7.1.0:
     semver "^7.3.2"
     tar "^6.0.2"
     which "^2.0.2"
+
+node-sarif-builder@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-sarif-builder/-/node-sarif-builder-2.0.2.tgz#b69166a98808a6eccb7921f1c0b80438e5018a98"
+  integrity sha512-SkNE1BnGyO5FdHscmGQ0cQ/9S1nHt+vi+UHr5AGbzVaeeTzZBHnpDoi5XIB3Cj7KtzI3kxocKkI6HLdTBcRNLA==
+  dependencies:
+    "@types/sarif" "^2.1.4"
+    fs-extra "^10.0.0"
 
 nopt@^4.0.1:
   version "4.0.3"
@@ -4565,7 +4622,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.3.1:
+prettier@^2.3.1, prettier@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
@@ -5607,6 +5664,25 @@ ts-node@^10.0.0, ts-node@^10.2.1:
     make-error "^1.1.1"
     yn "3.1.1"
 
+ts-node@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.5.0.tgz#618bef5854c1fbbedf5e31465cbb224a1d524ef9"
+  integrity sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.0"
+    yn "3.1.1"
+
 tsconfig-loader@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tsconfig-loader/-/tsconfig-loader-1.1.0.tgz#90f60a569a65569c1096719c112b48b3f13f9fc1"
@@ -5811,7 +5887,7 @@ typescript@^3.5.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.3.4, typescript@^4.4.3:
+typescript@^4.3.4, typescript@^4.4.3, typescript@^4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
@@ -5893,6 +5969,11 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+v8-compile-cache-lib@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"
+  integrity sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Usage

```
npm install @secretlint/secretlint-formatter-sarif --save-dev
secretlint --format @secretlint/secretlint-formatter-sarif "**/*"
# output as sarif format
```

## Consideration

- [ ] Should we includes safrif into builtin formatter?

Probably, we will reduce built-in formatter for reducing dependency cost in the future.
Almost people does not use sarif formatter.
So, We make it opt-in formatter.

fix #143 