### PR TITLE
fix: use workspace:* references for internal dependencies in examples

### DIFF
--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -29,9 +29,9 @@
         "benchmark": "node index.js"
     },
     "dependencies": {
-        "@secretlint/secretlint-rule-preset-canary": "^11.0.0",
+        "@secretlint/secretlint-rule-preset-canary": "workspace:*",
         "benchmark": "^2.1.4",
-        "secretlint": "^11.0.0"
+        "secretlint": "workspace:*"
     },
     "publishConfig": {
         "access": "public"

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -27,8 +27,8 @@
         "test": "secretlint \"**/*\" && exit 1 || exit 0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^11.0.0",
-        "secretlint": "^11.0.0"
+        "@secretlint/secretlint-rule-preset-recommend": "workspace:*",
+        "secretlint": "workspace:*"
     },
     "publishConfig": {
         "access": "public"

--- a/examples/quick-start/package.json
+++ b/examples/quick-start/package.json
@@ -27,7 +27,7 @@
         "test": "npx @secretlint/quick-start \"**/*\" && exit 1 || exit 0"
     },
     "devDependencies": {
-        "@secretlint/quick-start": "^11.0.0"
+        "@secretlint/quick-start": "workspace:*"
     },
     "publishConfig": {
         "access": "public"

--- a/examples/stdin/package.json
+++ b/examples/stdin/package.json
@@ -27,8 +27,8 @@
         "test": "cat ./credential | secretlint --stdinFileName=secret.txt --format json && exit 1 || exit 0"
     },
     "devDependencies": {
-        "@secretlint/secretlint-rule-preset-recommend": "^11.0.0",
-        "secretlint": "^11.0.0"
+        "@secretlint/secretlint-rule-preset-recommend": "workspace:*",
+        "secretlint": "workspace:*"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/@secretlint/quick-start/package.json
+++ b/packages/@secretlint/quick-start/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@secretlint/secretlint-rule-preset-recommend": "workspace:*",
-    "secretlint": "^11.0.0"
+    "secretlint": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^24.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,38 +36,38 @@ importers:
   examples/benchmark:
     dependencies:
       '@secretlint/secretlint-rule-preset-canary':
-        specifier: ^10.2.2
-        version: 10.2.2
+        specifier: workspace:*
+        version: link:../../packages/@secretlint/secretlint-rule-preset-canary
       benchmark:
         specifier: ^2.1.4
         version: 2.1.4
       secretlint:
-        specifier: ^10.2.2
-        version: 10.2.2
+        specifier: workspace:*
+        version: link:../../packages/secretlint
 
   examples/cli:
     devDependencies:
       '@secretlint/secretlint-rule-preset-recommend':
-        specifier: ^10.2.2
-        version: 10.2.2
+        specifier: workspace:*
+        version: link:../../packages/@secretlint/secretlint-rule-preset-recommend
       secretlint:
-        specifier: ^10.2.2
-        version: 10.2.2
+        specifier: workspace:*
+        version: link:../../packages/secretlint
 
   examples/quick-start:
     devDependencies:
       '@secretlint/quick-start':
-        specifier: ^10.2.2
-        version: 10.2.2
+        specifier: workspace:*
+        version: link:../../packages/@secretlint/quick-start
 
   examples/stdin:
     devDependencies:
       '@secretlint/secretlint-rule-preset-recommend':
-        specifier: ^10.2.2
-        version: 10.2.2
+        specifier: workspace:*
+        version: link:../../packages/@secretlint/secretlint-rule-preset-recommend
       secretlint:
-        specifier: ^10.2.2
-        version: 10.2.2
+        specifier: workspace:*
+        version: link:../../packages/secretlint
 
   packages/@secretlint/config-creator:
     dependencies:
@@ -315,8 +315,8 @@ importers:
         specifier: workspace:*
         version: link:../secretlint-rule-preset-recommend
       secretlint:
-        specifier: ^10.2.2
-        version: 10.2.2
+        specifier: workspace:*
+        version: link:../../secretlint
     devDependencies:
       '@types/node':
         specifier: ^24.1.0
@@ -1877,53 +1877,6 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
-
-  '@secretlint/config-creator@10.2.2':
-    resolution: {integrity: sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@secretlint/config-loader@10.2.2':
-    resolution: {integrity: sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@secretlint/core@10.2.2':
-    resolution: {integrity: sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==}
-    engines: {node: '>=20.0.0'}
-
-  '@secretlint/formatter@10.2.2':
-    resolution: {integrity: sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==}
-    engines: {node: '>=20.0.0'}
-
-  '@secretlint/node@10.2.2':
-    resolution: {integrity: sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@secretlint/profiler@10.2.2':
-    resolution: {integrity: sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==}
-
-  '@secretlint/quick-start@10.2.2':
-    resolution: {integrity: sha512-5ZCyDV3nEdfDQWJlYognuUaxGEdCvNV1YI7gl04VX6XHuwZdODBDl76DOYsXDZmxOKOCd98+HOmib711CVnr9w==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  '@secretlint/resolver@10.2.2':
-    resolution: {integrity: sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==}
-
-  '@secretlint/secretlint-rule-preset-canary@10.2.2':
-    resolution: {integrity: sha512-/gJbm3Jj9iV6FpP430HTxHee1DQ0UPEIEZQZ37tGNIgckQYxn6lcxwY0DTtrkzVJ/dgXSY7pckB45B3Sf9x+iA==}
-    engines: {node: '>=20.0.0'}
-
-  '@secretlint/secretlint-rule-preset-recommend@10.2.2':
-    resolution: {integrity: sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==}
-    engines: {node: '>=20.0.0'}
-
-  '@secretlint/source-creator@10.2.2':
-    resolution: {integrity: sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==}
-    engines: {node: '>=20.0.0'}
-
-  '@secretlint/types@10.2.2':
-    resolution: {integrity: sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==}
-    engines: {node: '>=20.0.0'}
 
   '@sigstore/bundle@3.1.0':
     resolution: {integrity: sha512-Mm1E3/CmDDCz3nDhFKTuYdB47EdRFRQMOE/EAbiG1MJW77/w1b3P7Qx7JSrVJs8PfwOLOVcKQCHErIwCTyPbag==}
@@ -3957,11 +3910,6 @@ packages:
     resolution: {integrity: sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==}
     engines: {node: '>=18.0.0'}
 
-  secretlint@10.2.2:
-    resolution: {integrity: sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
@@ -5335,81 +5283,6 @@ snapshots:
       type-fest: 4.26.1
 
   '@sec-ant/readable-stream@0.4.1': {}
-
-  '@secretlint/config-creator@10.2.2':
-    dependencies:
-      '@secretlint/types': 10.2.2
-
-  '@secretlint/config-loader@10.2.2':
-    dependencies:
-      '@secretlint/profiler': 10.2.2
-      '@secretlint/resolver': 10.2.2
-      '@secretlint/types': 10.2.2
-      ajv: 8.17.1
-      debug: 4.4.1
-      rc-config-loader: 4.1.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@secretlint/core@10.2.2':
-    dependencies:
-      '@secretlint/profiler': 10.2.2
-      '@secretlint/types': 10.2.2
-      debug: 4.4.1
-      structured-source: 4.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@secretlint/formatter@10.2.2':
-    dependencies:
-      '@secretlint/resolver': 10.2.2
-      '@secretlint/types': 10.2.2
-      '@textlint/linter-formatter': 15.2.1
-      '@textlint/module-interop': 15.2.1
-      '@textlint/types': 15.2.1
-      chalk: 5.5.0
-      debug: 4.4.1
-      pluralize: 8.0.0
-      strip-ansi: 7.1.0
-      table: 6.9.0
-      terminal-link: 4.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@secretlint/node@10.2.2':
-    dependencies:
-      '@secretlint/config-loader': 10.2.2
-      '@secretlint/core': 10.2.2
-      '@secretlint/formatter': 10.2.2
-      '@secretlint/profiler': 10.2.2
-      '@secretlint/source-creator': 10.2.2
-      '@secretlint/types': 10.2.2
-      debug: 4.4.1
-      p-map: 7.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@secretlint/profiler@10.2.2': {}
-
-  '@secretlint/quick-start@10.2.2':
-    dependencies:
-      '@secretlint/secretlint-rule-preset-recommend': 10.2.2
-      secretlint: 10.2.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@secretlint/resolver@10.2.2': {}
-
-  '@secretlint/secretlint-rule-preset-canary@10.2.2': {}
-
-  '@secretlint/secretlint-rule-preset-recommend@10.2.2': {}
-
-  '@secretlint/source-creator@10.2.2':
-    dependencies:
-      '@secretlint/types': 10.2.2
-      istextorbinary: 9.5.0
-
-  '@secretlint/types@10.2.2': {}
 
   '@sigstore/bundle@3.1.0':
     dependencies:
@@ -7631,18 +7504,6 @@ snapshots:
       elliptic: 6.6.1
       node-addon-api: 5.1.0
       node-gyp-build: 4.8.4
-
-  secretlint@10.2.2:
-    dependencies:
-      '@secretlint/config-creator': 10.2.2
-      '@secretlint/formatter': 10.2.2
-      '@secretlint/node': 10.2.2
-      '@secretlint/profiler': 10.2.2
-      debug: 4.4.1
-      globby: 14.1.0
-      read-pkg: 9.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   semver@5.7.2: {}
 


### PR DESCRIPTION
## Summary
- Fixed all example packages to use `workspace:*` references for internal dependencies
- Updated `@secretlint/quick-start` package as well
- This ensures proper dependency resolution during CI/CD workflows

## Changes
- `examples/cli/package.json`
- `examples/benchmark/package.json`
- `examples/quick-start/package.json`
- `examples/stdin/package.json`
- `packages/@secretlint/quick-start/package.json`

## Test plan
- [x] `pnpm install` runs successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)