### PR TITLE
chore: remove rimraf dependency from multiple packages and update to rimraf v6 in specific packages

### DIFF
--- a/packages/@secretlint/config-creator/package.json
+++ b/packages/@secretlint/config-creator/package.json
@@ -59,7 +59,6 @@
     "@types/node": "^20.17.31",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/config-loader/package.json
+++ b/packages/@secretlint/config-loader/package.json
@@ -72,7 +72,6 @@
     "create-validator-ts": "^4.0.2",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/core/package.json
+++ b/packages/@secretlint/core/package.json
@@ -64,7 +64,6 @@
     "assert-json-equal": "^1.0.1",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/formatter/package.json
+++ b/packages/@secretlint/formatter/package.json
@@ -73,7 +73,6 @@
     "escape-string-regexp": "^4.0.0",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/messages-to-markdown/package.json
+++ b/packages/@secretlint/messages-to-markdown/package.json
@@ -60,7 +60,6 @@
     "@types/node": "^20.17.31",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/node/package.json
+++ b/packages/@secretlint/node/package.json
@@ -68,7 +68,6 @@
     "@types/node": "^20.17.31",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/profiler/package.json
+++ b/packages/@secretlint/profiler/package.json
@@ -58,7 +58,6 @@
     "@types/node": "^20.17.31",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/resolver/package.json
+++ b/packages/@secretlint/resolver/package.json
@@ -61,7 +61,6 @@
     "@types/node": "^20.17.31",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-formatter-sarif/package.json
+++ b/packages/@secretlint/secretlint-formatter-sarif/package.json
@@ -66,7 +66,6 @@
     "escape-string-regexp": "^5.0.0",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-aws/package.json
+++ b/packages/@secretlint/secretlint-rule-aws/package.json
@@ -62,7 +62,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-azure/package.json
+++ b/packages/@secretlint/secretlint-rule-azure/package.json
@@ -62,7 +62,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-basicauth/package.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/package.json
@@ -62,7 +62,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-example/package.json
+++ b/packages/@secretlint/secretlint-rule-example/package.json
@@ -61,7 +61,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-filter-comments/package.json
+++ b/packages/@secretlint/secretlint-rule-filter-comments/package.json
@@ -65,7 +65,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-gcp/package.json
+++ b/packages/@secretlint/secretlint-rule-gcp/package.json
@@ -63,7 +63,6 @@
     "@types/node": "^20.17.31",
     "@types/node-forge": "^1.3.11",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-github/package.json
+++ b/packages/@secretlint/secretlint-rule-github/package.json
@@ -62,7 +62,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-no-dotenv/package.json
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/package.json
@@ -64,7 +64,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-no-homedir/package.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/package.json
@@ -62,7 +62,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/package.json
@@ -62,7 +62,6 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-npm/package.json
+++ b/packages/@secretlint/secretlint-rule-npm/package.json
@@ -62,7 +62,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-pattern/package.json
+++ b/packages/@secretlint/secretlint-rule-pattern/package.json
@@ -62,7 +62,6 @@
   "devDependencies": {
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -76,7 +76,7 @@
     "@secretlint/types": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
+    "rimraf": "^6.0.1",
     "rollup": "^3.29.5",
     "rollup-plugin-polyfill-node": "^0.13.0",
     "ts-node": "^10.9.2",

--- a/packages/@secretlint/secretlint-rule-preset-recommend/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/package.json
@@ -79,7 +79,7 @@
     "@secretlint/types": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
+    "rimraf": "^6.0.1",
     "rollup": "^3.29.5",
     "rollup-plugin-polyfill-node": "^0.13.0",
     "ts-node": "^10.9.2",

--- a/packages/@secretlint/secretlint-rule-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/package.json
@@ -62,7 +62,6 @@
     "@secretlint/types": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/package.json
@@ -70,7 +70,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-sendgrid/package.json
+++ b/packages/@secretlint/secretlint-rule-sendgrid/package.json
@@ -62,7 +62,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-shopify/package.json
+++ b/packages/@secretlint/secretlint-rule-shopify/package.json
@@ -64,7 +64,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/secretlint-rule-slack/package.json
+++ b/packages/@secretlint/secretlint-rule-slack/package.json
@@ -62,7 +62,6 @@
     "@secretlint/tester": "^9.3.2",
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/source-creator/package.json
+++ b/packages/@secretlint/source-creator/package.json
@@ -62,7 +62,6 @@
     "@types/node": "^20.17.31",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/tester/package.json
+++ b/packages/@secretlint/tester/package.json
@@ -64,7 +64,6 @@
     "@types/node": "^20.17.31",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/packages/@secretlint/types/package.json
+++ b/packages/@secretlint/types/package.json
@@ -60,7 +60,6 @@
   "devDependencies": {
     "@types/node": "^20.17.31",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "tsconfig-to-dual-package": "^1.2.0",
     "tsd": "^0.32.0",

--- a/packages/secretlint/package.json
+++ b/packages/secretlint/package.json
@@ -78,7 +78,6 @@
     "@types/node": "^20.17.31",
     "mocha": "^10.8.2",
     "prettier": "^2.8.1",
-    "rimraf": "^3.0.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.1.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,7 +880,6 @@ __metadata:
     "@types/node": "npm:^20.17.31"
     mocha: "npm:^10.8.2"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -903,7 +902,6 @@ __metadata:
     mocha: "npm:^10.8.2"
     prettier: "npm:^2.8.1"
     rc-config-loader: "npm:^4.1.3"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -922,7 +920,6 @@ __metadata:
     debug: "npm:^4.4.0"
     mocha: "npm:^10.8.2"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     structured-source: "npm:^4.0.0"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
@@ -973,7 +970,6 @@ __metadata:
     mocha: "npm:^10.8.2"
     pluralize: "npm:^8.0.0"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     strip-ansi: "npm:^6.0.1"
     table: "npm:^6.9.0"
     terminal-link: "npm:^2.1.1"
@@ -991,7 +987,6 @@ __metadata:
     "@types/node": "npm:^20.17.31"
     mocha: "npm:^10.8.2"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   bin:
@@ -1016,7 +1011,6 @@ __metadata:
     mocha: "npm:^10.8.2"
     p-map: "npm:^4.0.0"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1030,7 +1024,6 @@ __metadata:
     "@types/node": "npm:^20.17.31"
     mocha: "npm:^10.8.2"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1058,7 +1051,6 @@ __metadata:
     "@types/node": "npm:^20.17.31"
     mocha: "npm:^10.8.2"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1075,7 +1067,6 @@ __metadata:
     mocha: "npm:^10.8.2"
     node-sarif-builder: "npm:^2.0.3"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1104,7 +1095,6 @@ __metadata:
     "@textlint/regexp-string-matcher": "npm:^2.0.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1119,7 +1109,6 @@ __metadata:
     "@textlint/regexp-string-matcher": "npm:^2.0.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1134,7 +1123,6 @@ __metadata:
     "@textlint/regexp-string-matcher": "npm:^2.0.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1148,7 +1136,6 @@ __metadata:
     "@secretlint/types": "npm:^9.3.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1163,7 +1150,6 @@ __metadata:
     "@secretlint/types": "npm:^9.3.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1180,7 +1166,6 @@ __metadata:
     "@types/node-forge": "npm:^1.3.11"
     node-forge: "npm:^1.3.1"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1195,7 +1180,6 @@ __metadata:
     "@textlint/regexp-string-matcher": "npm:^2.0.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1240,7 +1224,6 @@ __metadata:
     "@secretlint/types": "npm:^9.3.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1256,7 +1239,6 @@ __metadata:
     "@types/node": "npm:^20.17.31"
     escape-string-regexp: "npm:^4.0.0"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1272,7 +1254,6 @@ __metadata:
     "@types/node": "npm:^20.17.31"
     js-yaml: "npm:^4.1.0"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1287,7 +1268,6 @@ __metadata:
     "@textlint/regexp-string-matcher": "npm:^2.0.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1315,7 +1295,6 @@ __metadata:
     "@textlint/regexp-string-matcher": "npm:^2.0.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1344,7 +1323,7 @@ __metadata:
     "@secretlint/types": "npm:^9.3.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
+    rimraf: "npm:^6.0.1"
     rollup: "npm:^3.29.5"
     rollup-plugin-polyfill-node: "npm:^0.13.0"
     ts-node: "npm:^10.9.2"
@@ -1377,7 +1356,7 @@ __metadata:
     "@secretlint/types": "npm:^9.3.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
+    rimraf: "npm:^6.0.1"
     rollup: "npm:^3.29.5"
     rollup-plugin-polyfill-node: "npm:^0.13.0"
     ts-node: "npm:^10.9.2"
@@ -1394,7 +1373,6 @@ __metadata:
     "@textlint/regexp-string-matcher": "npm:^2.0.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1411,7 +1389,6 @@ __metadata:
     "@types/secp256k1": "npm:^4.0.6"
     bn.js: "npm:^5.2.1"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     secp256k1: "npm:^5.0.1"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
@@ -1427,7 +1404,6 @@ __metadata:
     "@textlint/regexp-string-matcher": "npm:^2.0.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1442,7 +1418,6 @@ __metadata:
     "@textlint/regexp-string-matcher": "npm:^2.0.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1457,7 +1432,6 @@ __metadata:
     "@textlint/regexp-string-matcher": "npm:^2.0.2"
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1473,7 +1447,6 @@ __metadata:
     istextorbinary: "npm:^6.0.0"
     mocha: "npm:^10.8.2"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1491,7 +1464,6 @@ __metadata:
     "@types/node": "npm:^20.17.31"
     mocha: "npm:^10.8.2"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   languageName: unknown
@@ -1503,7 +1475,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:^20.17.31"
     prettier: "npm:^2.8.1"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     tsconfig-to-dual-package: "npm:^1.2.0"
     tsd: "npm:^0.32.0"
@@ -4438,6 +4409,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^11.0.0":
+  version: 11.0.2
+  resolution: "glob@npm:11.0.2"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^4.0.1"
+    minimatch: "npm:^10.0.0"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^2.0.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/49f91c64ca882d5e3a72397bd45a146ca91fd3ca53dafb5254daf6c0e83fc510d39ea66f136f9ac7ca075cdd11fbe9aaa235b28f743bd477622e472f4fdc0240
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -5461,6 +5448,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "jackspeak@npm:4.1.0"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+  checksum: 10c0/08a6a24a366c90b83aef3ad6ec41dcaaa65428ffab8d80bc7172add0fbb8b134a34f415ad288b2a6fbd406526e9a62abdb40ed4f399fbe00cb45c44056d4dce0
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^29.0.3":
   version: 29.5.0
   resolution: "jest-diff@npm:29.5.0"
@@ -5902,6 +5898,13 @@ __metadata:
   version: 10.0.1
   resolution: "lru-cache@npm:10.0.1"
   checksum: 10c0/982dabfb227b9a2daf56d712ae0e72e01115a28c0a2068cd71277bca04568f3417bbf741c6c7941abc5c620fd8059e34f15607f90ebccbfa0a17533322d27a8e
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^11.0.0":
+  version: 11.1.0
+  resolution: "lru-cache@npm:11.1.0"
+  checksum: 10c0/85c312f7113f65fae6a62de7985348649937eb34fb3d212811acbf6704dc322a421788aca253b62838f1f07049a84cc513d88f494e373d3756514ad263670a64
   languageName: node
   linkType: hard
 
@@ -6449,6 +6452,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "minimatch@npm:10.0.1"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/e6c29a81fe83e1877ad51348306be2e8aeca18c88fdee7a99df44322314279e15799e41d7cb274e4e8bb0b451a3bc622d6182e157dfa1717d6cda75e9cd8cd5d
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.1.1":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -6598,6 +6610,13 @@ __metadata:
   version: 7.0.3
   resolution: "minipass@npm:7.0.3"
   checksum: 10c0/c85426bce6310368218aad1f20b8f242180b6c2058209c78840959d6fff8a4738076a3224c3a6b651080f95684d559be1bdb084939bc40011c653ec4552cf06e
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 10c0/b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
   languageName: node
   linkType: hard
 
@@ -7346,6 +7365,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "package-json-from-dist@npm:1.0.1"
+  checksum: 10c0/62ba2785eb655fec084a257af34dbe24292ab74516d6aecef97ef72d4897310bc6898f6c85b5cd22770eaa1ce60d55a0230e150fb6a966e3ecd6c511e23d164b
+  languageName: node
+  linkType: hard
+
 "package-json@npm:^8.1.0":
   version: 8.1.1
   resolution: "package-json@npm:8.1.1"
@@ -7569,6 +7595,16 @@ __metadata:
     lru-cache: "npm:^9.1.1 || ^10.0.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10c0/e5dc78a7348d25eec61ab166317e9e9c7b46818aa2c2b9006c507a6ff48c672d011292d9662527213e558f5652ce0afcc788663a061d8b59ab495681840c0c1e
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/3da4adedaa8e7ef8d6dc4f35a0ff8f05a9b4d8365f2b28047752b62d4c1ad73eec21e37b1579ef2d075920157856a3b52ae8309c480a6f1a8bbe06ff8e52b33c
   languageName: node
   linkType: hard
 
@@ -8245,6 +8281,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rimraf@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "rimraf@npm:6.0.1"
+  dependencies:
+    glob: "npm:^11.0.0"
+    package-json-from-dist: "npm:^1.0.0"
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: 10c0/b30b6b072771f0d1e73b4ca5f37bb2944ee09375be9db5f558fcd3310000d29dfcfa93cf7734d75295ad5a7486dc8e40f63089ced1722a664539ffc0c3ece8c6
+  languageName: node
+  linkType: hard
+
 "rollup-plugin-polyfill-node@npm:^0.13.0":
   version: 0.13.0
   resolution: "rollup-plugin-polyfill-node@npm:0.13.0"
@@ -8431,7 +8479,6 @@ __metadata:
     mocha: "npm:^10.8.2"
     prettier: "npm:^2.8.1"
     read-pkg: "npm:^8.1.0"
-    rimraf: "npm:^3.0.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.1.6"
   bin:


### PR DESCRIPTION
rimraf v3 has been deprecated and updated to the latest version.
Also removed some pacakge that did not require rimraf.
<https://www.npmjs.com/package/rimraf/v/3.0.2>
<https://github.com/isaacs/rimraf>