### PR TITLE
fix(canary): remove `process.platform` from browser bundle

### DIFF
--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -60,6 +60,7 @@
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^10.0.1",
+    "@rollup/plugin-replace": "^5.0.2",
     "@secretlint/tester": "^6.2.1",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.11.18",

--- a/packages/@secretlint/secretlint-rule-preset-canary/rollup.config.mjs
+++ b/packages/@secretlint/secretlint-rule-preset-canary/rollup.config.mjs
@@ -1,8 +1,12 @@
 import resolve from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
 import commonjs from "@rollup/plugin-commonjs";
-import nodePolyfills from 'rollup-plugin-polyfill-node';
-export default [
+import nodePolyfills from "rollup-plugin-polyfill-node";
+import replace from "@rollup/plugin-replace";
+
+import { defineConfig } from "rollup";
+
+export default defineConfig([
     {
         input: "src/index.ts",
         output: [
@@ -10,10 +14,10 @@ export default [
                 dir: "lib/",
                 format: "commonjs",
                 exports: "named",
-                sourcemap: true,
+                sourcemap: true
             }
         ],
-        plugins: [resolve({ preferBuiltins: true }), commonjs(), typescript()],
+        plugins: [resolve({ preferBuiltins: true }), commonjs(), typescript()]
     },
     {
         input: "src/index.ts",
@@ -26,6 +30,12 @@ export default [
                 treeshake: true
             }
         ],
-        plugins: [resolve({ preferBuiltins: true }), commonjs(), typescript(), nodePolyfills()],
+        // Delete process.version
+        plugins: [replace({
+            "__DEV__": false,
+            "process.platform": null,
+            "process.version": null,
+            "process.env.NODE_ENV": JSON.stringify("production")
+        }), resolve({ preferBuiltins: false }), commonjs(), typescript(), nodePolyfills()]
     }
-];
+]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -590,6 +590,14 @@
     is-module "^1.0.0"
     resolve "^1.22.1"
 
+"@rollup/plugin-replace@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-5.0.2.tgz#45f53501b16311feded2485e98419acb8448c61d"
+  integrity sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    magic-string "^0.27.0"
+
 "@rollup/plugin-typescript@^10.0.1":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-10.0.1.tgz#270b515b116ea28320e6bb62451c4767d49072d6"


### PR DESCRIPTION
Follow up

- #405 

It will fix following error:

> Uncaught ReferenceError: process is not defined
