### PR TITLE
chore: use direct pnpm version commands in workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -36,7 +36,20 @@ jobs:
         run: |
           git config --global user.email "${GIT_AUTHOR_EMAIL}"
           git config --global user.name "${GIT_AUTHOR_NAME}"
-          pnpm run ci:versionup:${SEMVER}
+          
+          # Use pnpm to bump version in root package.json
+          pnpm version ${SEMVER} --no-git-tag-version
+          
+          # Get the new version from root package.json
+          NEW_VERSION=$(jq -r '.version' package.json)
+          echo "New version: $NEW_VERSION"
+          
+          # Update all workspace package.json files to match
+          pnpm --recursive exec pnpm pkg set version="$NEW_VERSION"
+          
+          # Commit the version changes
+          git add .
+          git commit -m "chore(release): v$NEW_VERSION"
         env:
           SEMVER: ${{ github.event.inputs.semver }}
           GIT_AUTHOR_NAME: ${{ github.actor }}

--- a/package.json
+++ b/package.json
@@ -29,10 +29,6 @@
   "scripts": {
     "versionup": "echo 'Error: Please use CI for versioning. Run the GitHub Actions workflow instead.' && exit 1",
     "release": "echo 'Error: Please use CI for releases. Run the GitHub Actions workflow instead.' && exit 1",
-    "ci:versionup:patch": "pnpm version patch --no-git-tag-version && pnpm --recursive exec pnpm pkg set version=\"`node -p \"JSON.parse(fs.readFileSync('package.json', 'utf8')).version\"`\" && npm run commit-version",
-    "ci:versionup:minor": "pnpm version minor --no-git-tag-version && pnpm --recursive exec pnpm pkg set version=\"`node -p \"JSON.parse(fs.readFileSync('package.json', 'utf8')).version\"`\" && npm run commit-version",
-    "ci:versionup:major": "pnpm version major --no-git-tag-version && pnpm --recursive exec pnpm pkg set version=\"`node -p \"JSON.parse(fs.readFileSync('package.json', 'utf8')).version\"`\" && npm run commit-version",
-    "commit-version": "git add . && git commit -m \"chore(release): v`node -p 'require(\"./package.json\").version'`\"",
     "build": "turbo run build",
     "build:withoutrule": "turbo run build --ignore=\"packages/@secretlint/*-rule-*\"",
     "updateSnapshot": "turbo run updateSnapshot",


### PR DESCRIPTION
## Summary

This PR updates the release PR creation workflow to execute pnpm commands directly instead of routing through npm scripts, improving transparency and maintainability of the release process.

## What's Changed

Modified `.github/workflows/create-release-pr.yml` to replace the npm script invocation with direct pnpm commands for version management.

## Key Changes

### Previous Implementation
- Executed `pnpm run ci:versionup:${SEMVER}` script
- Delegated processing to external script files

### New Implementation
- Updates root package version directly with `pnpm version ${SEMVER} --no-git-tag-version`
- Retrieves new version using `jq -r '.version' package.json`
- Updates all workspace packages with `pnpm --recursive exec pnpm pkg set version="$NEW_VERSION"`
- Executes commit processing inline within the workflow

## Benefits

- **Improved transparency**: All version update logic is visible directly in the workflow file
- **Reduced dependencies**: Eliminates reliance on external script files
- **Simplified debugging**: Easier to trace and debug version update issues
- **Better maintainability**: Workflow logic is self-contained and easier to modify

## Test Plan

- [ ] Verify that the release PR creation workflow executes successfully
- [ ] Confirm version updates are applied correctly to all packages
- [ ] Validate that commit messages are generated appropriately
- [ ] Test with different semver inputs (patch, minor, major)

## Breaking Changes

None - This is an internal workflow change that doesn't affect the public API or package functionality.

## Additional Notes

This change aligns with the recent migration from yarn to pnpm (#1218) and continues the modernization of the project's build and release infrastructure.

🤖 Generated with Claude Code