### PR TITLE
fix(docker): use latest formatter version

### DIFF
--- a/publish/docker/Dockerfile
+++ b/publish/docker/Dockerfile
@@ -10,7 +10,7 @@ ENV SECRETLINTRC /.secretlintrc.json
 COPY .secretlintrc.json $SECRETLINTRC
 RUN npm install -g secretlint@${SECRETLINT_VERSION} \
             @secretlint/secretlint-rule-preset-recommend@${SECRETLINT_VERSION} \
-            @secretlint/secretlint-formatter-sarif@${SECRETLINT_VERSION} && \
+            @secretlint/secretlint-formatter-sarif@latest && \
     rm -rf /usr/share/man /tmp/* \
            /root/.npm /root/.node-gyp \
            /usr/lib/node_modules/npm/man \


### PR DESCRIPTION
I noticed that formatt is not align to core version.