### PR TITLE
fix(secretlint-rule-pattern): support negation patterns in filePathGlobs

### DIFF
--- a/packages/@secretlint/secretlint-rule-pattern/package.json
+++ b/packages/@secretlint/secretlint-rule-pattern/package.json
@@ -57,9 +57,11 @@
     "dependencies": {
         "@secretlint/tester": "workspace:*",
         "@secretlint/types": "workspace:*",
-        "@textlint/regexp-string-matcher": "^2.0.2"
+        "@textlint/regexp-string-matcher": "^2.0.2",
+        "micromatch": "^4.0.8"
     },
     "devDependencies": {
+        "@types/micromatch": "^4.0.9",
         "@types/node": "^24.10.9",
         "prettier": "^2.8.8",
         "tsx": "^4.21.0",

--- a/packages/@secretlint/secretlint-rule-pattern/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-pattern/src/index.ts
@@ -6,6 +6,7 @@ import {
 } from "@secretlint/types";
 import { matchPatterns } from "@textlint/regexp-string-matcher";
 import path from "node:path";
+import micromatch from "micromatch";
 
 export const messages = {
     PATTERN: {
@@ -65,9 +66,10 @@ function reportIfFoundPattern({
 }) {
     for (const p of options.patterns) {
         // Check filePathGlobs if specified
+        // Use micromatch() to support negation patterns (e.g., "!**/excluded/**")
         if (p.filePathGlobs && p.filePathGlobs.length > 0 && source.filePath) {
-            const matchesPath = p.filePathGlobs.some((glob) => path.matchesGlob(source.filePath!, glob));
-            if (!matchesPath) {
+            const matchedPaths = micromatch([source.filePath], p.filePathGlobs);
+            if (matchedPaths.length === 0) {
                 continue; // Skip if file path doesn't match any glob pattern
             }
         }

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-negation/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-negation/.secretlintrc.json
@@ -1,0 +1,15 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-pattern",
+      "options": {
+        "patterns": [
+          {
+            "name": "config file pattern",
+            "filePathGlobs": ["**/*.config", "!**/excluded/**"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-negation/input.config
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-negation/input.config
@@ -1,0 +1,1 @@
+secret content

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-negation/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.filePathGlobs-negation/output.json
@@ -1,0 +1,32 @@
+{
+    "filePath": "[SNAPSHOT]/ng.filePathGlobs-negation/input.config",
+    "messages": [
+        {
+            "message": "found matching config file pattern: input.config",
+            "range": [
+                0,
+                15
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-pattern",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 0
+                }
+            },
+            "severity": "error",
+            "messageId": "PATTERN",
+            "data": {
+                "PATTERN_NAME": "config file pattern",
+                "CREDENTIAL": "input.config"
+            }
+        }
+    ],
+    "sourceContent": "secret content\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-negation/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-negation/.secretlintrc.json
@@ -1,0 +1,15 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-pattern",
+      "options": {
+        "patterns": [
+          {
+            "name": "config file pattern",
+            "filePathGlobs": ["**/*.config", "!**/excluded/**"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-negation/excluded/input.config
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-negation/excluded/input.config
@@ -1,0 +1,1 @@
+secret content

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-negation/options.ts
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-negation/options.ts
@@ -1,0 +1,3 @@
+export const options = {
+    inputFilePath: "excluded/input.config",
+};

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-negation/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.filePathGlobs-negation/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.filePathGlobs-negation/excluded/input.config",
+    "messages": [],
+    "sourceContent": "secret content\n",
+    "sourceContentType": "text"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -787,7 +787,13 @@ importers:
       '@textlint/regexp-string-matcher':
         specifier: ^2.0.2
         version: 2.0.2
+      micromatch:
+        specifier: ^4.0.8
+        version: 4.0.8
     devDependencies:
+      '@types/micromatch':
+        specifier: ^4.0.9
+        version: 4.0.10
       '@types/node':
         specifier: ^24.10.9
         version: 24.10.9
@@ -1996,6 +2002,9 @@ packages:
   '@types/bn.js@5.2.0':
     resolution: {integrity: sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==}
 
+  '@types/braces@3.0.5':
+    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
+
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -2019,6 +2028,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/micromatch@4.0.10':
+    resolution: {integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -4344,6 +4356,8 @@ snapshots:
     dependencies:
       '@types/node': 24.10.9
 
+  '@types/braces@3.0.5': {}
+
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -4367,6 +4381,10 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/micromatch@4.0.10':
+    dependencies:
+      '@types/braces': 3.0.5
 
   '@types/ms@2.1.0': {}
 


### PR DESCRIPTION
## Summary

Add support for negation patterns (`!` prefix) in the `filePathGlobs` option. This allows excluding specific directories or files from pattern matching.

## Changes

- Add `micromatch` library as a dependency
- Replace `path.matchesGlob()` with `micromatch()` to support negation patterns
- Add test cases for negation patterns

## Example

```json
{
  "patterns": [
    {
      "name": "config file pattern",
      "filePathGlobs": ["**/*.config", "!**/excluded/**"]
    }
  ]
}

Breaking Changes

None

Test Plan

1. ni run build --filter=@secretlint/secretlint-rule-pattern
2. ni test (in packages/@secretlint/secretlint-rule-pattern)
3. Verify ok.filePathGlobs-negation test passes (excluded file has no messages)
4. Verify ng.filePathGlobs-negation test passes (non-excluded file has messages)