### PR TITLE
Remove npm upgrade step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,12 +65,6 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install latest npm
-        if: steps.tag_check.outputs.exists_tag == 'false'
-        run: |
-          echo "Current npm version: $(npm -v)"
-          npm install -g npm@latest
-          echo "Updated npm version: $(npm -v)"
       - name: Publish with OIDC
         if: steps.tag_check.outputs.exists_tag == 'false'
         run: |


### PR DESCRIPTION
## Summary
Removed the "Install latest npm" step from the release workflow that was upgrading npm to the latest version before publishing.

## Changes
- Removed the npm upgrade step that was conditionally executed when a new tag was being created
- This step included version logging before and after the upgrade via `npm install -g npm@latest`

## Rationale
The npm upgrade step is no longer necessary in the release workflow. The environment's default npm version should be sufficient for publishing packages, reducing unnecessary operations and potential compatibility concerns during the release process.

https://claude.ai/code/session_01E5amJaUDy7PGGueyniGnLy