### PR TITLE
fix: correct typos in documentation files

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -13,7 +13,7 @@ labels: "Type: question"
 ### Environment (if relevant)
 
 <!--
-If you have install Node.js, please run follwing and paste it
+If you have install Node.js, please run following and paste it
 
   $ npx envinfo
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,7 +126,7 @@ For example, If you want to ignore "AWSAccountID" and "AWSAccessKeyID" of "@secr
 
 ### `.secretlintignore`
 
-You can tell Secretlint to ignore specific files and directories by creating an `.secretlintignore` file in your project's root directory. 
+You can tell Secretlint to ignore specific files and directories by creating an `.secretlintignore` file in your project's root directory.
 
 The `.secretlintignore` file is a plain text file where each line is a glob pattern indicating which paths should be omitted from linting. For example, the following will omit all JavaScript files:
 
@@ -170,7 +170,7 @@ Currently, secretlint ignore following file by default:
 ### Using an Alternate Ignoring File
 
 You can use specif file as ignoring configuration.
-you can specify it on the command line using the `--secretlintignore` option. 
+you can specify it on the command line using the `--secretlintignore` option.
 
 For example, you can use `.gitignore` file because it has the same format:
 

--- a/docs/secretlint-rule.md
+++ b/docs/secretlint-rule.md
@@ -22,10 +22,10 @@ Implementation:
   - `messages`: MessageIds
   - `meta`: meta information for the rule
     - `id`: `id` should be equal to `package.json`'s `name`
-    - `recommended`(optional): recommended to use 
+    - `recommended`(optional): recommended to use
     - `type`: `"scanner"`
     - `supportedContentTypes`: "text" or "binary" or "all"
-      - If specified `["text"]`, secretlint pass the content of text to the rule. 
+      - If specified `["text"]`, secretlint pass the content of text to the rule.
       - In other words, secretlint does not pass binary content
     - `docs`
       - `url`: document base url. secretlint show `{docs.url}#{MessageId}` in results.
@@ -65,7 +65,7 @@ export const creator: SecretLintRuleCreator = {
     },
     // Rule Logic
     create(context) {
-        // Create Traslate instance
+        // Create Translate instance
         const t = context.createTranslator(messages);
         return {
             // source has `content`, `filePath` etc...


### PR DESCRIPTION
correct typos in documentation files