### PR TITLE
docs(readme): add missing rules from preset-recommend

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,12 +332,16 @@ Secretlint rules has been implemented as separated modules.
 - [@secretlint/secretlint-rule-sendgrid](./packages/%40secretlint/secretlint-rule-sendgrid)
 - [@secretlint/secretlint-rule-shopify](./packages/%40secretlint/secretlint-rule-shopify)
 - [@secretlint/secretlint-rule-openai](./packages/%40secretlint/secretlint-rule-openai)
+- [@secretlint/secretlint-rule-anthropic](./packages/%40secretlint/secretlint-rule-anthropic)
 - [@secretlint/secretlint-rule-linear](./packages/%40secretlint/secretlint-rule-linear)
+- [@secretlint/secretlint-rule-1password](./packages/%40secretlint/secretlint-rule-1password)
+- [@secretlint/secretlint-rule-database-connection-string](./packages/%40secretlint/secretlint-rule-database-connection-string)
 - [@secretlint/secretlint-rule-secp256k1-privatekey](./packages/@secretlint/secretlint-rule-secp256k1-privatekey)
 - [@secretlint/secretlint-rule-no-k8s-kind-secret](./packages/@secretlint/secretlint-rule-no-k8s-kind-secret)
 - [@secretlint/secretlint-rule-pattern](./packages/@secretlint/secretlint-rule-pattern)
 - [@secretlint/secretlint-rule-no-homedir](./packages/@secretlint/secretlint-rule-no-homedir)
 - [@secretlint/secretlint-rule-no-dotenv](./packages/%40secretlint/secretlint-rule-no-dotenv)
+- [@secretlint/secretlint-rule-filter-comments](./packages/%40secretlint/secretlint-rule-filter-comments)
 
 
 Also, Secretlint provides rule preset that includes recommended rule set.

--- a/packages/@secretlint/secretlint-rule-preset-recommend/README.md
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/README.md
@@ -64,17 +64,20 @@ If you want to ignore `"AWSAccountID"` and `"AWSAccessKeyID"` of `"@secretlint/s
 
 ## Rules
 
-- [@secretlint/secretlint-rule-npm](https://www.npmjs.com/package/@secretlint/secretlint-rule-npm)
 - [@secretlint/secretlint-rule-aws](https://www.npmjs.com/package/@secretlint/secretlint-rule-aws)
 - [@secretlint/secretlint-rule-gcp](https://www.npmjs.com/package/@secretlint/secretlint-rule-gcp)
 - [@secretlint/secretlint-rule-privatekey](https://www.npmjs.com/package/@secretlint/secretlint-rule-privatekey)
+- [@secretlint/secretlint-rule-npm](https://www.npmjs.com/package/@secretlint/secretlint-rule-npm)
 - [@secretlint/secretlint-rule-basicauth](https://www.npmjs.com/package/@secretlint/secretlint-rule-basicauth)
 - [@secretlint/secretlint-rule-slack](https://www.npmjs.com/package/@secretlint/secretlint-rule-slack)
 - [@secretlint/secretlint-rule-sendgrid](https://www.npmjs.com/package/@secretlint/secretlint-rule-sendgrid)
 - [@secretlint/secretlint-rule-shopify](https://www.npmjs.com/package/@secretlint/secretlint-rule-shopify)
 - [@secretlint/secretlint-rule-github](https://www.npmjs.com/package/@secretlint/secretlint-rule-github)
-- [@secretlint/secretlint-rule-1password](https://www.npmjs.com/package/@secretlint/secretlint-rule-1password)
+- [@secretlint/secretlint-rule-openai](https://www.npmjs.com/package/@secretlint/secretlint-rule-openai)
+- [@secretlint/secretlint-rule-anthropic](https://www.npmjs.com/package/@secretlint/secretlint-rule-anthropic)
 - [@secretlint/secretlint-rule-linear](https://www.npmjs.com/package/@secretlint/secretlint-rule-linear)
+- [@secretlint/secretlint-rule-1password](https://www.npmjs.com/package/@secretlint/secretlint-rule-1password)
+- [@secretlint/secretlint-rule-database-connection-string](https://www.npmjs.com/package/@secretlint/secretlint-rule-database-connection-string)
 - [@secretlint/secretlint-rule-filter-comments](https://www.npmjs.com/package/@secretlint/secretlint-rule-filter-comments)
   - `secretlint-disable` directives. For more details, see <https://github.com/secretlint/secretlint/blob/master/docs/configuration.md#ignoring-error-by-comments>
 


### PR DESCRIPTION
## Summary
- Add missing rules to README.md that are included in @secretlint/secretlint-rule-preset-recommend
- Ensure all rules in the preset are properly documented

## Added Rules
The following rules were included in the preset but missing from the README documentation:

- **@secretlint/secretlint-rule-anthropic**: Detects Anthropic/Claude API keys (pattern: `sk-ant-api0\d-[A-Za-z0-9_-]{90,128}AA`)
- **@secretlint/secretlint-rule-database-connection-string**: Detects database credentials in connection strings (MongoDB, MySQL, PostgreSQL, etc.)
- **@secretlint/secretlint-rule-1password**: Detects 1Password secrets
- **@secretlint/secretlint-rule-filter-comments**: Supports ignoring secrets with comments like `secretlint-disable`

These rules are already part of the recommended preset, so users are already benefiting from them. This PR ensures they are properly documented in the main README.

🤖 Generated with [Claude Code](https://claude.ai/code)