### PR TITLE
ci: add npm environment to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'Type: Release')
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       contents: write
       id-token: write  # Required for OIDC


### PR DESCRIPTION
## Summary

Add the `npm` environment to the release workflow in GitHub Actions. This ensures the release job runs with proper npm environment configuration, which is required for npm OIDC Trusted Publisher authentication.

## Changes

- Added `environment: npm` to the release job in `.github/workflows/release.yml`

## Breaking Changes

None

## Test Plan

- Verify the release workflow runs successfully with the npm environment configured
- Check that npm publishing works correctly via OIDC Trusted Publisher after this change