### PR TITLE
fix(sendgrid): fix SENDGRID_KEY_PATTERN

### DIFF
--- a/packages/@secretlint/secretlint-rule-sendgrid/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-sendgrid/src/index.ts
@@ -32,7 +32,7 @@ function reportIfFoundKey({
     context: SecretLintRuleContext;
     t: SecretLintRuleMessageTranslate<typeof messages>;
 }) {
-    const SENDGRID_KEY_PATTERN = /SG\.\w{1,128}\.\w{1,128}-\w{1,128}/g;
+    const SENDGRID_KEY_PATTERN = /SG\.\w{1,128}\.\w{1,128}([-_]?)\w{1,128}/g;
     const results = source.content.matchAll(SENDGRID_KEY_PATTERN);
     for (const result of results) {
         const index = result.index || 0;

--- a/packages/@secretlint/secretlint-rule-sendgrid/test/snapshots/ng.apikey/input.txt
+++ b/packages/@secretlint/secretlint-rule-sendgrid/test/snapshots/ng.apikey/input.txt
@@ -1,3 +1,5 @@
 Oh no I'm accidentally committing something that looks like a sendgrid api key
 oops SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313-L5528K
 somSG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313-L5528Kewhere lost in staging files. This is not a real key by the way.
+SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313_L5528Ke
+SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313L5528Ke

--- a/packages/@secretlint/secretlint-rule-sendgrid/test/snapshots/ng.apikey/output.json
+++ b/packages/@secretlint/secretlint-rule-sendgrid/test/snapshots/ng.apikey/output.json
@@ -50,8 +50,58 @@
             "data": {
                 "KEY": "SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313-L5528Kewhere"
             }
+        },
+        {
+            "message": "found Sendgrid api key: SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313_L5528Ke",
+            "range": [
+                291,
+                361
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-sendgrid",
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 70
+                }
+            },
+            "severity": "error",
+            "messageId": "SENDGRID_KEY",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-sendgrid/README.md#SENDGRID_KEY",
+            "data": {
+                "KEY": "SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313_L5528Ke"
+            }
+        },
+        {
+            "message": "found Sendgrid api key: SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313L5528Ke",
+            "range": [
+                362,
+                431
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-sendgrid",
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 69
+                }
+            },
+            "severity": "error",
+            "messageId": "SENDGRID_KEY",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-sendgrid/README.md#SENDGRID_KEY",
+            "data": {
+                "KEY": "SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313L5528Ke"
+            }
         }
     ],
-    "sourceContent": "Oh no I'm accidentally committing something that looks like a sendgrid api key\noops SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313-L5528K\nsomSG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313-L5528Kewhere lost in staging files. This is not a real key by the way.\n",
+    "sourceContent": "Oh no I'm accidentally committing something that looks like a sendgrid api key\noops SG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313-L5528K\nsomSG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313-L5528Kewhere lost in staging files. This is not a real key by the way.\nSG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313_L5528Ke\nSG.APhb3zgjtx3hajdas1TjBB.H7Sgbba3afgKSDyB442aDK0kpGO3SD332313L5528Ke\n",
     "sourceContentType": "text"
 }


### PR DESCRIPTION
The latest sendgrid API key contained underscores instead of hyphens, or a pattern with neither, so we added them.