### PR TITLE
fix(renovate): use "automergeType": "pr"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "@azu:maintenance"
-  ]
+  ],
+  "automergeType": "pr"
 }


### PR DESCRIPTION
renovate always failed because it will push to main brach.
it is blocked by protect branches.
It will be resolved by using `"automergeType": "pr"`