### PR TITLE
fix(quick start): exit status align to secretlint command

### DIFF
--- a/packages/@secretlint/quick-start/bin/quick-start.js
+++ b/packages/@secretlint/quick-start/bin/quick-start.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { quickStart } from "../module/index.js";
 try {
+    const { quickStart } = await import("../module/index.js");
     const { exitStatus, stderr, stdout } = await quickStart();
     if (stdout) {
         console.log(stdout);
@@ -12,5 +12,5 @@ try {
     process.exit(exitStatus);
 } catch (error) {
     console.error(error);
-    process.exit(1);
+    process.exit(2); // fatal error
 }


### PR DESCRIPTION
- #399 

`@secretlint/quick-start` should align with `secretlint` command