### PR TITLE
feat: Add filePathGlobs option to @secretlint/secretlint-rule-pattern

### DIFF
--- a/packages/@secretlint/secretlint-rule-pattern/README.md
+++ b/packages/@secretlint/secretlint-rule-pattern/README.md
@@ -31,6 +31,42 @@ Via `.secretlintrc.json`(Recommended)
 
 ```
 
+### Using filePathGlobs
+
+You can use `filePathGlobs` to match against file paths using glob patterns:
+
+```json
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-pattern",
+      "options": {
+        "patterns": [
+          {
+            "name": "env files",
+            "filePathGlobs": ["**/.env", "**/.env.*"]
+          },
+          {
+            "name": "AWS credentials in env files",
+            "filePathGlobs": ["**/.env*"],
+            "pattern": "/aws_access_key_id|aws_secret_access_key/i"
+          },
+          {
+            "name": "private keys",
+            "filePathGlobs": ["**/*.pem", "**/*.key"],
+            "pattern": "/BEGIN (RSA |EC )?PRIVATE KEY/"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+- When only `filePathGlobs` is specified, the rule reports if the file path matches any of the glob patterns
+- When only `pattern` is specified, the rule reports if the file content matches the regex pattern
+- When both are specified, the rule reports only if both the file path matches the glob AND the content matches the pattern
+
 ## MessageIDs
 
 ### Pattern
@@ -42,6 +78,12 @@ Disallow to use specified RegEx patterns from SecretLint config.
 
 - `allows: string[]`
     - Allows a list of [RegExp-like String](https://github.com/textlint/regexp-string-matcher#regexp-like-string)
+- `patterns: PatternType[]`
+    - Array of pattern configurations
+    - Each pattern can have:
+        - `name: string` - Name of the pattern (required)
+        - `pattern?: string` - RegExp-like string to match against file content
+        - `filePathGlobs?: string[]` - Array of glob patterns to match against file paths
 
 ## Changelog
 

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-aws-in-env/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-aws-in-env/.secretlintrc.json
@@ -1,0 +1,16 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-pattern",
+      "options": {
+        "patterns": [
+          {
+            "name": "AWS credentials in env files",
+            "filePathGlobs": ["**/*.env", "**/.env*"],
+            "pattern": "/aws_access_key_id|aws_secret_access_key/i"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-aws-in-env/input.env
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-aws-in-env/input.env
@@ -1,0 +1,3 @@
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+DATABASE_URL=postgres://user:pass@localhost/db

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-aws-in-env/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-aws-in-env/output.json
@@ -1,0 +1,57 @@
+{
+  "filePath": "[SNAPSHOT]/ng.filePathGlobs-aws-in-env/input.env",
+  "sourceContent": "aws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\nDATABASE_URL=postgres://user:pass@localhost/db",
+  "sourceContentType": "text",
+  "messages": [
+    {
+      "data": {
+        "PATTERN_NAME": "AWS credentials in env files",
+        "CREDENTIAL": "aws_access_key_id"
+      },
+      "type": "message",
+      "message": "found matching AWS credentials in env files: aws_access_key_id",
+      "messageId": "PATTERN",
+      "range": [
+        0,
+        17
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 17
+        }
+      },
+      "severity": "error",
+      "ruleId": "@secretlint/secretlint-rule-pattern"
+    },
+    {
+      "data": {
+        "PATTERN_NAME": "AWS credentials in env files",
+        "CREDENTIAL": "aws_secret_access_key"
+      },
+      "type": "message",
+      "message": "found matching AWS credentials in env files: aws_secret_access_key",
+      "messageId": "PATTERN",
+      "range": [
+        39,
+        60
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 21
+        }
+      },
+      "severity": "error",
+      "ruleId": "@secretlint/secretlint-rule-pattern"
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-env-file/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-env-file/.secretlintrc.json
@@ -1,0 +1,15 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-pattern",
+      "options": {
+        "patterns": [
+          {
+            "name": "env files",
+            "filePathGlobs": ["**/*.env", "**/.env*"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-env-file/input.env
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-env-file/input.env
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://user:pass@localhost/db
+API_KEY=secret123

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-env-file/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-env-file/output.json
@@ -1,0 +1,32 @@
+{
+  "filePath": "[SNAPSHOT]/ng.filePathGlobs-env-file/input.env",
+  "sourceContent": "DATABASE_URL=postgres://user:pass@localhost/db\nAPI_KEY=secret123",
+  "sourceContentType": "text",
+  "messages": [
+    {
+      "data": {
+        "PATTERN_NAME": "env files",
+        "CREDENTIAL": "input.env"
+      },
+      "type": "message",
+      "message": "found matching env files: input.env",
+      "messageId": "PATTERN",
+      "range": [
+        0,
+        64
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 17
+        }
+      },
+      "severity": "error",
+      "ruleId": "@secretlint/secretlint-rule-pattern"
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-no-match/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-no-match/.secretlintrc.json
@@ -1,0 +1,16 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-pattern",
+      "options": {
+        "patterns": [
+          {
+            "name": "AWS credentials in env files",
+            "filePathGlobs": ["**/*.env", "**/.env*"],
+            "pattern": "/aws_access_key_id|aws_secret_access_key/i"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-no-match/input.txt
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-no-match/input.txt
@@ -1,0 +1,2 @@
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+This file won't match because it's not an .env file

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-no-match/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-no-match/output.json
@@ -1,0 +1,6 @@
+{
+  "filePath": "[SNAPSHOT]/ok.filePathGlobs-no-match/input.txt",
+  "sourceContent": "aws_access_key_id=AKIAIOSFODNN7EXAMPLE\nThis file won't match because it's not an .env file",
+  "sourceContentType": "text",
+  "messages": []
+}


### PR DESCRIPTION
## 概要

`@secretlint/secretlint-rule-pattern` ルールに `filePathGlobs` オプションを追加しました。このオプションにより、特定のファイルパスパターンに対してのみルールを適用できるようになります。

## 変更内容

### ✨ 新機能
- `PatternType` インターフェースに `filePathGlobs` オプションを追加
  - glob パターンの配列を指定して、特定のファイルパスにマッチする場合のみチェックを実行
  - Node.js の `path.matchesGlob` API を使用した効率的なパターンマッチング

### 🔧 改善
- パターン設定の柔軟性向上
  - `pattern` のみ指定: ファイル内容を正規表現でチェック
  - `filePathGlobs` のみ指定: ファイルパスがマッチしたらファイル全体を報告
  - 両方指定: パスがマッチしたファイルの内容を正規表現でチェック
- 設定検証の追加: `pattern` と `filePathGlobs` のいずれかが必須であることを保証

### 📝 ドキュメント
- README.md に `filePathGlobs` オプションの使用方法を追加
- 各パターンの組み合わせによる動作の詳細説明を記載

### ✅ テスト
- `filePathGlobs` の動作を検証する包括的なテストケースを追加
  - AWS クレデンシャルの環境変数ファイルチェック
  - 環境変数ファイルのパスマッチング
  - マッチしないファイルパスの処理

## 使用例

```json
{
  "rules": [
    {
      "id": "@secretlint/secretlint-rule-pattern",
      "options": {
        "patterns": [
          {
            "name": "Env files with AWS credentials",
            "pattern": "/aws_access_key_id|aws_secret_access_key/i",
            "filePathGlobs": ["**/*.env", "**/.env.*"]
          },
          {
            "name": "Any env file",
            "filePathGlobs": ["**/*.env"]
          }
        ]
      }
    }
  ]
}
```

## 背景・動機

特定のファイルタイプや配置場所に基づいてセキュリティチェックを行いたいケースがありました。例えば、環境変数ファイル（`.env`）にのみ適用したいルールや、特定のディレクトリ内のファイルに限定したチェックなどです。この機能により、より精密で効率的なセキュリティスキャンが可能になります。

## 破壊的変更

なし。既存の設定は引き続き動作し、新しいオプションは後方互換性を保ちながら追加されています。

## テスト計画

N/A（すべてのテストは自動化されています）

🤖 Generated with [Claude Code](https://claude.ai/code)