### PR TITLE
fix: use fileURLToPath for mimicked __dirname

### DIFF
--- a/packages/@secretlint/config-creator/test/index.test.ts
+++ b/packages/@secretlint/config-creator/test/index.test.ts
@@ -1,10 +1,11 @@
 // LICENSE : MIT
 import assert from "node:assert";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import fs from "node:fs/promises";
 import os from "node:os";
 import { createConfig } from "../src/index.js";
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const readPkg = (filePath: string) => {
     return fs.readFile(filePath, "utf-8").then((content) => {
         return JSON.parse(content);

--- a/packages/@secretlint/config-loader/test/index.test.ts
+++ b/packages/@secretlint/config-loader/test/index.test.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import assert from "node:assert";
 import { SecretLintCoreConfigUnionRule } from "@secretlint/types";
 import { importSecretlintCreator, loadConfig } from "../src/index.js";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const removeUndefined = (o: { [index: string]: any }) => {
     for (let key in o) {
         if (o[key] === undefined) {

--- a/packages/@secretlint/config-loader/test/snapshot.test.ts
+++ b/packages/@secretlint/config-loader/test/snapshot.test.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import assert from "node:assert";
 import { validateConfig, validateConfigResult } from "../src/index.js";
 import { isAggregationError } from "../src/AggregationError.js";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const snapshotDir = path.join(__dirname, "snapshots");
 const formatResult = (result: validateConfigResult) => {
     return result.ok

--- a/packages/@secretlint/formatter/src/index.ts
+++ b/packages/@secretlint/formatter/src/index.ts
@@ -10,6 +10,7 @@ import { FormatterConfig } from "./types.js";
 import { moduleInterop } from "@textlint/module-interop";
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 // @ts-expect-error: no @types
 import isFile from "is-file";
 // @ts-expect-error: no @types
@@ -17,7 +18,7 @@ import tryResolve from "try-resolve";
 import debug0 from "debug";
 
 const debug = debug0("@secretlint/formatter");
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export interface SecretLintFormatterConfig {
     /**

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import assert from "node:assert";
 import { loadFormatter, getFormatterList } from "../src/index.js";
 import { results } from "./snapshots/input.js";
 import escapeStringRegexp from "escape-string-regexp";
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const snapshotsDir = path.join(__dirname, "snapshots");
 const snapshotReplace = (value: string) => {
     return value.replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]");

--- a/packages/@secretlint/formatter/test/snapshots/input.ts
+++ b/packages/@secretlint/formatter/test/snapshots/input.ts
@@ -1,6 +1,7 @@
 import { SecretLintCoreResult } from "@secretlint/types";
 import path from "node:path";
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+import { fileURLToPath } from "node:url";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const results: SecretLintCoreResult[] = [
     {
         filePath: path.join(__dirname, "input.txt"),

--- a/packages/@secretlint/node/test/index.test.ts
+++ b/packages/@secretlint/node/test/index.test.ts
@@ -2,8 +2,9 @@ import { createEngine } from "../src/index.js";
 import fs from "node:fs";
 import assert from "node:assert";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const normalizeFilePath = (content: string): string => {
     return content.replace(__dirname, "[TEST_DIR]");
 };

--- a/packages/@secretlint/quick-start/src/index.ts
+++ b/packages/@secretlint/quick-start/src/index.ts
@@ -1,8 +1,10 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import { cli, run } from "secretlint/cli";
 
 export const quickStart = async () => {
     // Override secretlintrc with quick-start pkg if it is not defined.
-    const defaultSecretlintRc = new URL("../config/.secretlintrc.json", import.meta.url).pathname;
+    const defaultSecretlintRc = path.resolve(fileURLToPath(import.meta.url), "../config/.secretlintrc.json");
     const flags: typeof cli.flags = {
         ...cli.flags,
         secretlintrc: cli.flags.secretlintrc ?? defaultSecretlintRc,

--- a/packages/@secretlint/quick-start/src/index.ts
+++ b/packages/@secretlint/quick-start/src/index.ts
@@ -4,7 +4,8 @@ import { cli, run } from "secretlint/cli";
 
 export const quickStart = async () => {
     // Override secretlintrc with quick-start pkg if it is not defined.
-    const defaultSecretlintRc = path.resolve(fileURLToPath(import.meta.url), "../config/.secretlintrc.json");
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const defaultSecretlintRc = path.resolve(__dirname, "../config/.secretlintrc.json");
     const flags: typeof cli.flags = {
         ...cli.flags,
         secretlintrc: cli.flags.secretlintrc ?? defaultSecretlintRc,

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -1,12 +1,13 @@
 import fs from "node:fs";
 import test from "node:test";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import assert from "node:assert";
 import { results } from "./snapshots/input.js";
 import formatter from "../src/index.js";
 import escapeStringRegexp from "escape-string-regexp";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const snapshotsDir = path.join(__dirname, "snapshots");
 const snapshotReplace = (value: string) => {
     return value.replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]");

--- a/packages/@secretlint/secretlint-formatter-sarif/test/snapshots/input.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/snapshots/input.ts
@@ -1,6 +1,7 @@
 import { SecretLintCoreResult } from "@secretlint/types";
 import path from "node:path";
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+import { fileURLToPath } from "node:url";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const results: SecretLintCoreResult[] = [
     {
         filePath: path.join(__dirname, "input.txt"),

--- a/packages/@secretlint/secretlint-rule-preset-recommend/import-tests.js
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/import-tests.js
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packagesDir = path.join(__dirname, "../");
 const ruleDirs = fs
     .readdirSync(packagesDir, {

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/index.test.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 // Test target is bundled file
 import { creator as rule } from "../module/index.js";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 test("Snapshot Testing", async (t) => {
     const snapshot = (await import("@secretlint/tester")).snapshot;
     const eachRulesDir = fs

--- a/packages/@secretlint/source-creator/test/index.test.ts
+++ b/packages/@secretlint/source-creator/test/index.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import assert from "node:assert";
 import { createRawSource } from "../src/index.js";
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixturesDir = path.join(__dirname, "snapshots");
 const createSnapshotReplacer = () => {
     return (key: string, value: any) => {


### PR DESCRIPTION
Fix the __dirname mimic to remove a leading slash in it by using fileURLToPath instead.

Closes #562.

Ref: https://humanwhocodes.com/snippets/2023/01/mimicking-dirname-filename-nodejs-esm/

I checked through the repo and replaced all `__dirname`.