### PR TITLE
docs: add quotepath option to changed-files action for non-ASCII path support

### DIFF
--- a/.github/workflows/test-diff.yml
+++ b/.github/workflows/test-diff.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        with:
+          quotepath: "false"
       - name: setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:

--- a/README.md
+++ b/README.md
@@ -543,6 +543,8 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v44
+        with:
+          quotepath: "false"
       - name: setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
…support

The tj-actions/changed-files action wraps non-ASCII file paths in quotes by default (git's core.quotePath behavior), which causes secretlint to fail when scanning files with multibyte characters in their paths. Setting quotepath: "false" ensures paths are returned as-is.

Fixes #1057
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/secretlint/secretlint/pull/1423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
