### PR TITLE
fix(rules): add regex boundary assertions to 8 existing scanner rules

### DIFF
--- a/packages/@secretlint/secretlint-rule-1password/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-1password/src/index.ts
@@ -41,7 +41,7 @@ export const creator: SecretLintRuleCreator<Options> = {
                 // https://developer.1password.com/docs/service-accounts/security/
                 // It will be like ops_{"email":"ejwe64qmlxhri@1passwordserviceaccounts.lcl","muk":{"alg":"A256GCM","ext":true,"k":"M8VPfIc8VEfThcMXLaKCKF8sMh5JMZsPAtu92fQNb-o","key_ops":["encrypt","decrypt"],"kty":"oct","kid":"mp"},"secretKey":"A3-C4ZJMN-PQTZTL-HGL84-G64M7-KVZRN-4ZVP6","srpX":"870d67a9e626625d9e368507804c9c32e661c57e7e558778291bf29d5a279ae1","signInAddress":"gotham.b5local.com:4000","userAuth":{"method":"SRPg-4096","alg":"PBES2g-HS256","iterations":100000,"salt":"FMRUPiyrN4Xf_8Hoh6YRXQ"}}
                 // This regexp match `ops_{...}` pattern
-                const pattern = /ops_(ey[A-Za-z0-9+/=]{100,1280}fQ={0,2})(?![A-Za-z0-9+/=])/g;
+                const pattern = /(?<!\p{L})ops_(ey[A-Za-z0-9+/=]{100,1280}fQ={0,2})(?![A-Za-z0-9+/=])/gu;
                 const matches = source.content.matchAll(pattern);
                 for (const match of matches) {
                     const index = match.index ?? 0;

--- a/packages/@secretlint/secretlint-rule-1password/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-1password/src/index.ts
@@ -41,7 +41,7 @@ export const creator: SecretLintRuleCreator<Options> = {
                 // https://developer.1password.com/docs/service-accounts/security/
                 // It will be like ops_{"email":"ejwe64qmlxhri@1passwordserviceaccounts.lcl","muk":{"alg":"A256GCM","ext":true,"k":"M8VPfIc8VEfThcMXLaKCKF8sMh5JMZsPAtu92fQNb-o","key_ops":["encrypt","decrypt"],"kty":"oct","kid":"mp"},"secretKey":"A3-C4ZJMN-PQTZTL-HGL84-G64M7-KVZRN-4ZVP6","srpX":"870d67a9e626625d9e368507804c9c32e661c57e7e558778291bf29d5a279ae1","signInAddress":"gotham.b5local.com:4000","userAuth":{"method":"SRPg-4096","alg":"PBES2g-HS256","iterations":100000,"salt":"FMRUPiyrN4Xf_8Hoh6YRXQ"}}
                 // This regexp match `ops_{...}` pattern
-                const pattern = /ops_(ey[A-Za-z0-9+/=]{100,1280}fQ={0,2})/g;
+                const pattern = /ops_(ey[A-Za-z0-9+/=]{100,1280}fQ={0,2})(?![A-Za-z0-9+/=])/g;
                 const matches = source.content.matchAll(pattern);
                 for (const match of matches) {
                     const index = match.index ?? 0;

--- a/packages/@secretlint/secretlint-rule-anthropic/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-anthropic/src/index.ts
@@ -25,14 +25,13 @@ export const creator: SecretLintRuleCreator = {
                 // Anthropic Claude API keys patterns:
                 // - sk-ant-api03-... (original format) - 13 chars prefix
                 // - sk-ant-api04-... (newer format) - 13 chars prefix
-                // Examples:
-                // sk-ant-api03-z0zjHHXo5uibD2havvfqiZYJe9ENlwI1trcQC5pyDC2N2w6nbpUitUU_iR4kkSszVyUpINaxvCtun3_Mub0O3w-48GXRgAA (108 chars total)
+                // Example format: sk-ant-api03-<93 base64url chars>AA (108 chars total)
                 // Breakdown: prefix(13) + middle(93) + suffix(2) = 108 chars
                 // Pattern: sk-ant-api0[3-4]- + base64-like characters (exactly 93 chars) + ending with AA
                 // https://docs.anthropic.com/en/api/overview
                 // https://docs.anthropic.com/en/api/admin-api/apikeys/get-api-key
                 // https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/claude_api_key
-                const pattern = /sk-ant-api0\d-[A-Za-z0-9_-]{90,128}AA(?![A-Za-z0-9_-])/g;
+                const pattern = /(?<!\p{L})sk-ant-api0\d-[A-Za-z0-9_-]{90,128}AA(?![A-Za-z0-9_-])/gu;
                 const matches = source.content.matchAll(pattern);
                 for (const match of matches) {
                     const index = match.index ?? 0;

--- a/packages/@secretlint/secretlint-rule-anthropic/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-anthropic/src/index.ts
@@ -32,7 +32,7 @@ export const creator: SecretLintRuleCreator = {
                 // https://docs.anthropic.com/en/api/overview
                 // https://docs.anthropic.com/en/api/admin-api/apikeys/get-api-key
                 // https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/claude_api_key
-                const pattern = /sk-ant-api0\d-[A-Za-z0-9_-]{90,128}AA/g;
+                const pattern = /sk-ant-api0\d-[A-Za-z0-9_-]{90,128}AA(?![A-Za-z0-9_-])/g;
                 const matches = source.content.matchAll(pattern);
                 for (const match of matches) {
                     const index = match.index ?? 0;

--- a/packages/@secretlint/secretlint-rule-github/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-github/src/index.ts
@@ -99,10 +99,11 @@ export const creator: SecretLintRuleCreator<Options> = {
     create(context, options) {
         // token length should be 40
         // https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
-        const CLASSIC_GITHUB_TOKEN_PATTERN = /(?<type>ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36}(?![A-Za-z0-9_])/g;
+        const CLASSIC_GITHUB_TOKEN_PATTERN =
+            /(?<!\p{L})(?<type>ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36}(?![A-Za-z0-9_])/gu;
         // fine-grained personal access tokens. FIXME: Format of the token is unclear
         // https://github.com/community/community/discussions/36441#discussioncomment-4014190
-        const FINE_GRAINED_GITHUB_TOKEN_PATTERN = /(?<type>github_pat)_[A-Za-z0-9_]{82}(?![A-Za-z0-9_])/g;
+        const FINE_GRAINED_GITHUB_TOKEN_PATTERN = /(?<!\p{L})(?<type>github_pat)_[A-Za-z0-9_]{82}(?![A-Za-z0-9_])/gu;
         const patterns = [CLASSIC_GITHUB_TOKEN_PATTERN, FINE_GRAINED_GITHUB_TOKEN_PATTERN];
         const t = context.createTranslator(messages);
         const normalizedOptions = {

--- a/packages/@secretlint/secretlint-rule-github/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-github/src/index.ts
@@ -99,10 +99,10 @@ export const creator: SecretLintRuleCreator<Options> = {
     create(context, options) {
         // token length should be 40
         // https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
-        const CLASSIC_GITHUB_TOKEN_PATTERN = /(?<type>ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36}/g;
+        const CLASSIC_GITHUB_TOKEN_PATTERN = /(?<type>ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36}(?![A-Za-z0-9_])/g;
         // fine-grained personal access tokens. FIXME: Format of the token is unclear
         // https://github.com/community/community/discussions/36441#discussioncomment-4014190
-        const FINE_GRAINED_GITHUB_TOKEN_PATTERN = /(?<type>github_pat)_[A-Za-z0-9_]{82}/g;
+        const FINE_GRAINED_GITHUB_TOKEN_PATTERN = /(?<type>github_pat)_[A-Za-z0-9_]{82}(?![A-Za-z0-9_])/g;
         const patterns = [CLASSIC_GITHUB_TOKEN_PATTERN, FINE_GRAINED_GITHUB_TOKEN_PATTERN];
         const t = context.createTranslator(messages);
         const normalizedOptions = {

--- a/packages/@secretlint/secretlint-rule-linear/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-linear/src/index.ts
@@ -22,7 +22,7 @@ export const creator: SecretLintRuleCreator = {
         const t = context.createTranslator(messages);
         return {
             file(source: SecretLintSourceCode) {
-                const pattern = /lin_api_[a-zA-Z0-9_]{32,128}(?![a-zA-Z0-9_])/g;
+                const pattern = /(?<!\p{L})lin_api_[a-zA-Z0-9_]{32,128}(?![a-zA-Z0-9_])/gu;
                 const matches = source.content.matchAll(pattern);
                 for (const match of matches) {
                     const index = match.index ?? 0;

--- a/packages/@secretlint/secretlint-rule-linear/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-linear/src/index.ts
@@ -22,7 +22,7 @@ export const creator: SecretLintRuleCreator = {
         const t = context.createTranslator(messages);
         return {
             file(source: SecretLintSourceCode) {
-                const pattern = /lin_api_[a-zA-Z0-9_]{32,128}/g;
+                const pattern = /lin_api_[a-zA-Z0-9_]{32,128}(?![a-zA-Z0-9_])/g;
                 const matches = source.content.matchAll(pattern);
                 for (const match of matches) {
                     const index = match.index ?? 0;

--- a/packages/@secretlint/secretlint-rule-npm/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-npm/src/index.ts
@@ -113,7 +113,7 @@ function reportIfFound_NPM_ACCESS_TOKEN({
     // https://github.blog/2021-09-23-announcing-npms-new-access-token-format/
     // https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
     // token length should be 40
-    const NPM_ACCESS_TOKEN_PATTERN = /npm_[A-Za-z0-9_]{36}/g;
+    const NPM_ACCESS_TOKEN_PATTERN = /npm_[A-Za-z0-9_]{36}(?![A-Za-z0-9_])/g;
     const results = source.content.matchAll(NPM_ACCESS_TOKEN_PATTERN);
     for (const result of results) {
         const index = result.index || 0;

--- a/packages/@secretlint/secretlint-rule-npm/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-npm/src/index.ts
@@ -113,7 +113,7 @@ function reportIfFound_NPM_ACCESS_TOKEN({
     // https://github.blog/2021-09-23-announcing-npms-new-access-token-format/
     // https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
     // token length should be 40
-    const NPM_ACCESS_TOKEN_PATTERN = /npm_[A-Za-z0-9_]{36}(?![A-Za-z0-9_])/g;
+    const NPM_ACCESS_TOKEN_PATTERN = /(?<!\p{L})npm_[A-Za-z0-9_]{36}(?![A-Za-z0-9_])/gu;
     const results = source.content.matchAll(NPM_ACCESS_TOKEN_PATTERN);
     for (const result of results) {
         const index = result.index || 0;

--- a/packages/@secretlint/secretlint-rule-sendgrid/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-sendgrid/src/index.ts
@@ -32,7 +32,7 @@ function reportIfFoundKey({
     context: SecretLintRuleContext;
     t: SecretLintRuleMessageTranslate<typeof messages>;
 }) {
-    const SENDGRID_KEY_PATTERN = /(?<![A-Za-z])SG\.\w{1,128}\.\w{1,128}([-_]?)\w{1,128}(?!\w)/g;
+    const SENDGRID_KEY_PATTERN = /(?<!\p{L})SG\.\w{1,128}\.\w{1,128}([-_]?)\w{1,128}(?!\w)/gu;
     const results = source.content.matchAll(SENDGRID_KEY_PATTERN);
     for (const result of results) {
         const index = result.index || 0;

--- a/packages/@secretlint/secretlint-rule-sendgrid/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-sendgrid/src/index.ts
@@ -32,7 +32,7 @@ function reportIfFoundKey({
     context: SecretLintRuleContext;
     t: SecretLintRuleMessageTranslate<typeof messages>;
 }) {
-    const SENDGRID_KEY_PATTERN = /(?<![A-Za-z])SG\.\w{1,128}\.\w{1,128}([-_]?)\w{1,128}/g;
+    const SENDGRID_KEY_PATTERN = /(?<![A-Za-z])SG\.\w{1,128}\.\w{1,128}([-_]?)\w{1,128}(?!\w)/g;
     const results = source.content.matchAll(SENDGRID_KEY_PATTERN);
     for (const result of results) {
         const index = result.index || 0;

--- a/packages/@secretlint/secretlint-rule-shopify/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-shopify/src/index.ts
@@ -51,7 +51,7 @@ function reportIfFoundKey({
      * shppa_[a-zA-Z0-9]{32,64}
      * e.g.) shppa_7jqbg9cupMkZRxJKXWz3v8BvS8QBa7hMdJfAex
      */
-    const SHOPIFY_KEY_PATTERN = /(shppa|shpca|shpat|shpss)_[a-zA-Z0-9]{32,64}(?![a-zA-Z0-9])/g;
+    const SHOPIFY_KEY_PATTERN = /(?<!\p{L})(shppa|shpca|shpat|shpss)_[a-zA-Z0-9]{32,64}(?![a-zA-Z0-9])/gu;
     const results = source.content.matchAll(SHOPIFY_KEY_PATTERN);
     for (const result of results) {
         const index = result.index || 0;

--- a/packages/@secretlint/secretlint-rule-shopify/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-shopify/src/index.ts
@@ -51,7 +51,7 @@ function reportIfFoundKey({
      * shppa_[a-zA-Z0-9]{32,64}
      * e.g.) shppa_7jqbg9cupMkZRxJKXWz3v8BvS8QBa7hMdJfAex
      */
-    const SHOPIFY_KEY_PATTERN = /(shppa|shpca|shpat|shpss)_[a-zA-Z0-9]{32,64}/g;
+    const SHOPIFY_KEY_PATTERN = /(shppa|shpca|shpat|shpss)_[a-zA-Z0-9]{32,64}(?![a-zA-Z0-9])/g;
     const results = source.content.matchAll(SHOPIFY_KEY_PATTERN);
     for (const result of results) {
         const index = result.index || 0;

--- a/packages/@secretlint/secretlint-rule-vercel/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-vercel/src/index.ts
@@ -55,7 +55,7 @@ export const creator: SecretLintRuleCreator<Options> = {
         };
         return {
             file(source: SecretLintSourceCode) {
-                const pattern = /(?<!\p{L})(?<prefix>vcp|vci|vca|vcr|vck)_[A-Za-z0-9]{20,60}/gu;
+                const pattern = /(?<!\p{L})(?<prefix>vcp|vci|vca|vcr|vck)_[A-Za-z0-9]{20,60}(?![A-Za-z0-9])/gu;
                 const matches = source.content.matchAll(pattern);
                 for (const match of matches) {
                     const index = match.index ?? 0;


### PR DESCRIPTION
## Summary

AGENTS.md の regex boundary conventions に既存ルールを準拠させる。

- 末尾: 各パターンの文字クラスに対応する negative lookahead を追加（過剰マッチ防止）
- 先頭: `(?<!\p{L})` + `u` フラグを追加（単語途中でのマッチ防止）

## 対象ルール

| Rule | Leading | Trailing |
|------|---------|----------|
| vercel | (既存) | `(?![A-Za-z0-9])` 追加 |
| github | `(?<!\p{L})` 追加 | `(?![A-Za-z0-9_])` 追加 |
| linear | `(?<!\p{L})` 追加 | `(?![a-zA-Z0-9_])` 追加 |
| shopify | `(?<!\p{L})` 追加 | `(?![a-zA-Z0-9])` 追加 |
| npm | `(?<!\p{L})` 追加 | `(?![A-Za-z0-9_])` 追加 |
| sendgrid | `(?<!\p{L})` に変更 | `(?!\w)` 追加 |
| 1password | `(?<!\p{L})` 追加 | `(?![A-Za-z0-9+/=])` 追加 |
| anthropic | `(?<!\p{L})` 追加 | `(?![A-Za-z0-9_-])` 追加 |

## パフォーマンス

100KB入力 x 500回のベンチマークで変更前後の差は 1.02x（実質同等）。

https://claude.ai/code/session_012wCR4tfJSFSUpyMTT5CF1A