### PR TITLE
Improve SendGrid regex pattern

### DIFF
--- a/packages/@secretlint/secretlint-rule-sendgrid/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-sendgrid/src/index.ts
@@ -32,7 +32,7 @@ function reportIfFoundKey({
     context: SecretLintRuleContext;
     t: SecretLintRuleMessageTranslate<typeof messages>;
 }) {
-    const SENDGRID_KEY_PATTERN = /SG\.\w{1,128}\.\w{1,128}([-_]?)\w{1,128}/g;
+    const SENDGRID_KEY_PATTERN = /(?<![A-Za-z])SG\.\w{1,128}\.\w{1,128}([-_]?)\w{1,128}/g;
     const results = source.content.matchAll(SENDGRID_KEY_PATTERN);
     for (const result of results) {
         const index = result.index || 0;


### PR DESCRIPTION
Makes sure there is not letter infront of the `SG` prefix for send grid api keys

fixes https://github.com/secretlint/secretlint/issues/1076