### PR TITLE
Add Figma Personal Access Token detection rule

### DIFF
--- a/packages/@secretlint/secretlint-rule-figma/LICENSE
+++ b/packages/@secretlint/secretlint-rule-figma/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026 azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@secretlint/secretlint-rule-figma/README.md
+++ b/packages/@secretlint/secretlint-rule-figma/README.md
@@ -16,7 +16,7 @@ Install with [npm](https://www.npmjs.com/):
 
 Figma Personal Access Tokens (`figd_`) should be private.
 
-The token format is a `figd_` prefix followed by 40 or more characters of
+The token format is a `figd_` prefix followed by 40 to 200 characters of
 `[A-Za-z0-9_-]`. This prefix matches the pattern supported by
 [GitHub Secret Scanning](https://docs.github.com/en/code-security/secret-scanning/introduction/supported-secret-scanning-patterns).
 

--- a/packages/@secretlint/secretlint-rule-figma/README.md
+++ b/packages/@secretlint/secretlint-rule-figma/README.md
@@ -1,0 +1,54 @@
+# @secretlint/secretlint-rule-figma
+
+[Figma](https://www.figma.com/) rule for secretlint.
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install @secretlint/secretlint-rule-figma
+
+## MessageIDs
+
+### FIGMA_PERSONAL_ACCESS_TOKEN
+
+> found Figma Personal Access Token: ${props.ID}
+
+Figma Personal Access Tokens (`figd_`) should be private.
+
+The token format is a `figd_` prefix followed by 40 or more characters of
+`[A-Za-z0-9_-]`. This prefix matches the pattern supported by
+[GitHub Secret Scanning](https://docs.github.com/en/code-security/secret-scanning/introduction/supported-secret-scanning-patterns).
+
+Legacy UUID-format Figma tokens (without a prefix) are intentionally not
+detected because their pattern is too generic and would produce false
+positives.
+
+## Options
+
+-   `allows: string[]`
+    -   Allows a list of [RegExp-like String](https://github.com/textlint/regexp-string-matcher#regexp-like-string)
+
+## Changelog
+
+See [Releases page](https://github.com/secretlint/secretlint/releases).
+
+## Running tests
+
+No Test to avoid Dependency cycles.
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/secretlint/secretlint/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## License
+
+MIT © azu

--- a/packages/@secretlint/secretlint-rule-figma/package.json
+++ b/packages/@secretlint/secretlint-rule-figma/package.json
@@ -1,0 +1,70 @@
+{
+    "name": "@secretlint/secretlint-rule-figma",
+    "version": "11.6.0",
+    "description": "A secretlint rule for Figma",
+    "keywords": [
+        "secretlint",
+        "testing",
+        "rule"
+    ],
+    "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-figma/",
+    "bugs": {
+        "url": "https://github.com/secretlint/secretlint/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/secretlint/secretlint.git"
+    },
+    "license": "MIT",
+    "author": "azu",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./module/index.d.ts",
+                "default": "./module/index.js"
+            },
+            "default": "./module/index.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "main": "./module/index.js",
+    "types": "./module/index.d.ts",
+    "files": [
+        "bin/",
+        "module/",
+        "src/"
+    ],
+    "scripts": {
+        "build": "tsc --build",
+        "clean": "tsc --build --clean",
+        "prepublishOnly": "npm run clean && npm run build",
+        "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+        "prepublish": "npm run --if-present build",
+        "test": "node --import tsx --test test/index.test.ts",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
+        "watch": "tsc --build --watch"
+    },
+    "prettier": {
+        "printWidth": 120,
+        "singleQuote": false,
+        "tabWidth": 4
+    },
+    "dependencies": {
+        "@secretlint/types": "workspace:*",
+        "@textlint/regexp-string-matcher": "catalog:"
+    },
+    "devDependencies": {
+        "@secretlint/tester": "workspace:*",
+        "@types/node": "catalog:",
+        "prettier": "catalog:",
+        "tsx": "catalog:",
+        "typescript": "catalog:"
+    },
+    "engines": {
+        "node": ">=20.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/@secretlint/secretlint-rule-figma/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-figma/src/index.ts
@@ -1,0 +1,56 @@
+import type { SecretLintRuleCreator, SecretLintSourceCode } from "@secretlint/types";
+import { matchPatterns } from "@textlint/regexp-string-matcher";
+
+export const messages = {
+    FIGMA_PERSONAL_ACCESS_TOKEN: {
+        en: (props: { ID: string }) => `found Figma Personal Access Token: ${props.ID}`,
+        ja: (props: { ID: string }) => `Figma Personal Access Token: ${props.ID} がみつかりました`,
+    },
+};
+
+export type Options = {
+    allows?: string[];
+};
+
+export const creator: SecretLintRuleCreator<Options> = {
+    messages,
+    meta: {
+        id: "@secretlint/secretlint-rule-figma",
+        recommended: true,
+        type: "scanner",
+        supportedContentTypes: ["text"],
+        docs: {
+            url: "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-figma/README.md",
+        },
+    },
+    create(context, options) {
+        const t = context.createTranslator(messages);
+        const normalizedOptions = {
+            allows: options?.allows ?? [],
+        };
+        return {
+            file(source: SecretLintSourceCode) {
+                // Figma Personal Access Token
+                // Format: `figd_` prefix followed by 40-200 characters of [A-Za-z0-9_-]
+                // Reference: https://docs.github.com/en/code-security/secret-scanning/introduction/supported-secret-scanning-patterns
+                const pattern = /(?<!\p{L})figd_[A-Za-z0-9_-]{40,200}(?![A-Za-z0-9_-])/gu;
+                const matches = source.content.matchAll(pattern);
+                for (const match of matches) {
+                    const index = match.index ?? 0;
+                    const matchString = match[0] ?? "";
+                    const allowedResults = matchPatterns(matchString, normalizedOptions.allows);
+                    if (allowedResults.length > 0) {
+                        continue;
+                    }
+                    const range = [index, index + matchString.length] as const;
+                    context.report({
+                        message: t("FIGMA_PERSONAL_ACCESS_TOKEN", {
+                            ID: matchString,
+                        }),
+                        range,
+                    });
+                }
+            },
+        };
+    },
+};

--- a/packages/@secretlint/secretlint-rule-figma/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-figma/test/index.test.ts
@@ -1,0 +1,26 @@
+import { creator as rule } from "../src/index.js";
+import test from "node:test";
+
+test("@secretlint/secretlint-rule-figma", async (t) => {
+    const snapshot = (await import("@secretlint/tester")).snapshot;
+    await snapshot({
+        defaultConfig: {
+            rules: [
+                {
+                    id: "@secretlint/secretlint-rule-figma",
+                    rule,
+                    options: {},
+                },
+            ],
+        },
+        updateSnapshot: !!process.env.UPDATE_SNAPSHOT,
+        snapshotDirectory: new URL("snapshots", import.meta.url),
+    }).forEach((name, test) => {
+        return t.test(name, async (context) => {
+            const status = await test();
+            if (status === "skip") {
+                context.skip();
+            }
+        });
+    });
+});

--- a/packages/@secretlint/secretlint-rule-figma/test/snapshots/ng.secret/input.txt
+++ b/packages/@secretlint/secretlint-rule-figma/test/snapshots/ng.secret/input.txt
@@ -1,0 +1,1 @@
+FIGMA_TOKEN=figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz

--- a/packages/@secretlint/secretlint-rule-figma/test/snapshots/ng.secret/output.json
+++ b/packages/@secretlint/secretlint-rule-figma/test/snapshots/ng.secret/output.json
@@ -1,0 +1,32 @@
+{
+    "filePath": "[SNAPSHOT]/ng.secret/input.txt",
+    "messages": [
+        {
+            "message": "found Figma Personal Access Token: figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz",
+            "range": [
+                12,
+                73
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-figma",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 73
+                }
+            },
+            "severity": "error",
+            "messageId": "FIGMA_PERSONAL_ACCESS_TOKEN",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-figma/README.md#FIGMA_PERSONAL_ACCESS_TOKEN",
+            "data": {
+                "ID": "figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz"
+            }
+        }
+    ],
+    "sourceContent": "FIGMA_TOKEN=figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-figma/test/snapshots/ok.allows/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-figma/test/snapshots/ok.allows/.secretlintrc.json
@@ -1,0 +1,10 @@
+{
+    "rules": [
+        {
+            "id": "@secretlint/secretlint-rule-figma",
+            "options": {
+                "allows": ["/figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz/"]
+            }
+        }
+    ]
+}

--- a/packages/@secretlint/secretlint-rule-figma/test/snapshots/ok.allows/input.txt
+++ b/packages/@secretlint/secretlint-rule-figma/test/snapshots/ok.allows/input.txt
@@ -1,0 +1,1 @@
+FIGMA_TOKEN=figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz

--- a/packages/@secretlint/secretlint-rule-figma/test/snapshots/ok.allows/output.json
+++ b/packages/@secretlint/secretlint-rule-figma/test/snapshots/ok.allows/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.allows/input.txt",
+    "messages": [],
+    "sourceContent": "FIGMA_TOKEN=figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-figma/test/snapshots/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-figma/test/snapshots/ok.valid/input.txt
@@ -1,0 +1,2 @@
+THIS IS OK
+figd_abc

--- a/packages/@secretlint/secretlint-rule-figma/test/snapshots/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-figma/test/snapshots/ok.valid/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.valid/input.txt",
+    "messages": [],
+    "sourceContent": "THIS IS OK\nfigd_abc\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-figma/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-figma/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "newLine": "LF",
+    "outDir": "./module/",
+    "target": "ES2022",
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "jsx": "preserve",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    ".git",
+    "node_modules"
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -65,6 +65,7 @@
         "@secretlint/secretlint-rule-aws": "workspace:*",
         "@secretlint/secretlint-rule-basicauth": "workspace:*",
         "@secretlint/secretlint-rule-database-connection-string": "workspace:*",
+        "@secretlint/secretlint-rule-figma": "workspace:*",
         "@secretlint/secretlint-rule-filter-comments": "workspace:*",
         "@secretlint/secretlint-rule-gcp": "workspace:*",
         "@secretlint/secretlint-rule-github": "workspace:*",

--- a/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
@@ -14,6 +14,7 @@ import { creator as ruleGitHub } from "@secretlint/secretlint-rule-github";
 import { creator as rule1Password } from "@secretlint/secretlint-rule-1password";
 import { creator as ruleDatabaseConnectionString } from "@secretlint/secretlint-rule-database-connection-string";
 import { creator as ruleVercel } from "@secretlint/secretlint-rule-vercel";
+import { creator as ruleFigma } from "@secretlint/secretlint-rule-figma";
 import { creator as ruleFilterComments } from "@secretlint/secretlint-rule-filter-comments";
 
 export const rules = [
@@ -32,6 +33,7 @@ export const rules = [
     rule1Password,
     ruleDatabaseConnectionString,
     ruleVercel,
+    ruleFigma,
     ruleFilterComments,
 ];
 export type Options = {};

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ng.secret/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ng.secret/input.txt
@@ -1,0 +1,1 @@
+FIGMA_TOKEN=figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ng.secret/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ng.secret/output.json
@@ -1,0 +1,33 @@
+{
+    "filePath": "[SNAPSHOT]/ng.secret/input.txt",
+    "messages": [
+        {
+            "message": "found Figma Personal Access Token: figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz",
+            "range": [
+                12,
+                73
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-figma",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 73
+                }
+            },
+            "severity": "error",
+            "messageId": "FIGMA_PERSONAL_ACCESS_TOKEN",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-figma/README.md#FIGMA_PERSONAL_ACCESS_TOKEN",
+            "data": {
+                "ID": "figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz"
+            }
+        }
+    ],
+    "sourceContent": "FIGMA_TOKEN=figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ok.allows/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ok.allows/.secretlintrc.json
@@ -1,0 +1,17 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-preset-canary",
+      "rules": [
+        {
+          "id": "@secretlint/secretlint-rule-figma",
+          "options": {
+            "allows": [
+              "/figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz/"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ok.allows/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ok.allows/input.txt
@@ -1,0 +1,1 @@
+FIGMA_TOKEN=figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ok.allows/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ok.allows/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.allows/input.txt",
+    "messages": [],
+    "sourceContent": "FIGMA_TOKEN=figd_aBcDeFgHiJkLmNoPqRsT1234567890abcdefghijklmnopqrstuvwxyz\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ok.valid/input.txt
@@ -1,0 +1,2 @@
+THIS IS OK
+figd_abc

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-figma/ok.valid/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.valid/input.txt",
+    "messages": [],
+    "sourceContent": "THIS IS OK\nfigd_abc\n",
+    "sourceContentType": "text"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,6 +681,31 @@ importers:
         specifier: 'catalog:'
         version: 5.9.2
 
+  packages/@secretlint/secretlint-rule-figma:
+    dependencies:
+      '@secretlint/types':
+        specifier: workspace:*
+        version: link:../types
+      '@textlint/regexp-string-matcher':
+        specifier: 'catalog:'
+        version: 2.0.2
+    devDependencies:
+      '@secretlint/tester':
+        specifier: workspace:*
+        version: link:../tester
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      prettier:
+        specifier: 'catalog:'
+        version: 2.8.8
+      tsx:
+        specifier: 'catalog:'
+        version: 4.21.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
   packages/@secretlint/secretlint-rule-filter-comments:
     dependencies:
       '@secretlint/types':
@@ -986,6 +1011,9 @@ importers:
       '@secretlint/secretlint-rule-database-connection-string':
         specifier: workspace:*
         version: link:../secretlint-rule-database-connection-string
+      '@secretlint/secretlint-rule-figma':
+        specifier: workspace:*
+        version: link:../secretlint-rule-figma
       '@secretlint/secretlint-rule-filter-comments':
         specifier: workspace:*
         version: link:../secretlint-rule-filter-comments
@@ -2114,9 +2142,6 @@ packages:
 
   '@types/node-forge@1.3.14':
     resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
-
-  '@types/node@24.12.0':
-    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -4191,10 +4216,6 @@ snapshots:
     dependencies:
       '@types/node': 24.12.2
 
-  '@types/node@24.12.0':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
@@ -4373,7 +4394,7 @@ snapshots:
 
   bun-types@1.3.11:
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 24.12.2
 
   cac@6.7.14: {}
 


### PR DESCRIPTION
## Summary
This PR adds a new secretlint rule for detecting Figma Personal Access Tokens in source code.

Closes #1447

## Key Changes
- **New package**: `@secretlint/secretlint-rule-figma` - A dedicated rule for scanning Figma tokens
  - Detects tokens with the `figd_` prefix followed by 40-200 characters of `[A-Za-z0-9_-]`
  - Implements pattern matching based on GitHub's Secret Scanning specification
  - Supports allowlist configuration via the `allows` option
  - Includes bilingual messages (English and Japanese)
  - Provides comprehensive documentation and test coverage

- **Integration**: Added the new rule to `@secretlint/secretlint-rule-preset-canary` preset
  - Includes test snapshots for both valid and invalid token scenarios

## Implementation Details
- Uses Unicode-aware regex with negative lookbehind/lookahead to avoid false positives on word boundaries
- Leverages `@textlint/regexp-string-matcher` for flexible allowlist pattern matching
- Follows the established secretlint rule architecture with proper TypeScript types
- Intentionally excludes legacy UUID-format Figma tokens to prevent false positives
- Includes snapshot-based tests for validation

https://claude.ai/code/session_01PyFZnveYyhEkPJp9y6murP