### PR TITLE
docs(AGENTS): add regex boundary conventions for rule implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
         return {
             file(source: SecretLintSourceCode) {
-                const pattern = /YOUR_PATTERN/g;
+                const pattern = /(?<!\p{L})YOUR_PREFIX_[A-Za-z0-9]{20,60}(?![A-Za-z0-9])/gu;
                 const matches = source.content.matchAll(pattern);
                 for (const match of matches) {
                     const index = match.index || 0;
@@ -155,6 +155,11 @@ export const creator: SecretLintRuleCreator<Options> = {
 - **Messages must have at least `en` locale**; `ja` is strongly recommended
 - **Always support `allows` option** using `@textlint/regexp-string-matcher` for user-defined exclusions
 - **Use `matchAll` with global regex** for pattern scanning
+- **Regex boundary conventions**:
+  - Leading: use `(?<!\p{L})` to prevent matching mid-word
+  - Trailing: add a negative lookahead matching the pattern's character class (e.g., `(?![A-Za-z0-9])` or `(?![a-f0-9])`). Without this, greedy quantifiers over-match into adjacent content, causing incorrect `range` and breaking `allows` list matching
+  - Example: `/(?<!\p{L})prefix_[A-Za-z0-9]{20,60}(?![A-Za-z0-9])/gu`
+- **Length ranges**: follow official documentation if available, otherwise align with gitleaks/TruffleHog empirical data. Keep ranges as narrow as possible to minimize false positives
 - **Report with `context.report()`** providing `message` (from translator) and `range` (`[startIndex, endIndex]`)
 - **Filter rules use `context.ignore()`** instead of `context.report()`
 - **Avoid ReDoS**: be careful with regex complexity; use character class limits (e.g., `[A-Za-z0-9]{100,10000}`)


### PR DESCRIPTION
## Summary

- Add leading `(?<!\p{L})` and trailing negative lookahead conventions to rule implementation guide
- Add guidance on keeping length ranges narrow based on official docs or gitleaks/TruffleHog empirical data
- Update code example pattern to include boundary conventions

## Context

False positive analysis of new rule proposals (#1441-#1449) revealed that all proposed regexes lacked trailing boundaries. Without trailing boundaries, greedy quantifiers over-match into adjacent content, causing incorrect `range` and breaking `allows` list matching.

## Test plan

- [ ] Documentation change only, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)