### PR TITLE
Add missing `ghu` to typeMap and fix description

### DIFF
--- a/packages/@secretlint/secretlint-rule-github/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-github/src/index.ts
@@ -32,7 +32,8 @@ type GITHUB_TOKEN_TYPE = "ghp" | "gho" | "ghu" | "ghs" | "ghr" | "github_pat";
 const typeMap = new Map<GITHUB_TOKEN_TYPE, string>([
     ["ghp", "GitHub personal access tokens"],
     ["gho", "OAuth access tokens"],
-    ["ghs", "GitHub user-to-server tokens"],
+    ["ghu", "GitHub user-to-server tokens"],
+    ["ghs", "GitHub server-to-server tokens"],
     ["ghr", "refresh tokens"],
     ["github_pat", "fine-grained personal access tokens"],
 ]);


### PR DESCRIPTION
Fixes `Error: Unknown type:undefined` for GitHub user-to-server tokens (ghu) and updates the decription of `ghs` to `GitHub server-to-server tokens`

Fixes [Error: Unknown type:undefined for GitHub user-to-server tokens (ghu)](https://github.com/secretlint/secretlint/issues/1036)

