### PR TITLE
fix: stop using path.posix

### DIFF
--- a/packages/secretlint/src/search.ts
+++ b/packages/secretlint/src/search.ts
@@ -16,11 +16,10 @@ export type SearchFilesOptions = {
 };
 
 const mapGitIgnorePatternTo = (base: string) => (ignore: string) => {
-    if (ignore.startsWith("!")) {
-        return "!" + path.posix.resolve(path.posix.join(base, ignore.slice(1)));
-    }
-
-    return path.posix.resolve(path.posix.join(base, ignore));
+    const mapped = ignore.startsWith("!")
+        ? "!" + path.resolve(path.join(base, ignore.slice(1)))
+        : path.resolve(path.join(base, ignore));
+    return mapped.replace(/\\/g, "/");
 };
 /**
  * globby wrapper that support ignore options


### PR DESCRIPTION
Fixes #589

The usage of `path.posix` causes the error because it does not handle the drive name in Windows correctly, so stop using it.
However, `globby` or `fast-glob`, its dependent, only supports forward-slash so replace double back slashes with it.

https://github.com/mrmlnc/fast-glob#pattern-syntax