### PR TITLE
Consolidate TypeScript configuration into shared base config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ dist/
 browser/
 /module/
 /lib/
+
+# TypeScript incremental build output
+*.tsbuildinfo

--- a/packages/@secretlint/config-creator/tsconfig.json
+++ b/packages/@secretlint/config-creator/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/config-loader/tsconfig.json
+++ b/packages/@secretlint/config-loader/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/core/tsconfig.json
+++ b/packages/@secretlint/core/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/formatter/tsconfig.json
+++ b/packages/@secretlint/formatter/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/messages-to-markdown/tsconfig.json
+++ b/packages/@secretlint/messages-to-markdown/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/node/tsconfig.json
+++ b/packages/@secretlint/node/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/profiler/tsconfig.json
+++ b/packages/@secretlint/profiler/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/quick-start/tsconfig.json
+++ b/packages/@secretlint/quick-start/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/resolver/tsconfig.json
+++ b/packages/@secretlint/resolver/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-formatter-sarif/tsconfig.json
+++ b/packages/@secretlint/secretlint-formatter-sarif/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-1password/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-1password/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-anthropic/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-anthropic/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-aws/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-aws/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-azure/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-azure/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-basicauth/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-basicauth/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-database-connection-string/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-database-connection-string/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-databricks/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-databricks/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-docker/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-docker/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-example/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-example/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-figma/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-figma/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-filter-comments/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-filter-comments/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-gcp/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-gcp/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-github/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-github/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-gitlab/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-gitlab/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-grafana/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-grafana/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-groq/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-groq/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-hashicorp-vault/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-hashicorp-vault/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-huggingface/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-huggingface/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-internal-test-cjs/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-internal-test-cjs/tsconfig.json
@@ -1,35 +1,13 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
     "module": "CommonJS",
     "moduleResolution": "Node",
     "ignoreDeprecations": "6.0",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./lib/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-internal-test-esm/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-internal-test-esm/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-linear/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-linear/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-no-dotenv/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-no-dotenv/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-no-homedir/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-no-homedir/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-no-k8s-kind-secret/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-notion/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-notion/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-npm/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-npm/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-openai/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-openai/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-pattern/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-pattern/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-preset-canary/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/tsconfig.json
@@ -1,35 +1,11 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "noEmit": true,
-    "newLine": "LF",
     "outDir": "./module/",
     "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noEmit": true
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-preset-recommend/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-preset-recommend/tsconfig.json
@@ -1,35 +1,11 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
     "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noEmit": true
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-privatekey/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-privatekey/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-sendgrid/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-sendgrid/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-shopify/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-shopify/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-slack/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-slack/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/secretlint-rule-vercel/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-vercel/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/source-creator/tsconfig.json
+++ b/packages/@secretlint/source-creator/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/tester/tsconfig.json
+++ b/packages/@secretlint/tester/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/@secretlint/types/tsconfig.json
+++ b/packages/@secretlint/types/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/packages/secretlint/tsconfig.json
+++ b/packages/secretlint/tsconfig.json
@@ -1,34 +1,10 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    /* Basic Options */
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "newLine": "LF",
     "outDir": "./module/",
-    "rootDir": "./src",
-    "target": "ES2022",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-    "jsx": "preserve",
-    "lib": [
-      "esnext",
-      "dom"
-    ],
-    "strict": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    ".git",
-    "node_modules"
   ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "newLine": "LF",
+    "target": "ES2022",
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "jsx": "preserve",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "exclude": [
+    ".git",
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
Refactored TypeScript configuration across the monorepo by extracting common compiler options into a shared `tsconfig.base.json` file. All package-level `tsconfig.json` files now extend this base configuration, eliminating duplication and improving maintainability.

Closes #1494

## Key Changes
- Created new `tsconfig.base.json` at the repository root containing all common TypeScript compiler options (module resolution, target, strict mode settings, etc.)
- Updated 50+ package `tsconfig.json` files to extend the base configuration instead of duplicating settings
- Retained package-specific overrides (e.g., `outDir`, `rootDir`, `noEmit` for preset packages)
- Removed redundant `exclude` patterns from individual package configs (now inherited from base)
- Added `*.tsbuildinfo` to `.gitignore` for TypeScript incremental build artifacts

## Implementation Details
- The base configuration includes all standard compiler options: `module: "NodeNext"`, `target: "ES2022"`, strict type checking, source maps, and declaration files
- Special case: `@secretlint/secretlint-rule-internal-test-cjs` overrides `module` and `moduleResolution` for CommonJS compatibility
- Preset packages (`preset-canary`, `preset-recommend`) retain their `noEmit: true` setting
- All packages maintain their specific `outDir` and `rootDir` configurations as needed

https://claude.ai/code/session_01Af8a9aFwd7NrKwfGdt3ppL