### PR TITLE
feat: add Anthropic and Database Connection String rules to recommended preset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,11 +283,14 @@ New rules follow a two-stage deployment process:
 
 First, add your rule to [secretlint-rule-preset-canary](./packages/@secretlint/secretlint-rule-preset-canary):
 
-1. Add the rule package to devDependencies (from project root):
-   ```sh
-   # From any directory in the project
-   pnpm --filter "@secretlint/secretlint-rule-preset-canary" add -D @secretlint/secretlint-rule-your-rule
+1. Add the rule package to devDependencies in `packages/@secretlint/secretlint-rule-preset-canary/package.json`:
+   ```json
+   "devDependencies": {
+     // ... existing dependencies
+     "@secretlint/secretlint-rule-your-rule": "workspace:*"
+   }
    ```
+   Then run `pnpm install` to update dependencies.
 
 2. Import and add the rule to `packages/@secretlint/secretlint-rule-preset-canary/src/index.ts`:
    ```typescript

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,13 +283,13 @@ New rules follow a two-stage deployment process:
 
 First, add your rule to [secretlint-rule-preset-canary](./packages/@secretlint/secretlint-rule-preset-canary):
 
-1. Add the rule package to devDependencies:
+1. Add the rule package to devDependencies (from project root):
    ```sh
-   cd packages/@secretlint/secretlint-rule-preset-canary
-   pnpm add -D @secretlint/secretlint-rule-your-rule
+   # From any directory in the project
+   pnpm --filter "@secretlint/secretlint-rule-preset-canary" add -D @secretlint/secretlint-rule-your-rule
    ```
 
-2. Import and add the rule to `src/index.ts`:
+2. Import and add the rule to `packages/@secretlint/secretlint-rule-preset-canary/src/index.ts`:
    ```typescript
    import { creator as ruleYourRule } from "@secretlint/secretlint-rule-your-rule";
    
@@ -299,40 +299,55 @@ First, add your rule to [secretlint-rule-preset-canary](./packages/@secretlint/s
    ];
    ```
 
-3. Import test snapshots and run tests:
+3. Import test snapshots and run tests (from project root):
    ```sh
-   pnpm run import-test
-   pnpm test
+   # From any directory in the project
+   pnpm run -r --filter "@secretlint/secretlint-rule-preset-canary" import-test
+   pnpm run -r --filter "@secretlint/secretlint-rule-preset-canary" test
    ```
 
 ### Step 2: Sync to recommended preset (for major releases)
 
 After the rule has been tested in canary, sync it to [secretlint-rule-preset-recommend](./packages/@secretlint/secretlint-rule-preset-recommend):
 
-1. Navigate to the recommended preset:
+1. Run the sync script (from project root):
    ```sh
-   cd packages/@secretlint/secretlint-rule-preset-recommend
+   # From any directory in the project
+   pnpm run -r --filter "@secretlint/secretlint-rule-preset-recommend" sync-canary
    ```
 
-2. Run the sync script (this copies rules, tests, and dependencies from canary):
-   ```sh
-   pnpm run sync-canary
-   ```
-
-3. Verify the sync:
-   - Check that `src/index.ts` includes your new rule
+2. Verify the sync:
+   - Check that `packages/@secretlint/secretlint-rule-preset-recommend/src/index.ts` includes your new rule
    - Check that test snapshots were copied
    - Check that devDependencies were added
 
-4. Fix any version downgrades:
+3. Fix any version downgrades:
    - The sync script may downgrade some dependencies
    - Manually update `package.json` if needed (e.g., `@rollup/plugin-node-resolve`)
    - Run `pnpm install` to update the lock file
 
-5. Run tests to ensure everything works:
+4. Run tests to ensure everything works:
    ```sh
-   pnpm test
+   # From any directory in the project
+   pnpm run -r --filter "@secretlint/secretlint-rule-preset-recommend" test
    ```
+
+### Alternative: Direct navigation approach
+
+If you prefer to work directly in the package directories:
+
+```sh
+# For canary preset
+cd packages/@secretlint/secretlint-rule-preset-canary
+pnpm add -D @secretlint/secretlint-rule-your-rule
+pnpm run import-test
+pnpm test
+
+# For recommended preset
+cd packages/@secretlint/secretlint-rule-preset-recommend
+pnpm run sync-canary
+pnpm test
+```
 
 ### Important Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,23 +269,77 @@ pnpm run gen:rule
 
 This project has two preset rules:
 
-- [secretlint-rule-preset-canary](./packages/@secretlint/secretlint-rule-preset-canary)
-- [secretlint-rule-preset-recommend](./packages/@secretlint/secretlint-rule-preset-recommend)
+- [secretlint-rule-preset-canary](./packages/@secretlint/secretlint-rule-preset-canary): Experimental preset for testing new rules
+- [secretlint-rule-preset-recommend](./packages/@secretlint/secretlint-rule-preset-recommend): Stable preset for production use
 
-At first, you need to add a rule to [secretlint-rule-preset-canary](./packages/@secretlint/secretlint-rule-preset-canary).
+### Rule Addition Flow
 
-1. Add rule to `packages/@secretlint/secretlint-rule-preset-canary/package.json`'s `devDependencies`
-2. Add rule to `packages/@secretlint/secretlint-rule-preset-canary/src/index.ts`
-3. `pnpm run import-test`
-4. `pnpm test`
+New rules follow a two-stage deployment process:
 
-After testing on canary, you can sync to [secretlint-rule-preset-recommend](./packages/@secretlint/secretlint-rule-preset-recommend).
+1. **Stage 1: Canary Testing** - Add to canary preset for experimental testing
+2. **Stage 2: Production Release** - Sync to recommended preset for stable release (usually in major versions)
 
-```sh
-cd packages/@secretlint/secretlint-rule-preset-recommend
-pnpm run sync-canary
-pnpm test
-```
+### Step 1: Add a rule to canary preset
+
+First, add your rule to [secretlint-rule-preset-canary](./packages/@secretlint/secretlint-rule-preset-canary):
+
+1. Add the rule package to devDependencies:
+   ```sh
+   cd packages/@secretlint/secretlint-rule-preset-canary
+   pnpm add -D @secretlint/secretlint-rule-your-rule
+   ```
+
+2. Import and add the rule to `src/index.ts`:
+   ```typescript
+   import { creator as ruleYourRule } from "@secretlint/secretlint-rule-your-rule";
+   
+   export const rules = [
+       // ... existing rules
+       ruleYourRule,  // Add your rule here
+   ];
+   ```
+
+3. Import test snapshots and run tests:
+   ```sh
+   pnpm run import-test
+   pnpm test
+   ```
+
+### Step 2: Sync to recommended preset (for major releases)
+
+After the rule has been tested in canary, sync it to [secretlint-rule-preset-recommend](./packages/@secretlint/secretlint-rule-preset-recommend):
+
+1. Navigate to the recommended preset:
+   ```sh
+   cd packages/@secretlint/secretlint-rule-preset-recommend
+   ```
+
+2. Run the sync script (this copies rules, tests, and dependencies from canary):
+   ```sh
+   pnpm run sync-canary
+   ```
+
+3. Verify the sync:
+   - Check that `src/index.ts` includes your new rule
+   - Check that test snapshots were copied
+   - Check that devDependencies were added
+
+4. Fix any version downgrades:
+   - The sync script may downgrade some dependencies
+   - Manually update `package.json` if needed (e.g., `@rollup/plugin-node-resolve`)
+   - Run `pnpm install` to update the lock file
+
+5. Run tests to ensure everything works:
+   ```sh
+   pnpm test
+   ```
+
+### Important Notes
+
+- **Breaking Changes**: Adding new rules to the recommended preset is a breaking change as it may introduce new secret detections
+- **Major Versions Only**: Sync to recommended preset should typically be done only for major version releases (e.g., v11.0.0)
+- **Test Coverage**: Ensure all rules have adequate test coverage before adding to presets
+- **Documentation**: Update the rule's README with examples and configuration options
 
 ## Benchmark
 

--- a/packages/@secretlint/secretlint-rule-preset-recommend/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.6",
-    "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-node-resolve": "^15.3.1",
     "@rollup/plugin-typescript": "^12.1.4",
     "@secretlint/secretlint-rule-1password": "workspace:*",
     "@secretlint/secretlint-rule-aws": "workspace:*",
@@ -83,7 +83,9 @@
     "rollup": "^4.46.2",
     "rollup-plugin-polyfill-node": "^0.13.0",
     "tsx": "^4.20.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@secretlint/secretlint-rule-anthropic": "workspace:*",
+    "@secretlint/secretlint-rule-database-connection-string": "workspace:*"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/@secretlint/secretlint-rule-preset-recommend/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.6",
-    "@rollup/plugin-node-resolve": "^15.3.1",
+    "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.4",
     "@secretlint/secretlint-rule-1password": "workspace:*",
     "@secretlint/secretlint-rule-aws": "workspace:*",

--- a/packages/@secretlint/secretlint-rule-preset-recommend/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/src/index.ts
@@ -5,12 +5,14 @@ import { creator as ruleNpm } from "@secretlint/secretlint-rule-npm";
 import { creator as ruleSlack } from "@secretlint/secretlint-rule-slack";
 import { creator as ruleBasicAuth } from "@secretlint/secretlint-rule-basicauth";
 import { creator as ruleOpenAi } from "@secretlint/secretlint-rule-openai";
+import { creator as ruleAnthropic } from "@secretlint/secretlint-rule-anthropic";
 import { creator as ruleLinear } from "@secretlint/secretlint-rule-linear";
 import { creator as rulePrivateKey } from "@secretlint/secretlint-rule-privatekey";
 import { creator as ruleSendgrid } from "@secretlint/secretlint-rule-sendgrid";
 import { creator as ruleShopify } from "@secretlint/secretlint-rule-shopify";
 import { creator as ruleGitHub } from "@secretlint/secretlint-rule-github";
 import { creator as rule1Password } from "@secretlint/secretlint-rule-1password";
+import { creator as ruleDatabaseConnectionString } from "@secretlint/secretlint-rule-database-connection-string";
 import { creator as ruleFilterComments } from "@secretlint/secretlint-rule-filter-comments";
 
 export const rules = [
@@ -24,8 +26,10 @@ export const rules = [
     ruleShopify,
     ruleGitHub,
     ruleOpenAi,
+    ruleAnthropic,
     ruleLinear,
     rule1Password,
+    ruleDatabaseConnectionString,
     ruleFilterComments,
 ];
 export type Options = {};

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-anthropic/ng.secret/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-anthropic/ng.secret/input.txt
@@ -1,0 +1,8 @@
+# Anthropic Claude API keys that should be detected
+claude_api_key = 'sk-ant-api03-z0zjHHXo5uibD2havvfqiZYJe9ENlwI1trcQC4pyRC2N2w6nbpUitUU_iR4kkSszVyUpINaxvCtun3_Mub0O3w-48GXRgAA'
+
+sk-ant-api03-z0zjHHXo5k3zD2havvfqiZYJe9ENlwI1trcQC4pyRC2N2w6nbpUitUU_iR4ttSszVyUpINaxvCtun3_Mub0O3w-48GXRgAA
+
+CLAUDE_API_KEY=sk-ant-api03-lwfESWqh_7RvqZ2cCANYw9scfj8Z8tegAppkRnWnclSFEuEPcjuYUITSiziCs2_JRgru7AET1AxD4Fpdic3T-Q-apLfhQAA
+
+ANTHROPIC_API_KEY='sk-ant-api04-pRLEoxKCq2cuUW5bhgMTVPcAuDd6aoydZQYcEXVp_Fu46ri_GkPW5INiuAEYTqOx4w27CnqVik4Ak_wNjjzKAA-Q5uYbwAA'

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-anthropic/ng.secret/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-anthropic/ng.secret/output.json
@@ -1,0 +1,111 @@
+{
+    "filePath": "[SNAPSHOT]/ng.secret/input.txt",
+    "messages": [
+        {
+            "message": "found Anthropic Claude API key: sk-ant-api03-z0zjHHXo5uibD2havvfqiZYJe9ENlwI1trcQC4pyRC2N2w6nbpUitUU_iR4kkSszVyUpINaxvCtun3_Mub0O3w-48GXRgAA",
+            "range": [
+                70,
+                178
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-anthropic",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 18
+                },
+                "end": {
+                    "line": 2,
+                    "column": 126
+                }
+            },
+            "severity": "error",
+            "messageId": "ANTHROPIC_API_KEY",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-anthropic/README.md#ANTHROPIC_API_KEY",
+            "data": {
+                "KEY": "sk-ant-api03-z0zjHHXo5uibD2havvfqiZYJe9ENlwI1trcQC4pyRC2N2w6nbpUitUU_iR4kkSszVyUpINaxvCtun3_Mub0O3w-48GXRgAA"
+            }
+        },
+        {
+            "message": "found Anthropic Claude API key: sk-ant-api03-z0zjHHXo5k3zD2havvfqiZYJe9ENlwI1trcQC4pyRC2N2w6nbpUitUU_iR4ttSszVyUpINaxvCtun3_Mub0O3w-48GXRgAA",
+            "range": [
+                181,
+                289
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-anthropic",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 108
+                }
+            },
+            "severity": "error",
+            "messageId": "ANTHROPIC_API_KEY",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-anthropic/README.md#ANTHROPIC_API_KEY",
+            "data": {
+                "KEY": "sk-ant-api03-z0zjHHXo5k3zD2havvfqiZYJe9ENlwI1trcQC4pyRC2N2w6nbpUitUU_iR4ttSszVyUpINaxvCtun3_Mub0O3w-48GXRgAA"
+            }
+        },
+        {
+            "message": "found Anthropic Claude API key: sk-ant-api03-lwfESWqh_7RvqZ2cCANYw9scfj8Z8tegAppkRnWnclSFEuEPcjuYUITSiziCs2_JRgru7AET1AxD4Fpdic3T-Q-apLfhQAA",
+            "range": [
+                306,
+                414
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-anthropic",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 15
+                },
+                "end": {
+                    "line": 6,
+                    "column": 123
+                }
+            },
+            "severity": "error",
+            "messageId": "ANTHROPIC_API_KEY",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-anthropic/README.md#ANTHROPIC_API_KEY",
+            "data": {
+                "KEY": "sk-ant-api03-lwfESWqh_7RvqZ2cCANYw9scfj8Z8tegAppkRnWnclSFEuEPcjuYUITSiziCs2_JRgru7AET1AxD4Fpdic3T-Q-apLfhQAA"
+            }
+        },
+        {
+            "message": "found Anthropic Claude API key: sk-ant-api04-pRLEoxKCq2cuUW5bhgMTVPcAuDd6aoydZQYcEXVp_Fu46ri_GkPW5INiuAEYTqOx4w27CnqVik4Ak_wNjjzKAA-Q5uYbwAA",
+            "range": [
+                435,
+                543
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-anthropic",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 19
+                },
+                "end": {
+                    "line": 8,
+                    "column": 127
+                }
+            },
+            "severity": "error",
+            "messageId": "ANTHROPIC_API_KEY",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-anthropic/README.md#ANTHROPIC_API_KEY",
+            "data": {
+                "KEY": "sk-ant-api04-pRLEoxKCq2cuUW5bhgMTVPcAuDd6aoydZQYcEXVp_Fu46ri_GkPW5INiuAEYTqOx4w27CnqVik4Ak_wNjjzKAA-Q5uYbwAA"
+            }
+        }
+    ],
+    "sourceContent": "# Anthropic Claude API keys that should be detected\nclaude_api_key = 'sk-ant-api03-z0zjHHXo5uibD2havvfqiZYJe9ENlwI1trcQC4pyRC2N2w6nbpUitUU_iR4kkSszVyUpINaxvCtun3_Mub0O3w-48GXRgAA'\n\nsk-ant-api03-z0zjHHXo5k3zD2havvfqiZYJe9ENlwI1trcQC4pyRC2N2w6nbpUitUU_iR4ttSszVyUpINaxvCtun3_Mub0O3w-48GXRgAA\n\nCLAUDE_API_KEY=sk-ant-api03-lwfESWqh_7RvqZ2cCANYw9scfj8Z8tegAppkRnWnclSFEuEPcjuYUITSiziCs2_JRgru7AET1AxD4Fpdic3T-Q-apLfhQAA\n\nANTHROPIC_API_KEY='sk-ant-api04-pRLEoxKCq2cuUW5bhgMTVPcAuDd6aoydZQYcEXVp_Fu46ri_GkPW5INiuAEYTqOx4w27CnqVik4Ak_wNjjzKAA-Q5uYbwAA'\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-anthropic/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-anthropic/ok.valid/input.txt
@@ -1,0 +1,15 @@
+# These should NOT be detected as API keys
+export const EXAMPLE_URL = "https://api.anthropic.com";
+export const EXAMPLE_MODEL = "claude-3-opus-20240229";
+
+# Fat-fingered secret (should not be detected due to double 's')
+ssk-ant-api04-NotARealKeyButLooksLikeOne
+
+# OpenAI key (different format)
+sk-openai-123456
+
+# Incomplete Anthropic key
+sk-ant-api02-notarealkey
+
+# Wrong API version
+sk-ant-api05-alsonotreal

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-anthropic/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-anthropic/ok.valid/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.valid/input.txt",
+    "messages": [],
+    "sourceContent": "# These should NOT be detected as API keys\nexport const EXAMPLE_URL = \"https://api.anthropic.com\";\nexport const EXAMPLE_MODEL = \"claude-3-opus-20240229\";\n\n# Fat-fingered secret (should not be detected due to double 's')\nssk-ant-api04-NotARealKeyButLooksLikeOne\n\n# OpenAI key (different format)\nsk-openai-123456\n\n# Incomplete Anthropic key\nsk-ant-api02-notarealkey\n\n# Wrong API version\nsk-ant-api05-alsonotreal\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.mongodb/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.mongodb/input.txt
@@ -1,0 +1,16 @@
+# Valid MongoDB connection strings with real credentials
+
+# MongoDB standard connection
+const MONGO_URI = "mongodb://realuser:s3cr3tP4ss@db1.example.net:27017/production";
+
+# MongoDB SRV connection  
+const MONGO_SRV = "mongodb+srv://appuser:myR3alP@ssw0rd@cluster0.mongodb.net/mydb?retryWrites=true";
+
+# MongoDB from additional cases
+CONECTION_URI="mongodb://root:m42ploz2wd@google.com:5434/thegift"
+mongodb+srv://testuser:hub24aoeu@gg-is-awesome-xm273.mongodb.net/test?retryWrites=true&w=majority
+
+# Additional test cases for password patterns that should be detected
+mongodb://admin:secretKey456@cluster.mongodb.net:27017/admin
+mongodb+srv://user:passW0rd123@prod-cluster.mongodb.net/production?retryWrites=true
+mongodb://devuser:mySecret789@dev.mongodb.com:27017/dev_db

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.mongodb/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.mongodb/output.json
@@ -1,0 +1,189 @@
+{
+    "filePath": "[SNAPSHOT]/ng.mongodb/input.txt",
+    "messages": [
+        {
+            "message": "found MongoDB connection string: mongodb://realuser:s3cr3tP4ss@db1.example.net:27017/production\";",
+            "range": [
+                107,
+                171
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 19
+                },
+                "end": {
+                    "line": 4,
+                    "column": 83
+                }
+            },
+            "severity": "error",
+            "messageId": "MongoDBConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MongoDBConnection",
+            "data": {
+                "URI": "mongodb://realuser:s3cr3tP4ss@db1.example.net:27017/production\";"
+            }
+        },
+        {
+            "message": "found MongoDB connection string: mongodb+srv://appuser:myR3alP@ssw0rd@cluster0.mongodb.net/mydb?retryWrites=true\";",
+            "range": [
+                219,
+                300
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 19
+                },
+                "end": {
+                    "line": 7,
+                    "column": 100
+                }
+            },
+            "severity": "error",
+            "messageId": "MongoDBConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MongoDBConnection",
+            "data": {
+                "URI": "mongodb+srv://appuser:myR3alP@ssw0rd@cluster0.mongodb.net/mydb?retryWrites=true\";"
+            }
+        },
+        {
+            "message": "found MongoDB connection string: mongodb://root:m42ploz2wd@google.com:5434/thegift\"",
+            "range": [
+                349,
+                399
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 15
+                },
+                "end": {
+                    "line": 10,
+                    "column": 65
+                }
+            },
+            "severity": "error",
+            "messageId": "MongoDBConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MongoDBConnection",
+            "data": {
+                "URI": "mongodb://root:m42ploz2wd@google.com:5434/thegift\""
+            }
+        },
+        {
+            "message": "found MongoDB connection string: mongodb+srv://testuser:hub24aoeu@gg-is-awesome-xm273.mongodb.net/test?retryWrites=true&w=majority",
+            "range": [
+                400,
+                497
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 0
+                },
+                "end": {
+                    "line": 11,
+                    "column": 97
+                }
+            },
+            "severity": "error",
+            "messageId": "MongoDBConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MongoDBConnection",
+            "data": {
+                "URI": "mongodb+srv://testuser:hub24aoeu@gg-is-awesome-xm273.mongodb.net/test?retryWrites=true&w=majority"
+            }
+        },
+        {
+            "message": "found MongoDB connection string: mongodb://admin:secretKey456@cluster.mongodb.net:27017/admin",
+            "range": [
+                569,
+                629
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 0
+                },
+                "end": {
+                    "line": 14,
+                    "column": 60
+                }
+            },
+            "severity": "error",
+            "messageId": "MongoDBConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MongoDBConnection",
+            "data": {
+                "URI": "mongodb://admin:secretKey456@cluster.mongodb.net:27017/admin"
+            }
+        },
+        {
+            "message": "found MongoDB connection string: mongodb+srv://user:passW0rd123@prod-cluster.mongodb.net/production?retryWrites=true",
+            "range": [
+                630,
+                713
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 83
+                }
+            },
+            "severity": "error",
+            "messageId": "MongoDBConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MongoDBConnection",
+            "data": {
+                "URI": "mongodb+srv://user:passW0rd123@prod-cluster.mongodb.net/production?retryWrites=true"
+            }
+        },
+        {
+            "message": "found MongoDB connection string: mongodb://devuser:mySecret789@dev.mongodb.com:27017/dev_db",
+            "range": [
+                714,
+                772
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 58
+                }
+            },
+            "severity": "error",
+            "messageId": "MongoDBConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MongoDBConnection",
+            "data": {
+                "URI": "mongodb://devuser:mySecret789@dev.mongodb.com:27017/dev_db"
+            }
+        }
+    ],
+    "sourceContent": "# Valid MongoDB connection strings with real credentials\n\n# MongoDB standard connection\nconst MONGO_URI = \"mongodb://realuser:s3cr3tP4ss@db1.example.net:27017/production\";\n\n# MongoDB SRV connection  \nconst MONGO_SRV = \"mongodb+srv://appuser:myR3alP@ssw0rd@cluster0.mongodb.net/mydb?retryWrites=true\";\n\n# MongoDB from additional cases\nCONECTION_URI=\"mongodb://root:m42ploz2wd@google.com:5434/thegift\"\nmongodb+srv://testuser:hub24aoeu@gg-is-awesome-xm273.mongodb.net/test?retryWrites=true&w=majority\n\n# Additional test cases for password patterns that should be detected\nmongodb://admin:secretKey456@cluster.mongodb.net:27017/admin\nmongodb+srv://user:passW0rd123@prod-cluster.mongodb.net/production?retryWrites=true\nmongodb://devuser:mySecret789@dev.mongodb.com:27017/dev_db",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.mysql/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.mysql/input.txt
@@ -1,0 +1,19 @@
+# Valid MySQL connection strings with real credentials
+
+# MySQL standard connection
+const MYSQL_URI = "mysql://dbuser:compl3xPwd@mysql.server.com:3306/database";
+
+# MySQL JDBC connection
+const MYSQL_JDBC = "jdbc:mysql://admin:str0ngP4ss@db.company.com:3306/app_db";
+
+# MySQL from additional cases
+CONNECTION_URI="mysql://root:m42ploz2wd@google.com:5434/thegift"
+mysql --user=doadmin --password=strongp@55! --host=db-mysql-ams3-23775-do-user-7772205-0.a.db.ondigitalocean.com
+jdbc:mysql://sandy:secret@[myhost1:1111,myhost2:2222]/db
+jdbc:mysql://[(host=myhost1,port=1111,user=sandy,password=secret),(host=myhost2,port=2222,user=finn,password=secret)]/db
+Server=myServerAddress;Database=myDataBase;Uid=myUsername;Pwd=myPassword;
+
+# Additional test cases for password patterns that should be detected
+mysql://testuser:secretKey123@db.example.com:3306/testdb
+mysql://apiuser:passW0rd!@internal.db.com:3306/api
+mysql://devuser:mySecret2024@localhost:3306/dev_db

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.mysql/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.mysql/output.json
@@ -1,0 +1,163 @@
+{
+    "filePath": "[SNAPSHOT]/ng.mysql/input.txt",
+    "messages": [
+        {
+            "message": "found MySQL connection string: mysql://dbuser:compl3xPwd@mysql.server.com:3306/database\";",
+            "range": [
+                103,
+                161
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 19
+                },
+                "end": {
+                    "line": 4,
+                    "column": 77
+                }
+            },
+            "severity": "error",
+            "messageId": "MySQLConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MySQLConnection",
+            "data": {
+                "URI": "mysql://dbuser:compl3xPwd@mysql.server.com:3306/database\";"
+            }
+        },
+        {
+            "message": "found MySQL connection string: jdbc:mysql://admin:str0ngP4ss@db.company.com:3306/app_db\";",
+            "range": [
+                207,
+                265
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 20
+                },
+                "end": {
+                    "line": 7,
+                    "column": 78
+                }
+            },
+            "severity": "error",
+            "messageId": "MySQLConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MySQLConnection",
+            "data": {
+                "URI": "jdbc:mysql://admin:str0ngP4ss@db.company.com:3306/app_db\";"
+            }
+        },
+        {
+            "message": "found MySQL connection string: mysql://root:m42ploz2wd@google.com:5434/thegift\"",
+            "range": [
+                313,
+                361
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 16
+                },
+                "end": {
+                    "line": 10,
+                    "column": 64
+                }
+            },
+            "severity": "error",
+            "messageId": "MySQLConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MySQLConnection",
+            "data": {
+                "URI": "mysql://root:m42ploz2wd@google.com:5434/thegift\""
+            }
+        },
+        {
+            "message": "found MySQL connection string: mysql://testuser:secretKey123@db.example.com:3306/testdb",
+            "range": [
+                798,
+                854
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 0
+                },
+                "end": {
+                    "line": 17,
+                    "column": 56
+                }
+            },
+            "severity": "error",
+            "messageId": "MySQLConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MySQLConnection",
+            "data": {
+                "URI": "mysql://testuser:secretKey123@db.example.com:3306/testdb"
+            }
+        },
+        {
+            "message": "found MySQL connection string: mysql://apiuser:passW0rd!@internal.db.com:3306/api",
+            "range": [
+                855,
+                905
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 18,
+                    "column": 50
+                }
+            },
+            "severity": "error",
+            "messageId": "MySQLConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MySQLConnection",
+            "data": {
+                "URI": "mysql://apiuser:passW0rd!@internal.db.com:3306/api"
+            }
+        },
+        {
+            "message": "found MySQL connection string: mysql://devuser:mySecret2024@localhost:3306/dev_db",
+            "range": [
+                906,
+                956
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 0
+                },
+                "end": {
+                    "line": 19,
+                    "column": 50
+                }
+            },
+            "severity": "error",
+            "messageId": "MySQLConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#MySQLConnection",
+            "data": {
+                "URI": "mysql://devuser:mySecret2024@localhost:3306/dev_db"
+            }
+        }
+    ],
+    "sourceContent": "# Valid MySQL connection strings with real credentials\n\n# MySQL standard connection\nconst MYSQL_URI = \"mysql://dbuser:compl3xPwd@mysql.server.com:3306/database\";\n\n# MySQL JDBC connection\nconst MYSQL_JDBC = \"jdbc:mysql://admin:str0ngP4ss@db.company.com:3306/app_db\";\n\n# MySQL from additional cases\nCONNECTION_URI=\"mysql://root:m42ploz2wd@google.com:5434/thegift\"\nmysql --user=doadmin --password=strongp@55! --host=db-mysql-ams3-23775-do-user-7772205-0.a.db.ondigitalocean.com\njdbc:mysql://sandy:secret@[myhost1:1111,myhost2:2222]/db\njdbc:mysql://[(host=myhost1,port=1111,user=sandy,password=secret),(host=myhost2,port=2222,user=finn,password=secret)]/db\nServer=myServerAddress;Database=myDataBase;Uid=myUsername;Pwd=myPassword;\n\n# Additional test cases for password patterns that should be detected\nmysql://testuser:secretKey123@db.example.com:3306/testdb\nmysql://apiuser:passW0rd!@internal.db.com:3306/api\nmysql://devuser:mySecret2024@localhost:3306/dev_db",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.postgresql/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.postgresql/input.txt
@@ -1,0 +1,14 @@
+# Valid PostgreSQL connection strings with real credentials
+
+# PostgreSQL standard connection (postgresql protocol)
+const PG_URI = "postgresql://pguser:secur3Pass@postgres.example.com:5432/production_db";
+
+# PostgreSQL standard connection (postgres protocol)
+const POSTGRES_URI = "postgres://api_user:myC0mpl3xPwd@db.internal.com:5432/api_db";
+
+# PostgreSQL from additional cases
+CONNECTION_URI="postgres://postgres:m42p! o@2wd@google.com:5434/thegift"
+PG_USERNAME=root. PG_PASSWORD=m42ploz2wd
+PGPASSWORD=strongp@ss psql -hdb-postgresql-ams3-58486-do-user-7772205-0.b.db.ondigitalocean.com -Udoadmin -p 25060
+create_engine('postgresql://postgres:m42ploz2wd@google.com:5432/mydb')
+Host=your_host; Port=5432; Database=your_database; Username=your_username; Password=your_password;

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.postgresql/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ng.postgresql/output.json
@@ -1,0 +1,85 @@
+{
+    "filePath": "[SNAPSHOT]/ng.postgresql/input.txt",
+    "messages": [
+        {
+            "message": "found PostgreSQL connection string: postgresql://pguser:secur3Pass@postgres.example.com:5432/production_db\";",
+            "range": [
+                132,
+                204
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 16
+                },
+                "end": {
+                    "line": 4,
+                    "column": 88
+                }
+            },
+            "severity": "error",
+            "messageId": "PostgreSQLConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#PostgreSQLConnection",
+            "data": {
+                "URI": "postgresql://pguser:secur3Pass@postgres.example.com:5432/production_db\";"
+            }
+        },
+        {
+            "message": "found PostgreSQL connection string: postgres://api_user:myC0mpl3xPwd@db.internal.com:5432/api_db\";",
+            "range": [
+                281,
+                343
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 22
+                },
+                "end": {
+                    "line": 7,
+                    "column": 84
+                }
+            },
+            "severity": "error",
+            "messageId": "PostgreSQLConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#PostgreSQLConnection",
+            "data": {
+                "URI": "postgres://api_user:myC0mpl3xPwd@db.internal.com:5432/api_db\";"
+            }
+        },
+        {
+            "message": "found PostgreSQL connection string: postgresql://postgres:m42ploz2wd@google.com:5432/mydb')",
+            "range": [
+                624,
+                679
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-database-connection-string",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-recommend",
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 15
+                },
+                "end": {
+                    "line": 13,
+                    "column": 70
+                }
+            },
+            "severity": "error",
+            "messageId": "PostgreSQLConnection",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-database-connection-string/README.md#PostgreSQLConnection",
+            "data": {
+                "URI": "postgresql://postgres:m42ploz2wd@google.com:5432/mydb')"
+            }
+        }
+    ],
+    "sourceContent": "# Valid PostgreSQL connection strings with real credentials\n\n# PostgreSQL standard connection (postgresql protocol)\nconst PG_URI = \"postgresql://pguser:secur3Pass@postgres.example.com:5432/production_db\";\n\n# PostgreSQL standard connection (postgres protocol)\nconst POSTGRES_URI = \"postgres://api_user:myC0mpl3xPwd@db.internal.com:5432/api_db\";\n\n# PostgreSQL from additional cases\nCONNECTION_URI=\"postgres://postgres:m42p! o@2wd@google.com:5434/thegift\"\nPG_USERNAME=root. PG_PASSWORD=m42ploz2wd\nPGPASSWORD=strongp@ss psql -hdb-postgresql-ams3-58486-do-user-7772205-0.b.db.ondigitalocean.com -Udoadmin -p 25060\ncreate_engine('postgresql://postgres:m42ploz2wd@google.com:5432/mydb')\nHost=your_host; Port=5432; Database=your_database; Username=your_username; Password=your_password;",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ok.valid/input.txt
@@ -1,0 +1,15 @@
+# Valid database connection strings that should NOT be detected (false positives)
+
+# Template/placeholder patterns
+const MONGO_TEMPLATE = "mongodb://username:password@localhost:27017/database";
+const MYSQL_TEMPLATE = "mysql://user:${PASSWORD}@example.com:3306/db";
+const PG_TEMPLATE = "postgresql://{username}:{password}@{{host}}:5432/{database}";
+
+# Connection strings without credentials
+const MONGO_NO_AUTH = "mongodb://localhost:27017/database";
+const MYSQL_NO_AUTH = "mysql://db.example.com:3306/app";
+const PG_NO_AUTH = "postgresql://db.server.com:5432/production";
+
+# Connection strings with obvious placeholders
+const CONFIG_EXAMPLE = "mongodb://YOUR_USERNAME:YOUR_PASSWORD@cluster.mongodb.net/test";
+const DOC_EXAMPLE = "mysql://admin:REPLACE_WITH_PASSWORD@mysql.server.com:3306/database";

--- a/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/test/snapshots/secretlint-rule-database-connection-string/ok.valid/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.valid/input.txt",
+    "messages": [],
+    "sourceContent": "# Valid database connection strings that should NOT be detected (false positives)\n\n# Template/placeholder patterns\nconst MONGO_TEMPLATE = \"mongodb://username:password@localhost:27017/database\";\nconst MYSQL_TEMPLATE = \"mysql://user:${PASSWORD}@example.com:3306/db\";\nconst PG_TEMPLATE = \"postgresql://{username}:{password}@{{host}}:5432/{database}\";\n\n# Connection strings without credentials\nconst MONGO_NO_AUTH = \"mongodb://localhost:27017/database\";\nconst MYSQL_NO_AUTH = \"mysql://db.example.com:3306/app\";\nconst PG_NO_AUTH = \"postgresql://db.server.com:5432/production\";\n\n# Connection strings with obvious placeholders\nconst CONFIG_EXAMPLE = \"mongodb://YOUR_USERNAME:YOUR_PASSWORD@cluster.mongodb.net/test\";\nconst DOC_EXAMPLE = \"mysql://admin:REPLACE_WITH_PASSWORD@mysql.server.com:3306/database\";",
+    "sourceContentType": "text"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -900,14 +900,17 @@ importers:
         specifier: ^28.0.6
         version: 28.0.6(rollup@4.46.2)
       '@rollup/plugin-node-resolve':
-        specifier: ^16.0.1
-        version: 16.0.1(rollup@4.46.2)
+        specifier: ^15.3.1
+        version: 15.3.1(rollup@4.46.2)
       '@rollup/plugin-typescript':
         specifier: ^12.1.4
         version: 12.1.4(rollup@4.46.2)(tslib@2.8.1)(typescript@5.9.2)
       '@secretlint/secretlint-rule-1password':
         specifier: workspace:*
         version: link:../secretlint-rule-1password
+      '@secretlint/secretlint-rule-anthropic':
+        specifier: workspace:*
+        version: link:../secretlint-rule-anthropic
       '@secretlint/secretlint-rule-aws':
         specifier: workspace:*
         version: link:../secretlint-rule-aws
@@ -917,6 +920,9 @@ importers:
       '@secretlint/secretlint-rule-basicauth':
         specifier: workspace:*
         version: link:../secretlint-rule-basicauth
+      '@secretlint/secretlint-rule-database-connection-string':
+        specifier: workspace:*
+        version: link:../secretlint-rule-database-connection-string
       '@secretlint/secretlint-rule-filter-comments':
         specifier: workspace:*
         version: link:../secretlint-rule-filter-comments
@@ -1716,15 +1722,6 @@ packages:
 
   '@rollup/plugin-node-resolve@15.3.1':
     resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^2.78.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
-  '@rollup/plugin-node-resolve@16.0.1':
-    resolution: {integrity: sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
@@ -5196,16 +5193,6 @@ snapshots:
       rollup: 4.46.2
 
   '@rollup/plugin-node-resolve@15.3.1(rollup@4.46.2)':
-    dependencies:
-      '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-module: 1.0.0
-      resolve: 1.22.10
-    optionalDependencies:
-      rollup: 4.46.2
-
-  '@rollup/plugin-node-resolve@16.0.1(rollup@4.46.2)':
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
       '@types/resolve': 1.20.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -900,8 +900,8 @@ importers:
         specifier: ^28.0.6
         version: 28.0.6(rollup@4.46.2)
       '@rollup/plugin-node-resolve':
-        specifier: ^15.3.1
-        version: 15.3.1(rollup@4.46.2)
+        specifier: ^16.0.1
+        version: 16.0.1(rollup@4.46.2)
       '@rollup/plugin-typescript':
         specifier: ^12.1.4
         version: 12.1.4(rollup@4.46.2)(tslib@2.8.1)(typescript@5.9.2)
@@ -1722,6 +1722,15 @@ packages:
 
   '@rollup/plugin-node-resolve@15.3.1':
     resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-node-resolve@16.0.1':
+    resolution: {integrity: sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
@@ -5193,6 +5202,16 @@ snapshots:
       rollup: 4.46.2
 
   '@rollup/plugin-node-resolve@15.3.1(rollup@4.46.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-module: 1.0.0
+      resolve: 1.22.10
+    optionalDependencies:
+      rollup: 4.46.2
+
+  '@rollup/plugin-node-resolve@16.0.1(rollup@4.46.2)':
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
       '@types/resolve': 1.20.2


### PR DESCRIPTION
## Summary
- Add `@secretlint/secretlint-rule-anthropic` to detect Claude API keys (pattern: `sk-ant-api0\d-[A-Za-z0-9_-]{90,128}AA`)
- Add `@secretlint/secretlint-rule-database-connection-string` to detect database credentials
- Sync changes from canary preset to recommended preset for v11.0.0

## Breaking Change
This is a breaking change as it may introduce new secret detections in existing codebases.

## Test Plan
- [x] Run sync-canary script to copy rules from canary preset
- [x] Update test snapshots for the recommended preset
- [x] Verify all tests pass
- [x] Type checking passes

Fixes #1073

🤖 Generated with [Claude Code](https://claude.ai/code)