### PR TITLE
test(runConfigCreator): add tests for secretlint --init

### DIFF
--- a/packages/@secretlint/config-creator/package.json
+++ b/packages/@secretlint/config-creator/package.json
@@ -31,6 +31,7 @@
         "clean": "rimraf lib/",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
+        "test": "mocha \"test/**/*.ts\"",
         "watch": "tsc -p . --watch"
     },
     "prettier": {

--- a/packages/@secretlint/config-creator/test/fixtures/package.json
+++ b/packages/@secretlint/config-creator/test/fixtures/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "fixture-for-config-creator",
+    "private": true,
+    "devDependencies": {
+        "@secretlint/secretlint-rule-preset-recommend": "^5.2.4",
+        "expected-exit-status": "^2.0.0",
+        "secretlint": "^5.2.4"
+    }
+}

--- a/packages/@secretlint/config-creator/test/index.test.ts
+++ b/packages/@secretlint/config-creator/test/index.test.ts
@@ -2,7 +2,7 @@
 "use strict";
 import assert from "assert";
 import path from "path";
-import fs from "fs";
+import fs from "fs/promises";
 import os from "os";
 import readPkg from "read-pkg";
 import { createConfig } from "@secretlint/config-creator";
@@ -26,24 +26,24 @@ import { createConfig } from "@secretlint/config-creator";
 describe("@secretlint/config-creator", function () {
     let tmpConfigDir: string;
 
-    beforeEach(function () {
-        tmpConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-config"));
+    beforeEach(async () => {
+        tmpConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "secretlint-config"));
         const packageFilePath = path.join(__dirname, "fixtures", "package.json");
-        fs.promises.copyFile(packageFilePath, tmpConfigDir + "/package.json");
+        await fs.copyFile(packageFilePath, path.join(tmpConfigDir + "/package.json"));
     });
 
-    afterEach(function () {
-        fs.rmSync(tmpConfigDir, { recursive: true });
+    afterEach(async () => {
+        await fs.rm(tmpConfigDir, { recursive: true });
     });
 
     context("When config-creator is called", function () {
-        it("Run config-creator successfully", async function () {
+        it("Run config-creator successfully", async () => {
             const pkg = await readPkg({
                 cwd: tmpConfigDir,
             });
             const actual = createConfig({ packageJSON: pkg });
             actual.rules.forEach((rule) => {
-                assert.equal(rule.id, "@secretlint/secretlint-rule-preset-recommend");
+                assert.strictEqual(rule.id, "@secretlint/secretlint-rule-preset-recommend");
             });
         });
     });

--- a/packages/@secretlint/config-creator/test/index.test.ts
+++ b/packages/@secretlint/config-creator/test/index.test.ts
@@ -1,0 +1,50 @@
+// LICENSE : MIT
+"use strict";
+import assert from "assert";
+import path from "path";
+import fs from "fs";
+import os from "os";
+import readPkg from "read-pkg";
+import { createConfig } from "@secretlint/config-creator";
+
+/**
+ *
+ * Run config-creator
+ * - yarn test -g "@secretlint/config-creator"
+ *
+ * File Overview
+ *
+ * - tmpConfigDir
+ *   - A temporal directory with "secretlint-config"
+ *   - Create .secretlintrc.json on the directory
+ * - packageFilePath
+ *   - A path of package.json to use of this test
+ *   - When using this package.json, copy it to tmpConfigDir
+ * - expectedConfigFilePath
+ *   - A path of .secretlintrc.json to create by this test
+ */
+describe("@secretlint/config-creator", function () {
+    let tmpConfigDir: string;
+
+    beforeEach(function () {
+        tmpConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-config"));
+        const packageFilePath = path.join(__dirname, "fixtures", "package.json");
+        fs.promises.copyFile(packageFilePath, tmpConfigDir + "/package.json");
+    });
+
+    afterEach(function () {
+        fs.rmSync(tmpConfigDir, { recursive: true });
+    });
+
+    context("When config-creator is called", function () {
+        it("Run config-creator successfully", async function () {
+            const pkg = await readPkg({
+                cwd: tmpConfigDir,
+            });
+            const actual = createConfig({ packageJSON: pkg });
+            actual.rules.forEach((rule) => {
+                assert.equal(rule.id, "@secretlint/secretlint-rule-preset-recommend");
+            });
+        });
+    });
+});

--- a/packages/secretlint/test/create-secretlintrc.test.ts
+++ b/packages/secretlint/test/create-secretlintrc.test.ts
@@ -1,0 +1,67 @@
+// LICENSE : MIT
+"use strict";
+import assert from "assert";
+import path from "path";
+import fs from "fs";
+import os from "os";
+import { runConfigCreator } from "../src/create-secretlintrc";
+
+/**
+ *
+ * Create .secretlintrc.json
+ * - yarn test -g "create-secretlintrc-test"
+ *
+ * File Overview
+ *
+ * - tmpConfigDir
+ *   - A temporal directory with "secretlint-config"
+ *   - Create .secretlintrc.json on the directory
+ * - packageFilePath
+ *   - A path of package.json to use of this test
+ *   - When using this package.json, copy it to tmpConfigDir
+ * - expectedConfigFilePath
+ *   - A path of .secretlintrc.json to create by this test
+ */
+describe("create-secretlintrc-test", function () {
+    let tmpConfigDir: string;
+
+    beforeEach(function () {
+        tmpConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-config"));
+        const packageFilePath = path.join(__dirname, "fixtures", "package.json");
+        fs.promises.copyFile(packageFilePath, tmpConfigDir + "/package.json");
+    });
+
+    afterEach(function () {
+        fs.rmSync(tmpConfigDir, { recursive: true });
+    });
+
+    context("when pacakge.json has @secretlint/* packages", function () {
+        it("Run secretlint --init", async function () {
+            const expectedConfigFilePath = `${tmpConfigDir}/.secretlintrc.json`;
+            return runConfigCreator({ cwd: tmpConfigDir }).then(function (actual) {
+                assert.equal(actual.exitStatus, 0);
+                assert.equal(actual.stdout, `Create ${expectedConfigFilePath}`);
+                assert.equal(actual.stderr, null);
+            });
+        });
+    });
+
+    context("when .secretlintrc.json is already existed", function () {
+        it("should be an error", async function () {
+            const expectedConfigFilePath = `${tmpConfigDir}/.secretlintrc.json`;
+            return runConfigCreator({ cwd: tmpConfigDir })
+                .then((actual) => {
+                    assert.equal(actual.exitStatus, 0);
+                    assert.equal(actual.stdout, `Create ${expectedConfigFilePath}`);
+                    assert.equal(actual.stderr, null);
+                    // try to re-create
+                    return runConfigCreator({ cwd: tmpConfigDir });
+                })
+                .then((actual) => {
+                    assert.equal(actual.exitStatus, 1);
+                    assert.equal(actual.stdout, null);
+                    assert.equal(actual.stderr, "Error: secretlint config file is already existed.");
+                });
+        });
+    });
+});

--- a/packages/secretlint/test/create-secretlintrc.test.ts
+++ b/packages/secretlint/test/create-secretlintrc.test.ts
@@ -64,10 +64,7 @@ describe("create-secretlintrc", function () {
             if (reActual.stderr === null) {
                 assert.fail("stderr is unexpected null.");
             }
-            assert.match(
-                reActual.stderr.toString(),
-                new RegExp(`Error:\\s+secretlint\\s+config\\s+file\\s+is\\s+already\\s+existed\.`, "g")
-            );
+            assert.strictEqual(reActual.stderr.toString(), "Error: secretlint config file is already existed.");
         });
     });
 });

--- a/packages/secretlint/test/fixtures/package.json
+++ b/packages/secretlint/test/fixtures/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "fixture-for-create-secretlintrc",
+    "private": true,
+    "devDependencies": {
+        "@secretlint/secretlint-rule-preset-recommend": "^5.2.4",
+        "expected-exit-status": "^2.0.0",
+        "secretlint": "^5.2.4"
+    }
+}


### PR DESCRIPTION
Add tests as bellow:
- Check to create `.secretlintrc.json` when `runConfigCreator` is called
- Check whether `createConfig` works well

Ref. #33