### PR TITLE
feat: Add patterns array support to @secretlint/secretlint-rule-pattern

### DIFF
--- a/packages/@secretlint/secretlint-rule-pattern/README.md
+++ b/packages/@secretlint/secretlint-rule-pattern/README.md
@@ -20,6 +20,33 @@ Via `.secretlintrc.json`(Recommended)
       "options": {
         "patterns": [
           {
+            "name": "credentials",
+            "patterns": [
+              "/password\\s*=\\s*(?<password>[\\w\\d!@#$%^&(){}\\[\\]:\";'<>,.?\/~`_+-=|]{1,256})\\b.*/",
+              "/apikey\\s*=\\s*(?<apikey>[\\w\\d]{8,})\\b.*/",
+              "/token\\s*=\\s*(?<token>[\\w\\d]{16,})\\b.*/"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+
+```
+
+### Deprecated options
+
+The `pattern` field (singular) is still supported but deprecated. Use `patterns` array instead:
+
+```json
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-pattern",
+      "options": {
+        "patterns": [
+          {
             "name": "password",
             "pattern": "/password\\s*=\\s*(?<password>[\\w\\d!@#$%^&(){}\\[\\]:\";'<>,.?\/~`_+-=|]{1,256})\\b.*/"
           }
@@ -28,7 +55,6 @@ Via `.secretlintrc.json`(Recommended)
     }
   ]
 }
-
 ```
 
 ### Using filePathGlobs
@@ -49,12 +75,17 @@ You can use `filePathGlobs` to match against file paths using glob patterns:
           {
             "name": "AWS credentials in env files",
             "filePathGlobs": ["**/.env*"],
-            "pattern": "/aws_access_key_id|aws_secret_access_key/i"
+            "patterns": [
+              "/aws_access_key_id\\s*=\\s*\\S+/i",
+              "/aws_secret_access_key\\s*=\\s*\\S+/i"
+            ]
           },
           {
             "name": "private keys",
             "filePathGlobs": ["**/*.pem", "**/*.key"],
-            "pattern": "/BEGIN (RSA |EC )?PRIVATE KEY/"
+            "patterns": [
+              "/BEGIN (RSA |EC )?PRIVATE KEY/"
+            ]
           }
         ]
       }
@@ -64,8 +95,8 @@ You can use `filePathGlobs` to match against file paths using glob patterns:
 ```
 
 - When only `filePathGlobs` is specified, the rule reports if the file path matches any of the glob patterns
-- When only `pattern` is specified, the rule reports if the file content matches the regex pattern
-- When both are specified, the rule reports only if both the file path matches the glob AND the content matches the pattern
+- When only `patterns` is specified, the rule reports if the file content matches any of the regex patterns
+- When both are specified, the rule reports only if both the file path matches the glob AND the content matches any of the patterns
 
 ## MessageIDs
 
@@ -82,7 +113,8 @@ Disallow to use specified RegEx patterns from SecretLint config.
     - Array of pattern configurations
     - Each pattern can have:
         - `name: string` - Name of the pattern (required)
-        - `pattern?: string` - RegExp-like string to match against file content
+        - `patterns?: string[]` - Array of RegExp-like strings to match against file content
+        - `pattern?: string` - Single RegExp-like string to match against file content (deprecated, use `patterns` instead)
         - `filePathGlobs?: string[]` - Array of glob patterns to match against file paths
 
 ## Changelog

--- a/packages/@secretlint/secretlint-rule-pattern/README.md
+++ b/packages/@secretlint/secretlint-rule-pattern/README.md
@@ -92,7 +92,7 @@ Disallow to use specified RegEx patterns from SecretLint config.
     - Each pattern can have:
         - `name: string` - Name of the pattern (required)
         - `patterns?: string[]` - Array of RegExp-like strings to match against file content
-        - `pattern?: string` - Single RegExp-like string to match against file content (deprecated, use `patterns` instead)
+        - `pattern?: string` - **[DEPRECATED]** Single RegExp-like string to match against file content (use `patterns` instead)
         - `filePathGlobs?: string[]` - Array of glob patterns to match against file paths
 
 ### Deprecated options

--- a/packages/@secretlint/secretlint-rule-pattern/README.md
+++ b/packages/@secretlint/secretlint-rule-pattern/README.md
@@ -35,28 +35,6 @@ Via `.secretlintrc.json`(Recommended)
 
 ```
 
-### Deprecated options
-
-The `pattern` field (singular) is still supported but deprecated. Use `patterns` array instead:
-
-```json
-{
-  "rules": [
-    {
-      "id": "@secretlint/secretlint-rule-pattern",
-      "options": {
-        "patterns": [
-          {
-            "name": "password",
-            "pattern": "/password\\s*=\\s*(?<password>[\\w\\d!@#$%^&(){}\\[\\]:\";'<>,.?\/~`_+-=|]{1,256})\\b.*/"
-          }
-        ]
-      }
-    }
-  ]
-}
-```
-
 ### Using filePathGlobs
 
 You can use `filePathGlobs` to match against file paths using glob patterns:
@@ -116,6 +94,28 @@ Disallow to use specified RegEx patterns from SecretLint config.
         - `patterns?: string[]` - Array of RegExp-like strings to match against file content
         - `pattern?: string` - Single RegExp-like string to match against file content (deprecated, use `patterns` instead)
         - `filePathGlobs?: string[]` - Array of glob patterns to match against file paths
+
+### Deprecated options
+
+The `pattern` field (singular) is still supported but deprecated. Use `patterns` array instead:
+
+```json
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-pattern",
+      "options": {
+        "patterns": [
+          {
+            "name": "password",
+            "pattern": "/password\\s*=\\s*(?<password>[\\w\\d!@#$%^&(){}\\[\\]:\";'<>,.?\/~`_+-=|]{1,256})\\b.*/"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
 
 ## Changelog
 

--- a/packages/@secretlint/secretlint-rule-pattern/test/patterns-array.test.ts
+++ b/packages/@secretlint/secretlint-rule-pattern/test/patterns-array.test.ts
@@ -1,0 +1,38 @@
+import { creator as rule } from "../src/index.js";
+
+import test from "node:test";
+test("@secretlint/secretlint-rule-pattern with patterns array", async (t) => {
+    const snapshot = (await import("@secretlint/tester")).snapshot;
+    await snapshot({
+        defaultConfig: {
+            rules: [
+                {
+                    id: "@secretlint/secretlint-rule-pattern",
+                    rule,
+                    options: {
+                        patterns: [
+                            {
+                                name: "credentials",
+                                patterns: [
+                                    "/password\\s*=\\s*(?<password>[\\w\\d!@#$%^&(){}\\[\\]:\";'<>,.?/~`_+-=|]{1,256})\\b.*/gi",
+                                    "/apikey\\s*=\\s*(?<apikey>[\\w\\d_-]{8,})\\b.*/gi",
+                                    "/token\\s*=\\s*(?<token>[\\w\\d_-]{16,})\\b.*/gi",
+                                ],
+                            },
+                        ],
+                        allows: ["foo-bar"],
+                    },
+                },
+            ],
+        },
+        updateSnapshot: !!process.env.UPDATE_SNAPSHOT,
+        snapshotDirectory: new URL("snapshots-patterns-array", import.meta.url),
+    }).forEach((name, test) => {
+        return t.test(name, async (context) => {
+            const status = await test();
+            if (status === "skip") {
+                context.skip();
+            }
+        });
+    });
+});

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots-patterns-array/ng.multiple-patterns/input.txt
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots-patterns-array/ng.multiple-patterns/input.txt
@@ -1,0 +1,3 @@
+password = MySecretPass123!
+apikey = sk_test_abcd1234efgh5678
+token = ghp_1234567890abcdefghij1234567890abcdef

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots-patterns-array/ng.multiple-patterns/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots-patterns-array/ng.multiple-patterns/output.json
@@ -1,0 +1,82 @@
+{
+    "filePath": "[SNAPSHOT]/ng.multiple-patterns/input.txt",
+    "messages": [
+        {
+            "message": "found matching credentials: password = MySecretPass123!",
+            "range": [
+                0,
+                27
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-pattern",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            },
+            "severity": "error",
+            "messageId": "PATTERN",
+            "data": {
+                "PATTERN_NAME": "credentials",
+                "CREDENTIAL": "password = MySecretPass123!"
+            }
+        },
+        {
+            "message": "found matching credentials: apikey = sk_test_abcd1234efgh5678",
+            "range": [
+                28,
+                61
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-pattern",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 33
+                }
+            },
+            "severity": "error",
+            "messageId": "PATTERN",
+            "data": {
+                "PATTERN_NAME": "credentials",
+                "CREDENTIAL": "apikey = sk_test_abcd1234efgh5678"
+            }
+        },
+        {
+            "message": "found matching credentials: token = ghp_1234567890abcdefghij1234567890abcdef",
+            "range": [
+                62,
+                110
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-pattern",
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 48
+                }
+            },
+            "severity": "error",
+            "messageId": "PATTERN",
+            "data": {
+                "PATTERN_NAME": "credentials",
+                "CREDENTIAL": "token = ghp_1234567890abcdefghij1234567890abcdef"
+            }
+        }
+    ],
+    "sourceContent": "password = MySecretPass123!\napikey = sk_test_abcd1234efgh5678\ntoken = ghp_1234567890abcdefghij1234567890abcdef",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots-patterns-array/ok.allows-patterns/input.txt
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots-patterns-array/ok.allows-patterns/input.txt
@@ -1,0 +1,3 @@
+password = foo-bar
+apikey = foo-bar
+token = foo-bar

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots-patterns-array/ok.allows-patterns/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots-patterns-array/ok.allows-patterns/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.allows-patterns/input.txt",
+    "messages": [],
+    "sourceContent": "password = foo-bar\napikey = foo-bar\ntoken = foo-bar",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-aws-in-env/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-aws-in-env/output.json
@@ -1,57 +1,57 @@
 {
-  "filePath": "[SNAPSHOT]/ng.filePathGlobs-aws-in-env/input.env",
-  "sourceContent": "aws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\nDATABASE_URL=postgres://user:pass@localhost/db",
-  "sourceContentType": "text",
-  "messages": [
-    {
-      "data": {
-        "PATTERN_NAME": "AWS credentials in env files",
-        "CREDENTIAL": "aws_access_key_id"
-      },
-      "type": "message",
-      "message": "found matching AWS credentials in env files: aws_access_key_id",
-      "messageId": "PATTERN",
-      "range": [
-        0,
-        17
-      ],
-      "loc": {
-        "start": {
-          "line": 1,
-          "column": 0
+    "filePath": "[SNAPSHOT]/ng.filePathGlobs-aws-in-env/input.env",
+    "messages": [
+        {
+            "message": "found matching AWS credentials in env files: aws_access_key_id",
+            "range": [
+                0,
+                17
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-pattern",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            },
+            "severity": "error",
+            "messageId": "PATTERN",
+            "data": {
+                "PATTERN_NAME": "AWS credentials in env files",
+                "CREDENTIAL": "aws_access_key_id"
+            }
         },
-        "end": {
-          "line": 1,
-          "column": 17
+        {
+            "message": "found matching AWS credentials in env files: aws_secret_access_key",
+            "range": [
+                39,
+                60
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-pattern",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 21
+                }
+            },
+            "severity": "error",
+            "messageId": "PATTERN",
+            "data": {
+                "PATTERN_NAME": "AWS credentials in env files",
+                "CREDENTIAL": "aws_secret_access_key"
+            }
         }
-      },
-      "severity": "error",
-      "ruleId": "@secretlint/secretlint-rule-pattern"
-    },
-    {
-      "data": {
-        "PATTERN_NAME": "AWS credentials in env files",
-        "CREDENTIAL": "aws_secret_access_key"
-      },
-      "type": "message",
-      "message": "found matching AWS credentials in env files: aws_secret_access_key",
-      "messageId": "PATTERN",
-      "range": [
-        39,
-        60
-      ],
-      "loc": {
-        "start": {
-          "line": 2,
-          "column": 0
-        },
-        "end": {
-          "line": 2,
-          "column": 21
-        }
-      },
-      "severity": "error",
-      "ruleId": "@secretlint/secretlint-rule-pattern"
-    }
-  ]
+    ],
+    "sourceContent": "aws_access_key_id=AKIAIOSFODNN7EXAMPLE\naws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\nDATABASE_URL=postgres://user:pass@localhost/db",
+    "sourceContentType": "text"
 }

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.patterns-and-pattern-error/input.txt
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.patterns-and-pattern-error/input.txt
@@ -1,0 +1,1 @@
+This test should not run because patterns and pattern are both specified

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.patterns-and-pattern-error/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.patterns-and-pattern-error/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ng.patterns-and-pattern-error/input.txt",
+    "messages": [],
+    "sourceContent": "This test should not run because patterns and pattern are both specified",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.patterns-array/input.txt
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.patterns-array/input.txt
@@ -1,0 +1,3 @@
+password = MySecretPass123!
+apikey = sk_test_abcd1234efgh5678
+token = ghp_1234567890abcdefghij1234567890abcdef

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.patterns-array/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.patterns-array/output.json
@@ -1,11 +1,11 @@
 {
-    "filePath": "[SNAPSHOT]/ng.filePathGlobs-env-file/input.env",
+    "filePath": "[SNAPSHOT]/ng.patterns-array/input.txt",
     "messages": [
         {
-            "message": "found matching env files: input.env",
+            "message": "found matching password=: password = MySecretPass123!",
             "range": [
                 0,
-                64
+                27
             ],
             "type": "message",
             "ruleId": "@secretlint/secretlint-rule-pattern",
@@ -15,18 +15,18 @@
                     "column": 0
                 },
                 "end": {
-                    "line": 2,
-                    "column": 17
+                    "line": 1,
+                    "column": 27
                 }
             },
             "severity": "error",
             "messageId": "PATTERN",
             "data": {
-                "PATTERN_NAME": "env files",
-                "CREDENTIAL": "input.env"
+                "PATTERN_NAME": "password=",
+                "CREDENTIAL": "password = MySecretPass123!"
             }
         }
     ],
-    "sourceContent": "DATABASE_URL=postgres://user:pass@localhost/db\nAPI_KEY=secret123",
+    "sourceContent": "password = MySecretPass123!\napikey = sk_test_abcd1234efgh5678\ntoken = ghp_1234567890abcdefghij1234567890abcdef",
     "sourceContentType": "text"
 }

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-no-match/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-no-match/output.json
@@ -1,6 +1,6 @@
 {
-  "filePath": "[SNAPSHOT]/ok.filePathGlobs-no-match/input.txt",
-  "sourceContent": "aws_access_key_id=AKIAIOSFODNN7EXAMPLE\nThis file won't match because it's not an .env file",
-  "sourceContentType": "text",
-  "messages": []
+    "filePath": "[SNAPSHOT]/ok.filePathGlobs-no-match/input.txt",
+    "messages": [],
+    "sourceContent": "aws_access_key_id=AKIAIOSFODNN7EXAMPLE\nThis file won't match because it's not an .env file",
+    "sourceContentType": "text"
 }

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.patterns-array-with-allows/input.txt
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.patterns-array-with-allows/input.txt
@@ -1,0 +1,3 @@
+password = foo-bar
+apikey = foo-bar
+token = foo-bar

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.patterns-array-with-allows/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.patterns-array-with-allows/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.patterns-array-with-allows/input.txt",
+    "messages": [],
+    "sourceContent": "password = foo-bar\napikey = foo-bar\ntoken = foo-bar",
+    "sourceContentType": "text"
+}


### PR DESCRIPTION
## Summary

This PR adds support for specifying multiple patterns as an array in `@secretlint/secretlint-rule-pattern`. The new `patterns` field allows grouping related regex patterns into a single rule configuration, improving maintainability and readability.

## What's Changed

- Introduced a new `patterns` array field that accepts multiple regex patterns
- Deprecated the existing singular `pattern` field (soft deprecation with backward compatibility)
- Added validation to prevent simultaneous use of both `patterns` and `pattern` fields
- Refactored pattern collection logic into a dedicated `collectPatterns()` function

## Key Changes

- **`src/index.ts`**: 
  - Added `patterns?: string[]` field to `PatternType` interface
  - Created `collectPatterns()` function for cleaner pattern resolution logic
  - Added validation to throw error when both fields are specified together
  - Maintained backward compatibility with deprecated `pattern` field

- **`README.md`**:
  - Updated usage examples to demonstrate the new `patterns` array
  - Added "Deprecated options" section explaining migration path
  - Updated all examples to use the preferred `patterns` format

## Usage Example

### Before (Multiple separate rules)
```json
{
  "patterns": [
    {
      "name": "password",
      "pattern": "/password\\s*=\\s*[\\w\\d]+/"
    },
    {
      "name": "apikey", 
      "pattern": "/apikey\\s*=\\s*[\\w\\d]+/"
    }
  ]
}
```

### After (Single rule with multiple patterns)
```json
{
  "patterns": [
    {
      "name": "credentials",
      "patterns": [
        "/password\\s*=\\s*[\\w\\d]+/",
        "/apikey\\s*=\\s*[\\w\\d]+/",
        "/token\\s*=\\s*[\\w\\d]+/"
      ]
    }
  ]
}
```

## Test Plan

- [ ] Verify new `patterns` array correctly detects multiple patterns
- [ ] Confirm existing `pattern` field continues to work (backward compatibility)
- [ ] Test that specifying both `patterns` and `pattern` throws appropriate error
- [ ] Verify `filePathGlobs` works correctly with new `patterns` array
- [ ] Test error handling when neither patterns nor filePathGlobs are specified
- [ ] Validate README examples work as documented

## Breaking Changes

- **Minor breaking change**: Specifying both `patterns` and `pattern` fields together now throws an error. Users must choose one or the other.

## Additional Notes

- The `pattern` field remains functional but is now deprecated
- Migration period allows both formats to coexist (just not in the same rule)
- Related to #1184 which added `filePathGlobs` option

🤖 Generated with [Claude Code](https://claude.ai/code)