### PR TITLE
fix(turbo): fix turbo.json configuration to match actual file structure

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
         "build"
       ],
       "outputs": [
-        "snapshots/**"
+        "test/snapshots/**"
       ],
       "env": [
         "UPDATE_SNAPSHOT"
@@ -26,7 +26,7 @@
         "build"
       ],
       "outputs": [
-        "snapshots/**"
+        "test/snapshots/**"
       ],
       "env": [
         "UPDATE_SNAPSHOT"
@@ -35,7 +35,8 @@
     "secretlint": {
       "dependsOn": [
         "build"
-      ]
+      ],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary

- Update updateSnapshot task outputs from "snapshots/**" to "test/snapshots/**" to match actual file structure
- Add empty outputs array for secretlint task to suppress warnings
- Fix Turborepo warnings about missing output files for tasks

## Test plan

- [x] yarn install
- [x] yarn run updateSnapshot (no longer shows Turborepo warnings)
- [x] Verified that snapshots are actually located in test/snapshots/** directories
- [x] Tested that secretlint task no longer shows output file warnings

Fixes #1119

🤖 Generated with [Claude Code](https://claude.ai/code)