### PR TITLE
Add macOS SecureClipboard application to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,12 @@ This web extension aims to find credentials that are included in your request/re
 Secretlint WebExtension integrates to DevTools in Chrome/Firefox.
 This extension helps web developers to notice exposed credentials.
 
+### macOS
+
+[SecureClipboard](https://github.com/secretlint/secure-clipboard) is a macOS menu bar application that uses secretlint to detect and mask secrets in your clipboard before they are pasted elsewhere.
+
+- <https://github.com/secretlint/secure-clipboard>
+
 ### Others
 
 #### SARIF format support

--- a/README.md
+++ b/README.md
@@ -593,9 +593,7 @@ This extension helps web developers to notice exposed credentials.
 
 ### macOS
 
-[SecureClipboard](https://github.com/secretlint/secure-clipboard) is a macOS menu bar application that uses secretlint to detect and mask secrets in your clipboard before they are pasted elsewhere.
-
-- <https://github.com/secretlint/secure-clipboard>
+[SecureClipboard](https://github.com/secretlint/secure-clipboard) is a macOS menu bar application that uses Secretlint to detect and mask secrets in your clipboard before they are pasted elsewhere.
 
 ### Others
 


### PR DESCRIPTION
## Summary
Added documentation for SecureClipboard, a macOS menu bar application that integrates with secretlint to detect and mask secrets in the clipboard.

## Changes
- Added new "macOS" section to the README under integrations
- Documented SecureClipboard as a macOS-specific tool that uses secretlint to prevent accidental exposure of secrets when pasting
- Included link to the SecureClipboard GitHub repository

## Details
This addition highlights an official macOS integration that extends secretlint's functionality to the system clipboard level, helping developers avoid pasting sensitive credentials in unintended locations.

https://claude.ai/code/session_015xVAm1eUuZzFteUfTxFUy7