### PR TITLE
fix(database-connection-string): improve password detection to avoid false negatives

### DIFF
--- a/.secretlintignore
+++ b/.secretlintignore
@@ -160,3 +160,5 @@ fabric.properties
 .secretlintignore
 .secretlintrc.json
 .idea/
+# Test snapshots contain example credentials for testing
+**/test/snapshots/**/*.json

--- a/packages/@secretlint/secretlint-rule-database-connection-string/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-database-connection-string/src/index.ts
@@ -82,8 +82,9 @@ function isLikelyRealPassword(password: string): boolean {
     // Skip if it contains variable patterns
     if (isVariableLikeString(password)) return false;
 
-    // Skip if it's a common placeholder
-    if (BUILTIN_IGNORED_PATTERNS.some((pattern) => password.toLowerCase().includes(pattern.toLowerCase()))) {
+    // Skip if it's exactly a common placeholder (not just contains it)
+    const passwordLower = password.toLowerCase();
+    if (BUILTIN_IGNORED_PATTERNS.some((pattern) => passwordLower === pattern.toLowerCase())) {
         return false;
     }
 

--- a/packages/@secretlint/secretlint-rule-database-connection-string/test/snapshots/ng.postgresql/output.json
+++ b/packages/@secretlint/secretlint-rule-database-connection-string/test/snapshots/ng.postgresql/output.json
@@ -2,6 +2,31 @@
     "filePath": "[SNAPSHOT]/ng.postgresql/input.txt",
     "messages": [
         {
+            "message": "found PostgreSQL connection string: postgresql://pguser:secur3Pass@postgres.example.com:5432/production_db\";",
+            "range": [
+                132,
+                204
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 16
+                },
+                "end": {
+                    "line": 4,
+                    "column": 88
+                }
+            },
+            "severity": "error",
+            "messageId": "PostgreSQLConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#PostgreSQLConnection",
+            "data": {
+                "URI": "postgresql://pguser:secur3Pass@postgres.example.com:5432/production_db\";"
+            }
+        },
+        {
             "message": "found PostgreSQL connection string: postgres://api_user:myC0mpl3xPwd@db.internal.com:5432/api_db\";",
             "range": [
                 281,


### PR DESCRIPTION
## Summary
- Fixed PostgreSQL connection strings not being detected when passwords contain common words as substrings
- Updated password validation logic to check for exact matches instead of substring matches
- Added test snapshot JSON files to .secretlintignore

## Issue
Fixes #1117

## Problem
The `isLikelyRealPassword` function was rejecting passwords that contained common placeholder words as substrings. For example, "secur3Pass" was being rejected because it contains "pass" which partially matches "password" in the ignored patterns list.

## Solution
Changed the password validation to check for exact matches against placeholder patterns instead of substring matches. This allows real passwords like "secur3Pass" to be properly detected while still filtering out obvious placeholders like "password" or "mypassword".

## Test Results
- All existing tests pass
- PostgreSQL detection now correctly identifies 3 connection strings instead of 2
- The connection string with "secur3Pass" is now properly detected

🤖 Generated with [Claude Code](https://claude.ai/code)