### PR TITLE
feat(secretlint-rule-huggingface): add new rule for Hugging Face User Access Token

### DIFF
--- a/packages/@secretlint/secretlint-rule-huggingface/LICENSE
+++ b/packages/@secretlint/secretlint-rule-huggingface/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026 azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@secretlint/secretlint-rule-huggingface/README.md
+++ b/packages/@secretlint/secretlint-rule-huggingface/README.md
@@ -1,0 +1,67 @@
+# @secretlint/secretlint-rule-huggingface
+
+A rule for detecting [Hugging Face](https://huggingface.co/) User Access Tokens in your code.
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install @secretlint/secretlint-rule-huggingface
+
+## Usage
+
+Via `.secretlintrc.json`(Recommended)
+
+```json
+{
+    "rules": [
+        {
+            "id": "@secretlint/secretlint-rule-huggingface"
+        }
+    ]
+}
+```
+
+## MessageIDs
+
+### HUGGINGFACE_USER_ACCESS_TOKEN
+
+Hugging Face User Access Token is detected.
+
+A Hugging Face User Access Token starts with the `hf_` prefix followed by exactly 34 alphabetic characters
+(see [User Access Tokens](https://huggingface.co/docs/hub/security-tokens)).
+
+**NG** examples:
+
+```
+HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+## Options
+
+- `allows: string[]`
+    - Allows a list of [RegExp-like String](https://github.com/textlint/regexp-string-matcher#regexp-like-string)
+
+## Changelog
+
+See [Releases page](https://github.com/secretlint/secretlint/releases).
+
+## Running tests
+
+No Test to avoid Dependency cycles.
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/secretlint/secretlint/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## License
+
+MIT © azu

--- a/packages/@secretlint/secretlint-rule-huggingface/package.json
+++ b/packages/@secretlint/secretlint-rule-huggingface/package.json
@@ -1,0 +1,72 @@
+{
+    "name": "@secretlint/secretlint-rule-huggingface",
+    "version": "11.6.0",
+    "description": "A secretlint rule for detecting Hugging Face User Access Tokens",
+    "keywords": [
+        "secretlint",
+        "rule",
+        "huggingface",
+        "access-token",
+        "security"
+    ],
+    "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-huggingface/",
+    "bugs": {
+        "url": "https://github.com/secretlint/secretlint/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/secretlint/secretlint.git"
+    },
+    "license": "MIT",
+    "author": "azu",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./module/index.d.ts",
+                "default": "./module/index.js"
+            },
+            "default": "./module/index.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "main": "./module/index.js",
+    "types": "./module/index.d.ts",
+    "files": [
+        "bin/",
+        "module/",
+        "src/"
+    ],
+    "scripts": {
+        "build": "tsc --build",
+        "clean": "tsc --build --clean",
+        "prepublishOnly": "npm run clean && npm run build",
+        "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+        "prepublish": "npm run --if-present build",
+        "test": "node --import tsx --test test/index.test.ts",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
+        "watch": "tsc --build --watch"
+    },
+    "prettier": {
+        "printWidth": 120,
+        "singleQuote": false,
+        "tabWidth": 4
+    },
+    "dependencies": {
+        "@secretlint/types": "workspace:*",
+        "@textlint/regexp-string-matcher": "catalog:"
+    },
+    "devDependencies": {
+        "@secretlint/tester": "workspace:*",
+        "@types/node": "catalog:",
+        "prettier": "catalog:",
+        "tsx": "catalog:",
+        "typescript": "catalog:"
+    },
+    "engines": {
+        "node": ">=20.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/@secretlint/secretlint-rule-huggingface/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-huggingface/src/index.ts
@@ -1,0 +1,59 @@
+import type { SecretLintRuleCreator, SecretLintSourceCode } from "@secretlint/types";
+import { matchPatterns } from "@textlint/regexp-string-matcher";
+
+export const messages = {
+    HUGGINGFACE_USER_ACCESS_TOKEN: {
+        en: (props: { TOKEN: string }) => `found Hugging Face User Access Token: ${props.TOKEN}`,
+        ja: (props: { TOKEN: string }) => `Hugging Face User Access Token: ${props.TOKEN} がみつかりました`,
+    },
+};
+
+export type Options = {
+    allows?: string[];
+};
+
+export const creator: SecretLintRuleCreator<Options> = {
+    messages,
+    meta: {
+        id: "@secretlint/secretlint-rule-huggingface",
+        recommended: true,
+        type: "scanner",
+        supportedContentTypes: ["text"],
+        docs: {
+            url: "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-huggingface/README.md",
+        },
+    },
+    create(context, options) {
+        const t = context.createTranslator(messages);
+        const normalizedOptions = {
+            allows: options?.allows ?? [],
+        };
+        return {
+            file(source: SecretLintSourceCode) {
+                // Hugging Face User Access Token format:
+                // - Prefix: `hf_`
+                // - Body: exactly 34 alphabetic characters (a-z, A-Z)
+                // References:
+                // - https://huggingface.co/docs/hub/security-tokens
+                // - https://github.com/gitleaks/gitleaks
+                const pattern = /(?<!\p{L})hf_[a-zA-Z]{34}(?![a-zA-Z])/gu;
+                const matches = source.content.matchAll(pattern);
+                for (const match of matches) {
+                    const index = match.index ?? 0;
+                    const matchString = match[0] ?? "";
+                    const allowedResults = matchPatterns(matchString, normalizedOptions.allows);
+                    if (allowedResults.length > 0) {
+                        continue;
+                    }
+                    const range = [index, index + matchString.length] as const;
+                    context.report({
+                        message: t("HUGGINGFACE_USER_ACCESS_TOKEN", {
+                            TOKEN: matchString,
+                        }),
+                        range,
+                    });
+                }
+            },
+        };
+    },
+};

--- a/packages/@secretlint/secretlint-rule-huggingface/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-huggingface/test/index.test.ts
@@ -1,0 +1,27 @@
+import { creator as rule } from "../src/index.js";
+
+import test from "node:test";
+
+test("@secretlint/secretlint-rule-huggingface", async (t) => {
+    const snapshot = (await import("@secretlint/tester")).snapshot;
+    await snapshot({
+        defaultConfig: {
+            rules: [
+                {
+                    id: "@secretlint/secretlint-rule-huggingface",
+                    rule,
+                    options: {},
+                },
+            ],
+        },
+        updateSnapshot: !!process.env.UPDATE_SNAPSHOT,
+        snapshotDirectory: new URL("snapshots", import.meta.url),
+    }).forEach((name, test) => {
+        return t.test(name, async (context) => {
+            const status = await test();
+            if (status === "skip") {
+                context.skip();
+            }
+        });
+    });
+});

--- a/packages/@secretlint/secretlint-rule-huggingface/test/snapshots/ng.secret/input.txt
+++ b/packages/@secretlint/secretlint-rule-huggingface/test/snapshots/ng.secret/input.txt
@@ -1,0 +1,2 @@
+# Hugging Face User Access Tokens that should be detected
+hf_token = 'hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'

--- a/packages/@secretlint/secretlint-rule-huggingface/test/snapshots/ng.secret/output.json
+++ b/packages/@secretlint/secretlint-rule-huggingface/test/snapshots/ng.secret/output.json
@@ -1,0 +1,32 @@
+{
+    "filePath": "[SNAPSHOT]/ng.secret/input.txt",
+    "messages": [
+        {
+            "message": "found Hugging Face User Access Token: hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "range": [
+                70,
+                107
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-huggingface",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 12
+                },
+                "end": {
+                    "line": 2,
+                    "column": 49
+                }
+            },
+            "severity": "error",
+            "messageId": "HUGGINGFACE_USER_ACCESS_TOKEN",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-huggingface/README.md#HUGGINGFACE_USER_ACCESS_TOKEN",
+            "data": {
+                "TOKEN": "hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            }
+        }
+    ],
+    "sourceContent": "# Hugging Face User Access Tokens that should be detected\nhf_token = 'hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-huggingface/test/snapshots/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-huggingface/test/snapshots/ok.valid/input.txt
@@ -1,0 +1,19 @@
+# These should NOT be detected as Hugging Face tokens
+
+# Too short
+hf_abc
+
+# Contains digits in body
+hf_FakeFakeFake1FakeFakeFakeFakeFakeFa
+
+# Body is 33 alphabetic characters (one short)
+hf_FakeFakeFakeFakeFakeFakeFakeFakeF
+
+# Body is 35 alphabetic characters (one too many)
+hf_FakeFakeFakeFakeFakeFakeFakeFakeFak
+
+# Preceded by another letter (boundary check)
+xhf_FakeFakeFakeFakeFakeFakeFakeFakeFa
+
+# Hugging Face URL, not a token
+https://huggingface.co/models

--- a/packages/@secretlint/secretlint-rule-huggingface/test/snapshots/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-huggingface/test/snapshots/ok.valid/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.valid/input.txt",
+    "messages": [],
+    "sourceContent": "# These should NOT be detected as Hugging Face tokens\n\n# Too short\nhf_abc\n\n# Contains digits in body\nhf_FakeFakeFake1FakeFakeFakeFakeFakeFa\n\n# Body is 33 alphabetic characters (one short)\nhf_FakeFakeFakeFakeFakeFakeFakeFakeF\n\n# Body is 35 alphabetic characters (one too many)\nhf_FakeFakeFakeFakeFakeFakeFakeFakeFak\n\n# Preceded by another letter (boundary check)\nxhf_FakeFakeFakeFakeFakeFakeFakeFakeFa\n\n# Hugging Face URL, not a token\nhttps://huggingface.co/models\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-huggingface/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-huggingface/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "newLine": "LF",
+    "outDir": "./module/",
+    "target": "ES2022",
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "jsx": "preserve",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    ".git",
+    "node_modules"
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -68,6 +68,7 @@
         "@secretlint/secretlint-rule-filter-comments": "workspace:*",
         "@secretlint/secretlint-rule-gcp": "workspace:*",
         "@secretlint/secretlint-rule-github": "workspace:*",
+        "@secretlint/secretlint-rule-huggingface": "workspace:*",
         "@secretlint/secretlint-rule-linear": "workspace:*",
         "@secretlint/secretlint-rule-npm": "workspace:*",
         "@secretlint/secretlint-rule-openai": "workspace:*",

--- a/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
@@ -6,6 +6,7 @@ import { creator as ruleSlack } from "@secretlint/secretlint-rule-slack";
 import { creator as ruleBasicAuth } from "@secretlint/secretlint-rule-basicauth";
 import { creator as ruleOpenAi } from "@secretlint/secretlint-rule-openai";
 import { creator as ruleAnthropic } from "@secretlint/secretlint-rule-anthropic";
+import { creator as ruleHuggingface } from "@secretlint/secretlint-rule-huggingface";
 import { creator as ruleLinear } from "@secretlint/secretlint-rule-linear";
 import { creator as rulePrivateKey } from "@secretlint/secretlint-rule-privatekey";
 import { creator as ruleSendgrid } from "@secretlint/secretlint-rule-sendgrid";
@@ -28,6 +29,7 @@ export const rules = [
     ruleGitHub,
     ruleOpenAi,
     ruleAnthropic,
+    ruleHuggingface,
     ruleLinear,
     rule1Password,
     ruleDatabaseConnectionString,

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-huggingface/ng.secret/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-huggingface/ng.secret/input.txt
@@ -1,0 +1,2 @@
+# Hugging Face User Access Tokens that should be detected
+hf_token = 'hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-huggingface/ng.secret/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-huggingface/ng.secret/output.json
@@ -1,0 +1,33 @@
+{
+    "filePath": "[SNAPSHOT]/ng.secret/input.txt",
+    "messages": [
+        {
+            "message": "found Hugging Face User Access Token: hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "range": [
+                70,
+                107
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-huggingface",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 12
+                },
+                "end": {
+                    "line": 2,
+                    "column": 49
+                }
+            },
+            "severity": "error",
+            "messageId": "HUGGINGFACE_USER_ACCESS_TOKEN",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-huggingface/README.md#HUGGINGFACE_USER_ACCESS_TOKEN",
+            "data": {
+                "TOKEN": "hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            }
+        }
+    ],
+    "sourceContent": "# Hugging Face User Access Tokens that should be detected\nhf_token = 'hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-huggingface/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-huggingface/ok.valid/input.txt
@@ -1,0 +1,19 @@
+# These should NOT be detected as Hugging Face tokens
+
+# Too short
+hf_abc
+
+# Contains digits in body
+hf_FakeFakeFake1FakeFakeFakeFakeFakeFa
+
+# Body is 33 alphabetic characters (one short)
+hf_FakeFakeFakeFakeFakeFakeFakeFakeF
+
+# Body is 35 alphabetic characters (one too many)
+hf_FakeFakeFakeFakeFakeFakeFakeFakeFak
+
+# Preceded by another letter (boundary check)
+xhf_FakeFakeFakeFakeFakeFakeFakeFakeFa
+
+# Hugging Face URL, not a token
+https://huggingface.co/models

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-huggingface/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-huggingface/ok.valid/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.valid/input.txt",
+    "messages": [],
+    "sourceContent": "# These should NOT be detected as Hugging Face tokens\n\n# Too short\nhf_abc\n\n# Contains digits in body\nhf_FakeFakeFake1FakeFakeFakeFakeFakeFa\n\n# Body is 33 alphabetic characters (one short)\nhf_FakeFakeFakeFakeFakeFakeFakeFakeF\n\n# Body is 35 alphabetic characters (one too many)\nhf_FakeFakeFakeFakeFakeFakeFakeFakeFak\n\n# Preceded by another letter (boundary check)\nxhf_FakeFakeFakeFakeFakeFakeFakeFakeFa\n\n# Hugging Face URL, not a token\nhttps://huggingface.co/models\n",
+    "sourceContentType": "text"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -762,6 +762,31 @@ importers:
         specifier: 'catalog:'
         version: 5.9.2
 
+  packages/@secretlint/secretlint-rule-huggingface:
+    dependencies:
+      '@secretlint/types':
+        specifier: workspace:*
+        version: link:../types
+      '@textlint/regexp-string-matcher':
+        specifier: 'catalog:'
+        version: 2.0.2
+    devDependencies:
+      '@secretlint/tester':
+        specifier: workspace:*
+        version: link:../tester
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.2
+      prettier:
+        specifier: 'catalog:'
+        version: 2.8.8
+      tsx:
+        specifier: 'catalog:'
+        version: 4.21.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
   packages/@secretlint/secretlint-rule-internal-test-cjs:
     dependencies:
       '@secretlint/types':
@@ -995,6 +1020,9 @@ importers:
       '@secretlint/secretlint-rule-github':
         specifier: workspace:*
         version: link:../secretlint-rule-github
+      '@secretlint/secretlint-rule-huggingface':
+        specifier: workspace:*
+        version: link:../secretlint-rule-huggingface
       '@secretlint/secretlint-rule-linear':
         specifier: workspace:*
         version: link:../secretlint-rule-linear
@@ -2114,9 +2142,6 @@ packages:
 
   '@types/node-forge@1.3.14':
     resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
-
-  '@types/node@24.12.0':
-    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -4191,10 +4216,6 @@ snapshots:
     dependencies:
       '@types/node': 24.12.2
 
-  '@types/node@24.12.0':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
@@ -4373,7 +4394,7 @@ snapshots:
 
   bun-types@1.3.11:
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 24.12.2
 
   cac@6.7.14: {}
 


### PR DESCRIPTION
## Summary

Add a new rule package `@secretlint/secretlint-rule-huggingface` that detects [Hugging Face User Access Tokens](https://huggingface.co/docs/hub/security-tokens).

- Detection pattern: `(?<!\p{L})hf_[a-zA-Z]{34}(?![a-zA-Z])` — `hf_` prefix followed by exactly 34 alphabetic characters (a-z, A-Z), with Unicode letter boundary and negative lookahead to prevent over-matching.
- Messages: `HUGGINGFACE_USER_ACCESS_TOKEN` in both `en` and `ja`.
- `allows` option supported via `@textlint/regexp-string-matcher`.
- Registered in the **canary** preset (`@secretlint/secretlint-rule-preset-canary`). Sync to the recommend preset is intentionally deferred per `AGENTS.md`.

Out of scope: organization tokens with the `api_org_` prefix (deprecated by Hugging Face).

## Test plan

- [x] `pnpm run build` succeeds across the workspace
- [x] `pnpm test` — all 85 tasks pass, including new `ng.secret` / `ok.valid` snapshot tests for the rule
- [x] `pnpm run -r --filter "@secretlint/secretlint-rule-preset-canary" import-test` regenerates canary snapshots for the new rule
- [ ] Manual verification on real-world fixtures (deferred to reviewers)

Test fixtures use the documentation placeholder form `hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` so they exercise the regex without tripping GitHub's push protection on synthetic-looking tokens.

Closes #1449