### PR TITLE
chore(issue-template): Fix issue template: how to check the secretlint's version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,7 @@ Please update secretlint and try it before bug report.
 **What version of secretlint are you using?**
 <!-- 
 # Past result of following command: 
-$ npx secretlint -v
+$ npx secretlint --version
 -->
 
 **What did you do? Please include the actual steps causing the issue.**


### PR DESCRIPTION
Since `secrelint` only supports longs option, `-v` causes an error.

```
# npx secretlint -v
Error: Not found target files
# npx secretlint --version
5.2.1
```