### PR TITLE
feat(docker): support arm64 for image

### DIFF
--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -5,7 +5,7 @@ on:
     types: [publish-artifact]
 env:
   CI: true
-  DOCKER_BASE_NAME: docker.pkg.github.com/${{ github.repository }}/secretlint
+  DOCKER_BASE_NAME: ghcr.io/${{ github.repository }}
   DOCKER_HUB_BASE_NAME: secretlint/secretlint
 
 permissions:
@@ -60,27 +60,36 @@ jobs:
           echo "PKG_LATEST_TAG=${DOCKER_BASE_NAME}:latest" >> $GITHUB_ENV
           echo "HUB_TAG=${DOCKER_HUB_BASE_NAME}:${TAG_NAME}" >> $GITHUB_ENV
           echo "HUB_LATEST_TAG=${DOCKER_HUB_BASE_NAME}:latest" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Registries
+        run: |
+          echo "${GITHUB_TOKEN}" | docker login ghcr.io -u azu --password-stdin
+          echo "${DOCKER_HUB_TOKEN}" | docker login -u efcl --password-stdin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Build image
         run: |
-          docker build . -t "${PKG_TAG}" --build-arg SECRETLINT_VERSION=${SECRETLINT_VERSION}
-          docker tag "${PKG_TAG}" "${HUB_LATEST_TAG}"
-          docker tag "${PKG_TAG}" "${HUB_TAG}"
+          docker buildx build . \
+            --build-arg SECRETLINT_VERSION=${SECRETLINT_VERSION} \
+            --load \
+            -t "${PKG_TAG}"
         working-directory: ./publish/docker
       - name: Print version
         run: |
           docker run --rm ${PKG_TAG} --version
         working-directory: ./publish/docker
-      - name: Login to Registries
+      - name: Build and push images
         run: |
-          echo "${GITHUB_TOKEN}" | docker login docker.pkg.github.com -u azu --password-stdin
-          echo "${DOCKER_HUB_TOKEN}" | docker login -u efcl --password-stdin
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: Push to GitHub Packages
-        run: |
-          docker push "${PKG_TAG}"
-      - name: Push to Docker Hub
-        run: |
-          docker push "${HUB_TAG}"
-          docker push "${HUB_LATEST_TAG}"
+          docker buildx build . \
+            --build-arg SECRETLINT_VERSION=${SECRETLINT_VERSION} \
+            --platform linux/amd64,linux/arm64 \
+            --push \
+            -t "${PKG_TAG}" \
+            -t "${PKG_LATEST_TAG}" \
+            -t "${HUB_TAG}" \
+            -t "${HUB_LATEST_TAG}"
+        working-directory: ./publish/docker


### PR DESCRIPTION
fix #252.

## Summary
- Build and push a docker images for linux/amd64 and linux/arm64 using docker buildx.
  - https://github.com/docker/setup-buildx-action
  - https://github.com/docker/setup-qemu-action
- Change the image push destination from docker.pkg.github.com to ghcr.io. Because docker.pkg.github.com does not support multi-platform images.
  - > The Docker service docker.pkg.github.com has not (and will not) receive this update. The new Container Registry (GHCR) now supports multi-arch images.
  https://github.community/t/publish-docker-package-fails/17569/10
- I have tried publishing in my repository.
  - pull request: https://github.com/korosuke613/secretlint/pull/4
  - publish logs: https://github.com/korosuke613/secretlint/runs/5815978333
  - ghcr.io: https://github.com/korosuke613/secretlint/pkgs/container/secretlint
  - Docker Hub: https://hub.docker.com/repository/docker/korosuke613/secretlint