### PR TITLE
hotfix: secretlint --version returning 1.0.0

### DIFF
--- a/packages/@secretlint/messages-to-markdown/src/cli.ts
+++ b/packages/@secretlint/messages-to-markdown/src/cli.ts
@@ -35,7 +35,7 @@ export const run = (input = cli.input, flags = cli.flags) => {
             process.exit(0);
         }
         if (flags.version) {
-            const packageJson = getPackageJson();
+            const packageJson = getPackageJson(import.meta.url);
             console.log(packageJson?.version ?? "");
             process.exit(0);
         }

--- a/packages/@secretlint/resolver/src/index.ts
+++ b/packages/@secretlint/resolver/src/index.ts
@@ -127,15 +127,21 @@ export const clearHooks = () => {
 
 /**
  * get package.json content from startDir
- * @param startDir
+ * @param cwd
  * @returns package.json content
  */
-export const getPackageJson = (startDir: string = process.cwd()) => {
-    const packageJsonPath = findPackageJson(startDir);
-    if (packageJsonPath) {
-        return require(packageJsonPath);
+export const getPackageJson = (cwd: string) => {
+    try {
+        const startDir = path.dirname(url.fileURLToPath(cwd));
+        const packageJsonPath = findPackageJson(startDir);
+        if (packageJsonPath) {
+            return require(packageJsonPath);
+        }
+        return undefined;
+    } catch (error) {
+        // ignore error
+        return undefined;
     }
-    return undefined;
 };
 
 /**
@@ -143,7 +149,7 @@ export const getPackageJson = (startDir: string = process.cwd()) => {
  * @param startDir
  * @returns
  */
-const findPackageJson = (startDir: string = process.cwd()): string => {
+const findPackageJson = (startDir: string): string => {
     let currentDir = startDir;
     while (true) {
         const packageJsonPath = path.join(currentDir, "package.json");

--- a/packages/@secretlint/resolver/test/index.test.ts
+++ b/packages/@secretlint/resolver/test/index.test.ts
@@ -73,7 +73,7 @@ describe("@secretlint/resolver", () => {
     });
     describe("getPackageJson", () => {
         it("should return package.json", () => {
-            const result = getPackageJson();
+            const result = getPackageJson(import.meta.url);
             assert.ok(result);
         });
         it("should return undefined", () => {

--- a/packages/secretlint/src/cli.ts
+++ b/packages/secretlint/src/cli.ts
@@ -205,7 +205,7 @@ export const run = async (
         };
     }
     if (flags.version) {
-        const packageJson = getPackageJson();
+        const packageJson = getPackageJson(import.meta.url);
         return {
             exitStatus: 0,
             stdout: packageJson?.version ?? "",


### PR DESCRIPTION
resolve: https://github.com/secretlint/secretlint/issues/1005

# test

dir is 

- **oss**
    - ts
        - **secretlint**
            - packages
                - secretlint
                    - bin
                        - **secretlint.js**

## in `oss`

![image](https://github.com/user-attachments/assets/eb75a1e8-d502-4a53-b5b1-a394a731578b)

## in `oss/ts/secretlint`

![image](https://github.com/user-attachments/assets/f9a6246b-2e4c-4ec0-b958-667749ffdfc9)

## in `oss/ts/secretlint/packages/secretlint/bin/secretlint.js`

![image](https://github.com/user-attachments/assets/a8915b8c-99b8-45a8-bea2-b761747d9b3d)
