### PR TITLE
fix: add Node.js setup and dependencies installation to release workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: 20
+          node-version: 22
       - name: Install dependencies
         run: pnpm install
       - name: Update Version

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -24,11 +24,17 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - name: Setup Node.js
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: pnpm install
       - name: Update Version
         run: |
           git config --global user.email "${GIT_AUTHOR_EMAIL}"
           git config --global user.name "${GIT_AUTHOR_NAME}"
-          pnpm run ci:versionup:${SEMVER} --yes
+          pnpm run ci:versionup:${SEMVER}
         env:
           SEMVER: ${{ github.event.inputs.semver }}
           GIT_AUTHOR_NAME: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- Add Node.js setup and pnpm install steps to the Create Release PR workflow
- Remove redundant `--yes` flag from ci:versionup script call

## Problem
The Create Release PR workflow was failing with exit code 1 because:
1. Node.js was not set up before running pnpm commands
2. Dependencies were not installed before running the version update scripts

## Solution
- Added `Setup Node.js` step with Node.js version 20
- Added `Install dependencies` step to run `pnpm install`
- Removed the redundant `--yes` flag from the pnpm run command (it's already included in the package.json script)

## Test Plan
- [ ] The workflow should successfully run when triggered
- [ ] Version updates should work correctly
- [ ] Release PR should be created with proper version changes

Fixes: https://github.com/secretlint/secretlint/actions/runs/16862855392/job/47765617958

🤖 Generated with [Claude Code](https://claude.ai/code)