### PR TITLE
docs(contributing): add pre-release documentation checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -369,6 +369,22 @@ Secretlint has a continuous benchmark:
 
 A Maintainer release new version of secretlint by following way.
 
+### Pre-Release Checklist
+
+Before creating a release, ensure documentation is up-to-date:
+
+1. **For new packages/rules**: Check that they are documented in:
+   - Main README.md (if it's a standalone rule or important package)
+   - docs/configuration.md (if it affects configuration)
+   - CONTRIBUTING.md (if it's a preset that affects the rule addition flow)
+
+2. **For preset packages** (`@secretlint/secretlint-rule-preset-*`):
+   - Ensure the preset is listed in README.md
+   - Update configuration examples if needed
+   - Document any breaking changes in the preset
+
+### Release Process
+
 1. Create Release PR via GitHub Actions: <https://github.com/secretlint/secretlint/actions/workflows/create-release-pr.yml>
    - Run workflow with `version` input
       - You can select new version with semver(patch,minor,major)
@@ -378,6 +394,7 @@ A Maintainer release new version of secretlint by following way.
    - e.g. https://github.com/azu/monorepo-github-releases/pull/18
 3. Review the Release PR
    - You can modify PR body for changelog
+   - Verify that documentation mentions all new packages/features
 4. Merge the Release PR
 5. [CI] Publish new version to npm and GitHub Release
    - The release note content is same to PR body


### PR DESCRIPTION
## Summary
- Add pre-release checklist to CONTRIBUTING.md to ensure documentation is updated when releasing new packages
- Emphasize documentation requirements for preset packages

## Details
This PR improves the release flow documentation by adding a pre-release checklist that reminds maintainers to:
1. Check that new packages/rules are properly documented in README.md, docs/configuration.md, and CONTRIBUTING.md
2. Ensure preset packages are listed and have updated configuration examples
3. Document any breaking changes

This helps prevent situations where new packages (like `@secretlint/secretlint-rule-preset-recommend`) are released without being fully documented in all relevant places.

🤖 Generated with [Claude Code](https://claude.ai/code)