### PR TITLE
fix(filter-comment): fix secretlint-disable comment parsing

### DIFF
--- a/packages/@secretlint/secretlint-rule-filter-comments/src/parse-comment.ts
+++ b/packages/@secretlint/secretlint-rule-filter-comments/src/parse-comment.ts
@@ -36,12 +36,20 @@ export const parseComments = (source: SecretLintSourceCode) => {
 
 /**
  * Parses a config of values separated by comma.
+ *
+ * secretlint-disable a,b,c => ["a", "b", "c"]
+ * secretlint-disable -- comment　=> []
  */
 export function parseComment(options?: string): string[] {
+    if (!options) {
+        return [];
+    }
+    const commentStart = options.indexOf("--");
+    const ruleIdString = commentStart === -1 ? options : options.slice(0, commentStart);
     return (
-        options
-            ?.split(/\s{0, 5},\s{0,5}/)
-            .map((arg) => arg.split(/\s-{2,}\s/u)[0].trim())
+        ruleIdString
+            .split(/,/)
+            .map((arg) => arg.trim())
             .filter((arg) => arg !== "") ?? []
     );
 }

--- a/packages/@secretlint/secretlint-rule-filter-comments/test/parseComment.test.ts
+++ b/packages/@secretlint/secretlint-rule-filter-comments/test/parseComment.test.ts
@@ -2,6 +2,14 @@ import { parseComment } from "../src/parse-comment";
 import * as assert from "assert";
 
 describe("parseComment", function () {
+    it("should return [] when no option ", () => {
+        const results = parseComment("");
+        assert.deepStrictEqual(results, []);
+    });
+    it("should parse rule id: a ", () => {
+        const results = parseComment("secretlint-rule-a");
+        assert.deepStrictEqual(results, ["secretlint-rule-a"]);
+    });
     it("should parse rule ids: a,b,c ", () => {
         const results = parseComment(" a, b,c ");
         assert.deepStrictEqual(results, ["a", "b", "c"]);

--- a/packages/@secretlint/secretlint-rule-filter-comments/test/parseComment.test.ts
+++ b/packages/@secretlint/secretlint-rule-filter-comments/test/parseComment.test.ts
@@ -1,0 +1,21 @@
+import { parseComment } from "../src/parse-comment";
+import * as assert from "assert";
+
+describe("parseComment", function () {
+    it("should parse rule ids: a,b,c ", () => {
+        const results = parseComment(" a, b,c ");
+        assert.deepStrictEqual(results, ["a", "b", "c"]);
+    });
+    it("should ignore comment: -- ", () => {
+        const results = parseComment(" -- comment ");
+        assert.deepStrictEqual(results, []);
+    });
+    it("should parse rule ids + comment : a,b,c -- comment", () => {
+        const results = parseComment(" a,  b,   c ");
+        assert.deepStrictEqual(results, ["a", "b", "c"]);
+    });
+    it("should parse markdown comment : a,b,c -->", () => {
+        const results = parseComment("a, b,   c ");
+        assert.deepStrictEqual(results, ["a", "b", "c"]);
+    });
+});

--- a/packages/@secretlint/secretlint-rule-filter-comments/test/snapshots/ok.ignore-in-markdown/input.md
+++ b/packages/@secretlint/secretlint-rule-filter-comments/test/snapshots/ok.ignore-in-markdown/input.md
@@ -1,0 +1,7 @@
+<!-- secretlint-disable -->
+
+THIS IS SECRET A
+THIS IS SECRET B
+THIS IS SECRET C
+
+<!-- secretlint-enable -->

--- a/packages/@secretlint/secretlint-rule-filter-comments/test/snapshots/ok.ignore-in-markdown/output.json
+++ b/packages/@secretlint/secretlint-rule-filter-comments/test/snapshots/ok.ignore-in-markdown/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.ignore-in-markdown/input.md",
+    "messages": [],
+    "sourceContent": "<!-- secretlint-disable -->\n\nTHIS IS SECRET A\nTHIS IS SECRET B\nTHIS IS SECRET C\n\n<!-- secretlint-enable -->\n",
+    "sourceContentType": "text"
+}


### PR DESCRIPTION
Markdown comment `<!-- secretlint-disable -->` does not work correctly.

fix #371 