### PR TITLE
chore: update release workflow to use pnpm recursive publish directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Publish with OIDC
         if: steps.tag_check.outputs.exists_tag == 'false'
         run: |
-          pnpm run ci:release
+          pnpm -r publish --no-git-checks
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ci:versionup:minor": "pnpm version minor --no-git-tag-version && pnpm --recursive exec pnpm pkg set version=\"`node -p \"JSON.parse(fs.readFileSync('package.json', 'utf8')).version\"`\" && npm run commit-version",
     "ci:versionup:major": "pnpm version major --no-git-tag-version && pnpm --recursive exec pnpm pkg set version=\"`node -p \"JSON.parse(fs.readFileSync('package.json', 'utf8')).version\"`\" && npm run commit-version",
     "commit-version": "git add . && git commit -m \"chore(release): v`node -p 'require(\"./package.json\").version'`\"",
-    "ci:release": "pnpm run build && pnpm -r publish --no-git-checks",
     "build": "turbo run build",
     "build:withoutrule": "turbo run build --ignore=\"packages/@secretlint/*-rule-*\"",
     "updateSnapshot": "turbo run updateSnapshot",


### PR DESCRIPTION
## 概要

リリースワークフローを簡素化し、`pnpm -r publish --no-git-checks` を直接使用するように変更しました。

## 変更内容

不要な中間スクリプトを削除し、GitHub Actions のリリースワークフローで直接 pnpm のコマンドを実行するようにしました。

## 主な変更点

- `.github/workflows/release.yml`: `pnpm run ci:release` を `pnpm -r publish --no-git-checks` に変更
- `package.json`: 不要になった `ci:release` スクリプトを削除

## テストプラン

N/A - CI/CDの設定変更のため、次回のリリース時に動作確認

## 破壊的変更

なし

## 補足

この変更により、リリースプロセスがより直接的で理解しやすくなります。

🤖 Generated with [Claude Code](https://claude.ai/code)