### PR TITLE
feat: migrate from lerna-lite to pnpm native commands with OIDC support

### DIFF
--- a/.github/workflows/check-provenance.yml
+++ b/.github/workflows/check-provenance.yml
@@ -32,7 +32,7 @@ jobs:
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -431,5 +431,5 @@ Before creating a release, ensure documentation is up-to-date:
 
 > **Warning**
 > If the publishing(Step 5) is failed, you can re-run the workflow.  
-> Or, Open <https://github.com/textlint/secretlint/actions/workflows/publish.yml> and do "Run workflow".
+> Or, Open <https://github.com/secretlint/secretlint/actions/workflows/release.yml> and do "Run workflow".
 


### PR DESCRIPTION
## Summary
- Migrate from lerna-lite to pnpm native commands for package publishing
- Implement OIDC trusted publishing to eliminate npm tokens
- Add provenance verification workflow for all packages

## Changes
- Replace lerna-lite with pnpm native commands for versioning and publishing
- Rename publish.yml to release.yml to match OIDC configuration
- Add check-provenance.yml workflow to verify OIDC setup
- Update documentation with new release process
- Remove lerna.json and lerna-lite dependencies

## Related
- Fixes #1207

## Test plan
- [ ] Provenance check workflow runs on PR
- [ ] Release workflow uses OIDC for publishing
- [ ] Documentation reflects new process

🤖 Generated with [Claude Code](https://claude.ai/code)