### PR TITLE
fix(ci): replace pnpm pkg set with node script for version updates

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -39,13 +39,19 @@ jobs:
           
           # Use pnpm to bump version in root package.json
           pnpm version ${SEMVER} --no-git-tag-version
-          
+
           # Get the new version from root package.json
           NEW_VERSION=$(jq -r '.version' package.json)
           echo "New version: $NEW_VERSION"
-          
+
           # Update all workspace package.json files to match
-          pnpm --recursive exec pnpm pkg set version="$NEW_VERSION"
+          # Using node instead of 'pnpm pkg set' to avoid npm compatibility issues
+          pnpm --recursive exec node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = '${NEW_VERSION}';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 4) + '\n');
+          "
           
           # Commit the version changes
           git add .


### PR DESCRIPTION
The `pnpm pkg set` command internally delegates to `npm pkg`, which can fail with "Unexpected end of JSON input while parsing empty string" error in certain CI environments due to npm configuration or cache issues.

This change replaces the `pnpm pkg set version` command with a direct Node.js script that reads, updates, and writes the package.json files. This approach is more reliable and doesn't depend on npm's pkg command.