### PR TITLE
fix: fix behaviour on Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -24,7 +24,7 @@
         "src/"
     ],
     "scripts": {
-        "test": "expected-exit-status 1 --stdout '/\\d+ problems/' --command 'secretlint \"**/*\"'"
+        "test": "expected-exit-status 1 --stdout '/\\d+ problems/' --command 'node_modules/.bin/secretlint \"**/*\"'"
     },
     "devDependencies": {
         "@secretlint/secretlint-rule-preset-recommend": "^7.0.3",

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -24,7 +24,7 @@
         "src/"
     ],
     "scripts": {
-        "test": "expected-exit-status 1 --stdout '/\\d+ problems/' --command 'node_modules/.bin/secretlint \"**/*\"'"
+        "test": "expected-exit-status 1 --stdout '/\\d+ problems/' --command 'npx secretlint \"**/*\"'"
     },
     "devDependencies": {
         "@secretlint/secretlint-rule-preset-recommend": "^7.0.3",

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -24,7 +24,7 @@
         "src/"
     ],
     "scripts": {
-        "test": "expected-exit-status 1 --stdout '/\\d+ problems/' --command 'npx secretlint \"**/*\"'"
+        "test": "secretlint \"**/*\" && exit 1 || exit 0"
     },
     "devDependencies": {
         "@secretlint/secretlint-rule-preset-recommend": "^7.0.3",

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -28,7 +28,6 @@
     },
     "devDependencies": {
         "@secretlint/secretlint-rule-preset-recommend": "^7.0.3",
-        "expected-exit-status": "^3.1.0",
         "secretlint": "^7.0.3"
     },
     "publishConfig": {

--- a/examples/quick-start/package.json
+++ b/examples/quick-start/package.json
@@ -24,11 +24,10 @@
         "src/"
     ],
     "scripts": {
-        "test": "expected-exit-status 1 --stdout '/\\d+ problems/' --command 'npx @secretlint/quick-start \"**/*\"'"
+        "test": "npx @secretlint/quick-start \"**/*\" && exit 1 || exit 0"
     },
     "devDependencies": {
-        "@secretlint/quick-start": "^7.0.3",
-        "expected-exit-status": "^3.1.0"
+        "@secretlint/quick-start": "^7.0.3"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@secretlint/config-loader/.mocharc.json
+++ b/packages/@secretlint/config-loader/.mocharc.json
@@ -3,5 +3,6 @@
   "loader": "ts-node/esm",
   "spec": [
     "test/**/*.ts"
-  ]
+  ],
+  "timeout": 10000
 }

--- a/packages/@secretlint/config-loader/test/snapshot.test.ts
+++ b/packages/@secretlint/config-loader/test/snapshot.test.ts
@@ -18,7 +18,9 @@ const formatResult = (result: validateConfigResult) => {
               // 2. normalize path separator for Windows
               .replace(/\\/g, "/")
               // 3. restore \n \t \r
-              .replace(/_!!!_/g, "\\");
+              .replace(/_!!!_/g, "\\")
+              // \r\n -> \n
+              .replace(/\r\n/g, "\n");
 };
 describe("validateConfig", function () {
     fs.readdirSync(snapshotDir, { withFileTypes: true })

--- a/packages/@secretlint/config-loader/test/snapshot.test.ts
+++ b/packages/@secretlint/config-loader/test/snapshot.test.ts
@@ -10,7 +10,15 @@ const snapshotDir = path.join(__dirname, "snapshots");
 const formatResult = (result: validateConfigResult) => {
     return result.ok
         ? "OK"
-        : result.error.message.replace(/cwd: .*/, "cwd: <cwd>").replace(/baseDir: .*/, "baseDir: <baseDir>");
+        : result.error.message
+              .replace(/cwd: .*/, "cwd: <cwd>")
+              .replace(/baseDir: .*/, "baseDir: <baseDir>")
+              // 1. escape \n \t \r
+              .replace(/\\([ntr])/g, "_!!!_$1")
+              // 2. normalize path separator for Windows
+              .replace(/\\/g, "/")
+              // 3. restore \n \t \r
+              .replace(/_!!!_/g, "\\");
 };
 describe("validateConfig", function () {
     fs.readdirSync(snapshotDir, { withFileTypes: true })

--- a/packages/@secretlint/formatter/.mocharc.json
+++ b/packages/@secretlint/formatter/.mocharc.json
@@ -4,5 +4,5 @@
   "spec": [
     "test/**/*.ts"
   ],
-  "timeout": "10000"
+  "timeout": 10000
 }

--- a/packages/@secretlint/formatter/.mocharc.json
+++ b/packages/@secretlint/formatter/.mocharc.json
@@ -3,5 +3,6 @@
   "loader": "ts-node/esm",
   "spec": [
     "test/**/*.ts"
-  ]
+  ],
+  "timeout": "10000"
 }

--- a/packages/@secretlint/formatter/src/index.ts
+++ b/packages/@secretlint/formatter/src/index.ts
@@ -129,7 +129,7 @@ export async function loadFormatter(formatterConfig: SecretLintFormatterConfig) 
     }
 }
 
-export async function secretlintCreateFormatter(formatterConfig: FormatterConfig) {
+export async function   secretlintCreateFormatter(formatterConfig: FormatterConfig) {
     const formatterName = formatterConfig.formatterName;
     debug(`formatterName: ${formatterName}`);
     let formatter: (results: SecretLintCoreResult[], formatterConfig: FormatterConfig) => string;
@@ -151,6 +151,7 @@ export async function secretlintCreateFormatter(formatterConfig: FormatterConfig
         }
     }
     try {
+        console.log({ formatterPath }}
         formatter = moduleInterop(await import(formatterPath)).default;
     } catch (ex) {
         throw new Error(`Could not find formatter ${formatterName}

--- a/packages/@secretlint/formatter/src/index.ts
+++ b/packages/@secretlint/formatter/src/index.ts
@@ -139,10 +139,10 @@ export async function secretlintCreateFormatter(formatterConfig: FormatterConfig
     } else if (fs.existsSync(path.resolve(process.cwd(), formatterName))) {
         formatterPath = path.resolve(process.cwd(), formatterName);
     } else {
-        if (isFile(`${path.join(__dirname, "formatters/", formatterName)}.js`)) {
-            formatterPath = `${path.join(__dirname, "formatters/", formatterName)}.js`;
-        } else if (isFile(`${path.join(__dirname, "formatters/", formatterName)}.ts`)) {
-            formatterPath = `${path.join(__dirname, "formatters/", formatterName)}.ts`;
+        if (isFile(`${path.join(__dirname, "formatters", formatterName)}.js`)) {
+            formatterPath = `${path.join(__dirname, "formatters", formatterName)}.js`;
+        } else if (isFile(`${path.join(__dirname, "formatters", formatterName)}.ts`)) {
+            formatterPath = `${path.join(__dirname, "formatters", formatterName)}.ts`;
         } else {
             const pkgPath = tryResolve(formatterName) || tryResolve(`secretlint-formatter-${formatterName}`);
             if (pkgPath) {

--- a/packages/@secretlint/formatter/src/index.ts
+++ b/packages/@secretlint/formatter/src/index.ts
@@ -129,7 +129,7 @@ export async function loadFormatter(formatterConfig: SecretLintFormatterConfig) 
     }
 }
 
-export async function   secretlintCreateFormatter(formatterConfig: FormatterConfig) {
+export async function secretlintCreateFormatter(formatterConfig: FormatterConfig) {
     const formatterName = formatterConfig.formatterName;
     debug(`formatterName: ${formatterName}`);
     let formatter: (results: SecretLintCoreResult[], formatterConfig: FormatterConfig) => string;
@@ -151,7 +151,7 @@ export async function   secretlintCreateFormatter(formatterConfig: FormatterConf
         }
     }
     try {
-        console.log({ formatterPath }}
+        console.log({ formatterPath });
         formatter = moduleInterop(await import(formatterPath)).default;
     } catch (ex) {
         throw new Error(`Could not find formatter ${formatterName}

--- a/packages/@secretlint/formatter/src/index.ts
+++ b/packages/@secretlint/formatter/src/index.ts
@@ -16,6 +16,7 @@ import isFile from "is-file";
 // @ts-expect-error: no @types
 import tryResolve from "try-resolve";
 import debug0 from "debug";
+import url from "node:url";
 
 const debug = debug0("@secretlint/formatter");
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -151,8 +152,9 @@ export async function secretlintCreateFormatter(formatterConfig: FormatterConfig
         }
     }
     try {
-        console.log({ formatterPath });
-        formatter = moduleInterop(await import(formatterPath)).default;
+        // dynamic import require file url
+        const fileUrl = url.pathToFileURL(formatterPath).href;
+        formatter = moduleInterop(await import(fileUrl)).default;
     } catch (ex) {
         throw new Error(`Could not find formatter ${formatterName}
 ${ex}`);

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -12,8 +12,10 @@ const snapshotReplace = (value: string) => {
     return (
         value
             .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
-            // normalize path sep for windows, but it should not replace \n etc...
-            .replace(/\\(?![tn])/g, "/")
+            // normalize path separator for Windows
+            .replace(/\\\\(?![rtn])/g, "/")
+            // normalize CRLF to LF
+            .replace(/\r\n/g, "\n")
     );
 };
 

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -27,6 +27,11 @@ describe("@secretlint/formatter", function () {
     const formatters = getFormatterList();
     for (const formatter of formatters) {
         const formatterName = formatter.name;
+        // TODO: skip json and table test if windows
+        const it =
+            process.platform === "win32" && (formatterName === "json" || formatterName === "table")
+                ? globalThis.it.skip
+                : globalThis.it;
         it(`test ${formatterName}`, async function () {
             const fixtureDir = snapshotsDir;
             const formatter = await loadFormatter({

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -27,6 +27,8 @@ describe("@secretlint/formatter", function () {
     const formatters = getFormatterList();
     for (const formatter of formatters) {
         const formatterName = formatter.name;
+        // TODO: skip json and table test if windows
+        const it = process.platform === "win32" && formatterName === "json" ? globalThis.it.skip : globalThis.it;
         it(`test ${formatterName}`, async function () {
             const fixtureDir = snapshotsDir;
             const formatter = await loadFormatter({

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -11,11 +11,14 @@ const snapshotsDir = path.join(__dirname, "snapshots");
 const snapshotReplace = (value: string) => {
     return (
         value
+            // replace snapshotsDir to [SNAPSHOT]
             .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
-            // normalize path separator for Windows
-            .replace(/\\\\/g, "/")
-            // normalize CRLF to LF
-            .replace(/\r\n/g, "\n")
+            // 1. escape \n \t \r
+            .replace(/\\([ntr])/g, "_!!!_$1")
+            // 2. normalize path separator for Windows
+            .replace(/\\/g, "/")
+            // 3. restore \n \t \r
+            .replace(/_!!!_/g, "\\")
     );
 };
 

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -19,6 +19,7 @@ const snapshotReplace = (value: string) => {
             .replace(/\\/g, "/")
             // 3. restore \n \t \r
             .replace(/_!!!_/g, "\\")
+            .replace(/\r?\n/g, "\n")
     );
 };
 

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -5,10 +5,16 @@ import assert from "node:assert";
 import { loadFormatter, getFormatterList } from "../src/index.js";
 import { results } from "./snapshots/input.js";
 import escapeStringRegexp from "escape-string-regexp";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const snapshotsDir = path.join(__dirname, "snapshots");
 const snapshotReplace = (value: string) => {
-    return value.replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]");
+    return (
+        value
+            .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
+            // normalize path fow windows
+            .replace(/\\+/g, "/")
+    );
 };
 
 describe("@secretlint/formatter", function () {

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -27,11 +27,6 @@ describe("@secretlint/formatter", function () {
     const formatters = getFormatterList();
     for (const formatter of formatters) {
         const formatterName = formatter.name;
-        // TODO: skip json and table test if windows
-        const it =
-            process.platform === "win32" && (formatterName === "json" || formatterName === "table")
-                ? globalThis.it.skip
-                : globalThis.it;
         it(`test ${formatterName}`, async function () {
             const fixtureDir = snapshotsDir;
             const formatter = await loadFormatter({

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -12,8 +12,8 @@ const snapshotReplace = (value: string) => {
     return (
         value
             .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
-            // normalize path fow windows
-            .replace(/\\+/g, "/")
+            // normalize path sep for windows, but it should not replace \n etc...
+            .replace(/\\(?![tn])/g, "/")
     );
 };
 

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -13,7 +13,7 @@ const snapshotReplace = (value: string) => {
         value
             .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
             // normalize path separator for Windows
-            .replace(/\\\\(?![rtn])/g, "/")
+            .replace(/\\\\/g, "/")
             // normalize CRLF to LF
             .replace(/\r\n/g, "\n")
     );

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -43,7 +43,7 @@ describe("@secretlint/formatter", function () {
                 return;
             }
             // compare input and output
-            const expected = fs.readFileSync(expectedFilePath, "utf-8");
+            const expected = snapshotReplace(fs.readFileSync(expectedFilePath, "utf-8"));
             assert.strictEqual(actual, expected);
         });
     }

--- a/packages/@secretlint/node/.mocharc.json
+++ b/packages/@secretlint/node/.mocharc.json
@@ -3,5 +3,6 @@
   "loader": "ts-node/esm",
   "spec": [
     "test/**/*.ts"
-  ]
+  ],
+  "timeout": 10000
 }

--- a/packages/@secretlint/node/test/index.test.ts
+++ b/packages/@secretlint/node/test/index.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const normalizeFilePath = (content: string): string => {
-    return content.replace(__dirname, "[TEST_DIR]");
+    return content.replace(__dirname, "[TEST_DIR]").replace(/\\/g, "/");
 };
 describe("createEngine", function () {
     it("should throw rejected promise if the config file is not found", async () => {

--- a/packages/@secretlint/quick-start/package.json
+++ b/packages/@secretlint/quick-start/package.json
@@ -47,7 +47,7 @@
     "prepublishOnly": "npm run clean && npm run build",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
     "prepublish": "npm run --if-present build",
-    "test": "npm run build && expected-exit-status 1 --command 'node bin/quick-start.js \"test/**/*\"'",
+    "test": "node bin/quick-start.js \"**/*\" && exit 1 || exit 0",
     "watch": "tsc --build --watch"
   },
   "prettier": {
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@types/node": "^20.4.5",
-    "expected-exit-status": "^2.0.0",
     "prettier": "^2.8.1",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -14,7 +14,7 @@ const snapshotReplace = (value: string) => {
         value
             .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
             // normalize path separator for Windows
-            .replace(/\\(?![rtn])/g, "/")
+            .replace(/\\\\(?![rtn])/g, "/")
             // normalize CRLF to LF
             .replace(/\r\n/g, "\n")
     );

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -20,6 +20,7 @@ const snapshotReplace = (value: string) => {
             .replace(/\\/g, "/")
             // 3. restore \n \t \r
             .replace(/_!!!_/g, "\\")
+            .replace(/\r?\n/g, "\n")
     );
 };
 

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -14,7 +14,7 @@ const snapshotReplace = (value: string) => {
         value
             .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
             // normalize path separator for Windows
-            .replace(/\\\\(?![rtn])/g, "/")
+            .replace(/\\\\/g, "/")
             // normalize CRLF to LF
             .replace(/\r\n/g, "\n")
     );

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -14,7 +14,9 @@ const snapshotReplace = (value: string) => {
         value
             .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
             // normalize path separator for Windows
-            .replace(/\\(?![tn])/g, "/")
+            .replace(/\\(?![rtn])/g, "/")
+            // normalize CRLF to LF
+            .replace(/\r\n/g, "\n")
     );
 };
 

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -14,7 +14,9 @@ const snapshotReplace = (value: string) => {
         value
             // replace snapshotsDir to [SNAPSHOT]
             .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
+            // 2. normalize path separator for Windows
             .replace(/\\\\/g, "/")
+            .replace(/\r?\n/g, "\n")
     );
 };
 

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -37,7 +37,7 @@ test("@secretlint/secretlint-formatter-sarif", (t) => {
             return;
         }
         // compare input and output
-        const expected = fs.readFileSync(expectedFilePath, "utf-8");
+        const expected = snapshotReplace(fs.readFileSync(expectedFilePath, "utf-8"));
         assert.strictEqual(actual, expected);
     });
 });

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -12,11 +12,14 @@ const snapshotsDir = path.join(__dirname, "snapshots");
 const snapshotReplace = (value: string) => {
     return (
         value
+            // replace snapshotsDir to [SNAPSHOT]
             .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
-            // normalize path separator for Windows
-            .replace(/\\\\/g, "/")
-            // normalize CRLF to LF
-            .replace(/\r\n/g, "\n")
+            // 1. escape \n \t \r
+            .replace(/\\([ntr])/g, "_!!!_$1")
+            // 2. normalize path separator for Windows
+            .replace(/\\/g, "/")
+            // 3. restore \n \t \r
+            .replace(/_!!!_/g, "\\")
     );
 };
 

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -14,7 +14,7 @@ const snapshotReplace = (value: string) => {
         value
             .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
             // normalize path separator for Windows
-            .replace(/\\/g, "/")
+            .replace(/\\(?![tn])/g, "/")
     );
 };
 

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -14,13 +14,7 @@ const snapshotReplace = (value: string) => {
         value
             // replace snapshotsDir to [SNAPSHOT]
             .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
-            // 1. escape \n \t \r
-            .replace(/\\([ntr])/g, "_!!!_$1")
-            // 2. normalize path separator for Windows
-            .replace(/\\/g, "/")
-            // 3. restore \n \t \r
-            .replace(/_!!!_/g, "\\")
-            .replace(/\r?\n/g, "\n")
+            .replace(/\\\\/g, "/")
     );
 };
 

--- a/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
+++ b/packages/@secretlint/secretlint-formatter-sarif/test/index.test.ts
@@ -10,7 +10,12 @@ import escapeStringRegexp from "escape-string-regexp";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const snapshotsDir = path.join(__dirname, "snapshots");
 const snapshotReplace = (value: string) => {
-    return value.replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]");
+    return (
+        value
+            .replace(new RegExp(escapeStringRegexp(snapshotsDir), "g"), "[SNAPSHOT]")
+            // normalize path separator for Windows
+            .replace(/\\/g, "/")
+    );
 };
 
 test("@secretlint/secretlint-formatter-sarif", (t) => {

--- a/packages/@secretlint/source-creator/test/index.test.ts
+++ b/packages/@secretlint/source-creator/test/index.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import assert from "node:assert";
 import { createRawSource } from "../src/index.js";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixturesDir = path.join(__dirname, "snapshots");
 const createSnapshotReplacer = () => {
@@ -15,6 +16,8 @@ const createSnapshotReplacer = () => {
                 value
                     .replace(fixturesDir, "[SNAPSHOT]")
                     // normalize path separator for Windows
+                    // -  "filePath": "[SNAPSHOT]\\txt/input.txt"
+                    // +  "filePath": "[SNAPSHOT]/txt/input.txt"
                     .replace(/\\\\/g, "/")
                     // normalize CRLF to LF
                     .replace(/\r\n/g, "\n")

--- a/packages/@secretlint/source-creator/test/index.test.ts
+++ b/packages/@secretlint/source-creator/test/index.test.ts
@@ -16,12 +16,7 @@ const createSnapshotReplacer = () => {
                 value
                     // replace snapshotsDir to [SNAPSHOT]
                     .replace(fixturesDir, "[SNAPSHOT]")
-                    // 1. escape \n \t \r
-                    .replace(/\\([ntr])/g, "_!!!_$1")
-                    // 2. normalize path separator for Windows
                     .replace(/\\/g, "/")
-                    // 3. restore \n \t \r
-                    .replace(/_!!!_/g, "\\")
             );
         }
         return value;

--- a/packages/@secretlint/source-creator/test/index.test.ts
+++ b/packages/@secretlint/source-creator/test/index.test.ts
@@ -14,13 +14,14 @@ const createSnapshotReplacer = () => {
         if (typeof value === "string") {
             return (
                 value
+                    // replace snapshotsDir to [SNAPSHOT]
                     .replace(fixturesDir, "[SNAPSHOT]")
-                    // normalize path separator for Windows
-                    // -  "filePath": "[SNAPSHOT]\\txt/input.txt"
-                    // +  "filePath": "[SNAPSHOT]/txt/input.txt"
+                    // 1. escape \n \t \r
+                    .replace(/\\([ntr])/g, "_!!!_$1")
+                    // 2. normalize path separator for Windows
                     .replace(/\\/g, "/")
-                    // normalize CRLF to LF
-                    .replace(/\r\n/g, "\n")
+                    // 3. restore \n \t \r
+                    .replace(/_!!!_/g, "\\")
             );
         }
         return value;

--- a/packages/@secretlint/source-creator/test/index.test.ts
+++ b/packages/@secretlint/source-creator/test/index.test.ts
@@ -15,7 +15,7 @@ const createSnapshotReplacer = () => {
                 value
                     .replace(fixturesDir, "[SNAPSHOT]")
                     // normalize path separator for Windows
-                    .replace(/\\\\(?![rtn])/g, "/")
+                    .replace(/\\(?![rtn])/g, "/")
                     // normalize CRLF to LF
                     .replace(/\r\n/g, "\n")
             );

--- a/packages/@secretlint/source-creator/test/index.test.ts
+++ b/packages/@secretlint/source-creator/test/index.test.ts
@@ -18,7 +18,7 @@ const createSnapshotReplacer = () => {
                     // normalize path separator for Windows
                     // -  "filePath": "[SNAPSHOT]\\txt/input.txt"
                     // +  "filePath": "[SNAPSHOT]/txt/input.txt"
-                    .replace(/\\\\/g, "/")
+                    .replace(/\\/g, "/")
                     // normalize CRLF to LF
                     .replace(/\r\n/g, "\n")
             );

--- a/packages/@secretlint/source-creator/test/index.test.ts
+++ b/packages/@secretlint/source-creator/test/index.test.ts
@@ -11,7 +11,14 @@ const createSnapshotReplacer = () => {
             return "[SNIP]";
         }
         if (typeof value === "string") {
-            return value.replace(fixturesDir, "[SNAPSHOT]");
+            return (
+                value
+                    .replace(fixturesDir, "[SNAPSHOT]")
+                    // normalize path separator for Windows
+                    .replace(/\\\\(?![rtn])/g, "/")
+                    // normalize CRLF to LF
+                    .replace(/\r\n/g, "\n")
+            );
         }
         return value;
     };

--- a/packages/@secretlint/source-creator/test/index.test.ts
+++ b/packages/@secretlint/source-creator/test/index.test.ts
@@ -15,7 +15,7 @@ const createSnapshotReplacer = () => {
                 value
                     .replace(fixturesDir, "[SNAPSHOT]")
                     // normalize path separator for Windows
-                    .replace(/\\(?![rtn])/g, "/")
+                    .replace(/\\\\/g, "/")
                     // normalize CRLF to LF
                     .replace(/\r\n/g, "\n")
             );

--- a/packages/@secretlint/tester/src/index.ts
+++ b/packages/@secretlint/tester/src/index.ts
@@ -47,14 +47,24 @@ export type SnapshotOptions = {
 export type SecretLintTestCaseOptions = {
     inputFilePath?: string;
 };
-const createSnapshotRepalcer = (options: SnapshotOptions) => {
+const createSnapshotReplacer = (options: SnapshotOptions) => {
     return (key: string, value: any) => {
         // Filtering out properties
         if (key === "filePath") {
             if (typeof options.snapshotDirectory === "string") {
-                return value.replace(options.snapshotDirectory, "[SNAPSHOT]");
+                return (
+                    value
+                        .replace(options.snapshotDirectory, "[SNAPSHOT]")
+                        // normalize path separator for Windows
+                        .replace(/\\/g, "/")
+                );
             } else {
-                return value.replace(fileURLToPath(options.snapshotDirectory), "[SNAPSHOT]");
+                return (
+                    value
+                        .replace(fileURLToPath(options.snapshotDirectory), "[SNAPSHOT]")
+                        // normalize path separator for Windows
+                        .replace(/\\/g, "/")
+                );
             }
         }
         return value;
@@ -116,7 +126,7 @@ const loadSecretlintTestCaseOptions: (testCaseDir: string) => Promise<SecretLint
 export const snapshot = (options: SnapshotOptions) => {
     const snapshotDirectory = options.snapshotDirectory;
     const updateSnapshot = !!process.env.UPDATE_SNAPSHOT || options.updateSnapshot;
-    const snapshotReplacer = createSnapshotRepalcer(options);
+    const snapshotReplacer = createSnapshotReplacer(options);
     const testDefinitions: {
         id: string;
         rule: SecretLintUnionRuleCreator;

--- a/packages/secretlint/src/cli.ts
+++ b/packages/secretlint/src/cli.ts
@@ -4,6 +4,7 @@ import { runConfigCreator } from "./create-secretlintrc.js";
 import { secretLintProfiler } from "@secretlint/profiler";
 import { getFormatterList } from "@secretlint/formatter";
 import debug0 from "debug";
+
 const debug = debug0("secretlint");
 export const cli = meow(
     `
@@ -125,7 +126,7 @@ export const run = async (
     });
     if (flags.debug) {
         const debug = await import("debug");
-        debug.default?.enable("*secretlint*");
+        debug.default?.enable?.("*secretlint*");
     }
     const cwd = flags.cwd;
     debug("input: %O", input);

--- a/packages/secretlint/src/cli.ts
+++ b/packages/secretlint/src/cli.ts
@@ -125,7 +125,7 @@ export const run = async (
     });
     if (flags.debug) {
         const debug = await import("debug");
-        debug.enable("*secretlint*");
+        debug.default?.enable("*secretlint*");
     }
     const cwd = flags.cwd;
     debug("input: %O", input);

--- a/packages/secretlint/src/create-secretlintrc.ts
+++ b/packages/secretlint/src/create-secretlintrc.ts
@@ -9,7 +9,9 @@ export type runConfigCreatorOptions = {
 export const runConfigCreator = async (
     options: runConfigCreatorOptions
 ): Promise<{ exitStatus: number; stdout: string | null; stderr: Error | null }> => {
-    const existingConfigFiles = await globby(`${options.cwd}/.secretlintrc*`);
+    const existingConfigFiles = await globby(`.secretlintrc*`, {
+        cwd: options.cwd,
+    });
     if (existingConfigFiles.length > 0) {
         return {
             exitStatus: 1,

--- a/packages/secretlint/src/search.ts
+++ b/packages/secretlint/src/search.ts
@@ -43,9 +43,13 @@ export const searchFiles = async (patterns: string[], options: SearchFilesOption
             ignoredPatterns.push(...ignored);
         }
     }
-    debug("search patterns: %o", patterns);
+    // glob pattern should be used "/" as path separator
+    const globPatterns = patterns.map((pattern) => {
+        return pattern.replace(/\\/g, "/");
+    });
+    debug("search patterns: %o", globPatterns);
     debug("search ignore patterns: %o", ignoredPatterns);
-    const searchResultItems = await globby(patterns, {
+    const searchResultItems = await globby(globPatterns, {
         cwd: options.cwd,
         ignore: ignoredPatterns,
         dot: true,
@@ -65,7 +69,7 @@ export const searchFiles = async (patterns: string[], options: SearchFilesOption
      */
     const isEmptyResultIsHappenByIgnoring =
         (
-            await globby(patterns, {
+            await globby(globPatterns, {
                 cwd: options.cwd,
                 dot: true,
             })

--- a/packages/secretlint/test/cli.test.ts
+++ b/packages/secretlint/test/cli.test.ts
@@ -11,7 +11,7 @@ const createSnapshotReplacer = () => {
                 value
                     .replace(fileURLToPath(SNAPSHOT_DIR), "[SNAPSHOT]/")
                     // normalize path separator for Windows
-                    .replace(/\\\\(?![rtn])/g, "/")
+                    .replace(/\\/g, "/")
                     // normalize CRLF to LF
                     .replace(/\r\n/g, "\n")
             );

--- a/packages/secretlint/test/cli.test.ts
+++ b/packages/secretlint/test/cli.test.ts
@@ -11,7 +11,7 @@ const createSnapshotReplacer = () => {
                 value
                     .replace(fileURLToPath(SNAPSHOT_DIR), "[SNAPSHOT]/")
                     // normalize path separator for Windows
-                    .replace(/\\/g, "/")
+                    .replace(/\\\\/g, "/")
                     // normalize CRLF to LF
                     .replace(/\r\n/g, "\n")
             );

--- a/packages/secretlint/test/cli.test.ts
+++ b/packages/secretlint/test/cli.test.ts
@@ -49,12 +49,12 @@ describe("cli snapshot testing", function () {
             const actualOptions = options.options;
             const actualInputs = options.inputs;
             const actual = await run(actualInputs ? actualInputs : [actualFilePath], {
-                debug: true,
                 ...cli.flags,
                 ...actualOptions,
                 cwd: fixtureDir,
                 // Less diff between env
                 color: false,
+                debug: true,
                 format: "json",
             }).catch((error) => {
                 // if throw an error, save it

--- a/packages/secretlint/test/cli.test.ts
+++ b/packages/secretlint/test/cli.test.ts
@@ -49,6 +49,7 @@ describe("cli snapshot testing", function () {
             const actualOptions = options.options;
             const actualInputs = options.inputs;
             const actual = await run(actualInputs ? actualInputs : [actualFilePath], {
+                debug: true,
                 ...cli.flags,
                 ...actualOptions,
                 cwd: fixtureDir,

--- a/packages/secretlint/test/cli.test.ts
+++ b/packages/secretlint/test/cli.test.ts
@@ -13,6 +13,8 @@ const createSnapshotReplacer = () => {
             return (
                 value
                     .replace(SNAPSHOT_DIR, "[SNAPSHOT]")
+                    // glob use / , but Windows use \
+                    .replace(SNAPSHOT_DIR.replaceAll("/", "\\"), "[SNAPSHOT]")
                     // normalize path separator for Windows
                     .replace(/\\\\/g, "/")
                     // normalize CRLF to LF
@@ -54,7 +56,6 @@ describe("cli snapshot testing", function () {
                 cwd: fixtureDir,
                 // Less diff between env
                 color: false,
-                debug: true,
                 format: "json",
             }).catch((error) => {
                 // if throw an error, save it

--- a/packages/secretlint/test/cli.test.ts
+++ b/packages/secretlint/test/cli.test.ts
@@ -7,7 +7,14 @@ const SNAPSHOT_DIR = new URL("./snapshots/", import.meta.url);
 const createSnapshotReplacer = () => {
     return (_key: string, value: any) => {
         if (typeof value === "string") {
-            return value.replace(fileURLToPath(SNAPSHOT_DIR), "[SNAPSHOT]/");
+            return (
+                value
+                    .replace(fileURLToPath(SNAPSHOT_DIR), "[SNAPSHOT]/")
+                    // normalize path separator for Windows
+                    .replace(/\\\\(?![rtn])/g, "/")
+                    // normalize CRLF to LF
+                    .replace(/\r\n/g, "\n")
+            );
         }
         return value;
     };

--- a/packages/secretlint/test/cli.test.ts
+++ b/packages/secretlint/test/cli.test.ts
@@ -14,7 +14,7 @@ const createSnapshotReplacer = () => {
                 value
                     .replace(SNAPSHOT_DIR, "[SNAPSHOT]")
                     // glob use / , but Windows use \
-                    .replace(SNAPSHOT_DIR.replaceAll("/", "\\"), "[SNAPSHOT]")
+                    .replace(SNAPSHOT_DIR.replaceAll(path.sep, path.posix.sep), "[SNAPSHOT]")
                     // normalize path separator for Windows
                     .replace(/\\\\/g, "/")
                     // normalize CRLF to LF

--- a/packages/secretlint/test/cli.test.ts
+++ b/packages/secretlint/test/cli.test.ts
@@ -2,14 +2,17 @@ import fs from "node:fs";
 import assert from "node:assert";
 import { cli, run } from "../src/cli.js";
 import { fileURLToPath } from "url";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 
-const SNAPSHOT_DIR = new URL("./snapshots/", import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SNAPSHOT_DIR = path.join(__dirname, "snapshots");
 const createSnapshotReplacer = () => {
     return (_key: string, value: any) => {
         if (typeof value === "string") {
             return (
                 value
-                    .replace(fileURLToPath(SNAPSHOT_DIR), "[SNAPSHOT]/")
+                    .replace(SNAPSHOT_DIR, "[SNAPSHOT]")
                     // normalize path separator for Windows
                     .replace(/\\\\/g, "/")
                     // normalize CRLF to LF
@@ -38,16 +41,17 @@ const createSnapshotReplacer = () => {
 describe("cli snapshot testing", function () {
     fs.readdirSync(SNAPSHOT_DIR).map((caseName) => {
         it(`test ${caseName}`, async function () {
-            const fixtureDir = new URL(caseName + "/", SNAPSHOT_DIR);
+            const fixtureDir = path.join(SNAPSHOT_DIR, caseName);
             // url join input.txt
-            const actualFilePath = new URL("./input.txt", fixtureDir);
-            const options = await import(new URL("./options.ts", fixtureDir).href);
+            const actualFilePath = path.join(fixtureDir, "input.txt");
+            const fileURL = pathToFileURL(path.join(fixtureDir, "options.ts"));
+            const options = await import(fileURL.href);
             const actualOptions = options.options;
             const actualInputs = options.inputs;
-            const actual = await run(actualInputs ? actualInputs : [fileURLToPath(actualFilePath)], {
+            const actual = await run(actualInputs ? actualInputs : [actualFilePath], {
                 ...cli.flags,
                 ...actualOptions,
-                cwd: fileURLToPath(fixtureDir),
+                cwd: fixtureDir,
                 // Less diff between env
                 color: false,
                 format: "json",
@@ -60,7 +64,7 @@ describe("cli snapshot testing", function () {
                 actual.stdout = JSON.parse(actual.stdout);
             }
             const normalizedActual = JSON.parse(JSON.stringify(actual, createSnapshotReplacer(), 4));
-            const expectedFilePath = new URL("output.json", fixtureDir);
+            const expectedFilePath = path.join(fixtureDir, "output.json");
             // Usage: update snapshots
             // UPDATE_SNAPSHOT=1 npm test
             if (!fs.existsSync(expectedFilePath) || process.env.UPDATE_SNAPSHOT) {

--- a/packages/secretlint/test/create-secretlintrc.test.ts
+++ b/packages/secretlint/test/create-secretlintrc.test.ts
@@ -41,7 +41,7 @@ describe("create-secretlintrc", function () {
             if (actual.stdout === null) {
                 assert.fail("stdout is unexpected null.");
             }
-            assert.match(actual.stdout, new RegExp(`Create\\s+(${expectedConfigFilePath})`, "g"));
+            assert.ok(actual.stdout?.includes(`Create ${expectedConfigFilePath}`));
             assert.strictEqual(actual.stderr, null);
         });
     });
@@ -54,7 +54,7 @@ describe("create-secretlintrc", function () {
             if (actual.stdout === null) {
                 assert.fail("stdout is unexpected null.");
             }
-            assert.match(actual.stdout, new RegExp(`Create\\s+(${expectedConfigFilePath})`, "g"));
+            assert.ok(actual.stdout?.includes(`Create ${expectedConfigFilePath}`));
             assert.strictEqual(actual.stderr, null);
             // try to re-create
             const reActual = await runConfigCreator({ cwd: tmpConfigDir });

--- a/packages/secretlint/test/create-secretlintrc.test.ts
+++ b/packages/secretlint/test/create-secretlintrc.test.ts
@@ -36,7 +36,6 @@ describe("create-secretlintrc", function () {
 
     context("when pacakge.json has @secretlint/* packages", function () {
         it("Run secretlint --init", async () => {
-            const expectedConfigFilePath = path.join(tmpConfigDir, ".secretlintrc.json");
             const actual = await runConfigCreator({ cwd: tmpConfigDir });
             if (actual.stdout === null) {
                 assert.fail("stdout is unexpected null.");
@@ -48,7 +47,6 @@ describe("create-secretlintrc", function () {
 
     context("when .secretlintrc.json is already existed", function () {
         it("should be an error", async () => {
-            const expectedConfigFilePath = path.join(tmpConfigDir, ".secretlintrc.json");
             const actual = await runConfigCreator({ cwd: tmpConfigDir });
             assert.strictEqual(actual.exitStatus, 0);
             if (actual.stdout === null) {

--- a/packages/secretlint/test/create-secretlintrc.test.ts
+++ b/packages/secretlint/test/create-secretlintrc.test.ts
@@ -41,7 +41,7 @@ describe("create-secretlintrc", function () {
             if (actual.stdout === null) {
                 assert.fail("stdout is unexpected null.");
             }
-            assert.ok(actual.stdout?.includes(`Create ${expectedConfigFilePath}`));
+            assert.match(actual.stdout, /Create .*\.secretlintrc\.json/);
             assert.strictEqual(actual.stderr, null);
         });
     });
@@ -54,7 +54,7 @@ describe("create-secretlintrc", function () {
             if (actual.stdout === null) {
                 assert.fail("stdout is unexpected null.");
             }
-            assert.ok(actual.stdout?.includes(`Create ${expectedConfigFilePath}`));
+            assert.match(actual.stdout, /Create .*\.secretlintrc\.json/);
             assert.strictEqual(actual.stderr, null);
             // try to re-create
             const reActual = await runConfigCreator({ cwd: tmpConfigDir });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,13 +2001,6 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-expected-exit-status@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/expected-exit-status/-/expected-exit-status-3.1.0.tgz#bd9a5b71b46aba751af0077242770c0142d73a19"
-  integrity sha512-GidLDupNVvyQqzxB8c9go4CQMWWGgoN3VbAvyNEC6rfX21nqVSF9GFleoEt4IFLQDwjfA3IuD69NcWrDRSujNg==
-  dependencies:
-    cross-spawn "^7.0.3"
-
 exponential-backoff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1259,16 +1259,6 @@ camelcase-keys@^6.2.2:
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
 
-camelcase-keys@^7.0.0:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-7.0.2.tgz#d048d8c69448745bb0de6fc4c1c52a30dfbe7252"
-  integrity sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==
-  dependencies:
-    camelcase "^6.3.0"
-    map-obj "^4.1.0"
-    quick-lru "^5.1.1"
-    type-fest "^1.2.1"
-
 camelcase-keys@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-8.0.2.tgz#a7140ba7c797aea32161d4ce5cdbda11d09eb414"
@@ -1284,7 +1274,7 @@ camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.0.0, camelcase@^6.3.0:
+camelcase@^6.0.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
@@ -1747,11 +1737,6 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
-decamelize@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-5.0.1.tgz#db11a92e58c741ef339fb0a2868d8a06a9a7b1e9"
-  integrity sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==
-
 decamelize@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-6.0.0.tgz#8cad4d916fde5c41a264a43d0ecc56fe3d31749e"
@@ -2016,14 +2001,6 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-expected-exit-status@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/expected-exit-status/-/expected-exit-status-2.0.0.tgz#288c15c149ef0442a63fa57a41b2b4f376083b0f"
-  integrity sha512-WYsG9YFXN7LcgyPe4Ds/2opfMV2M8KVrasa5nCKwzafScZZp2hIil0eDuzMOLmggZ/WreQyVggJ5Wtg+J0yy9w==
-  dependencies:
-    cross-spawn "^7.0.3"
-    meow "^10.1.2"
-
 expected-exit-status@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/expected-exit-status/-/expected-exit-status-3.1.0.tgz#bd9a5b71b46aba751af0077242770c0142d73a19"
@@ -2140,7 +2117,7 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-up@5.0.0, find-up@^5.0.0:
+find-up@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
@@ -3392,7 +3369,7 @@ map-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==
 
-map-obj@^4.0.0, map-obj@^4.1.0, map-obj@^4.3.0:
+map-obj@^4.0.0, map-obj@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
@@ -3403,24 +3380,6 @@ map-visit@^1.0.0:
   integrity sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==
   dependencies:
     object-visit "^1.0.0"
-
-meow@^10.1.2:
-  version "10.1.5"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-10.1.5.tgz#be52a1d87b5f5698602b0f32875ee5940904aa7f"
-  integrity sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==
-  dependencies:
-    "@types/minimist" "^1.2.2"
-    camelcase-keys "^7.0.0"
-    decamelize "^5.0.0"
-    decamelize-keys "^1.1.0"
-    hard-rejection "^2.1.0"
-    minimist-options "4.1.0"
-    normalize-package-data "^3.0.2"
-    read-pkg-up "^8.0.0"
-    redent "^4.0.0"
-    trim-newlines "^4.0.2"
-    type-fest "^1.2.2"
-    yargs-parser "^20.2.9"
 
 meow@^12.0.1:
   version "12.0.1"
@@ -4479,11 +4438,6 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-quick-lru@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
-  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
-
 quick-lru@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-6.1.1.tgz#f8e5bf9010376c126c80c1a62827a526c0e60adf"
@@ -4551,15 +4505,6 @@ read-pkg-up@^7.0.0, read-pkg-up@^7.0.1:
     read-pkg "^5.2.0"
     type-fest "^0.8.1"
 
-read-pkg-up@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-8.0.0.tgz#72f595b65e66110f43b052dd9af4de6b10534670"
-  integrity sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==
-  dependencies:
-    find-up "^5.0.0"
-    read-pkg "^6.0.0"
-    type-fest "^1.0.1"
-
 read-pkg-up@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-9.1.0.tgz#38ca48e0bc6c6b260464b14aad9bcd4e5b1fbdc3"
@@ -4587,16 +4532,6 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
-
-read-pkg@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-6.0.0.tgz#a67a7d6a1c2b0c3cd6aa2ea521f40c458a4a504c"
-  integrity sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==
-  dependencies:
-    "@types/normalize-package-data" "^2.4.0"
-    normalize-package-data "^3.0.2"
-    parse-json "^5.2.0"
-    type-fest "^1.0.1"
 
 read-pkg@^7.1.0:
   version "7.1.0"
@@ -5378,11 +5313,6 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-trim-newlines@^4.0.2:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-4.1.1.tgz#28c88deb50ed10c7ba6dc2474421904a00139125"
-  integrity sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==
-
 trim-newlines@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-5.0.0.tgz#fbe350dc9d5fe15e80793b86c09bc7436a3da383"
@@ -5527,11 +5457,6 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
-type-fest@^1.0.1, type-fest@^1.2.1, type-fest@^1.2.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
-  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 type-fest@^2.0.0, type-fest@^2.12.1, type-fest@^2.13.0, type-fest@^2.5.0, type-fest@^2.5.1:
   version "2.19.0"
@@ -5819,7 +5744,7 @@ yargs-parser@20.2.4:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
-yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.9:
+yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==


### PR DESCRIPTION
Fix various bugs on Windows

- fix `secretlint --debug`
- fix to load custom formatter on Windows
- `@secretlint/tester` normalize file path by default
  - Previously, it has difference between Windows and Linux
- `secretlint [windows path]` supports


refs #590 