### PR TITLE
Add per-pattern allows configuration for secretlint-rule-pattern

### DIFF
--- a/packages/@secretlint/secretlint-rule-pattern/README.md
+++ b/packages/@secretlint/secretlint-rule-pattern/README.md
@@ -106,6 +106,7 @@ Each pattern can have its own `allows` list in addition to the global `allows`. 
     {
       "id": "@secretlint/secretlint-rule-pattern",
       "options": {
+        "allows": ["/^test-/"],
         "patterns": [
           {
             "name": "password=",
@@ -123,7 +124,9 @@ Each pattern can have its own `allows` list in addition to the global `allows`. 
 }
 ```
 
-In this example, `dummy-*` values are allowed only for the `password=` pattern, but still flagged for `apikey=`.
+In this example:
+- `test-*` values are allowed globally for all patterns
+- `dummy-*` values are allowed only for the `password=` pattern, but still flagged for `apikey=`
 
 ### Deprecated options
 

--- a/packages/@secretlint/secretlint-rule-pattern/README.md
+++ b/packages/@secretlint/secretlint-rule-pattern/README.md
@@ -94,6 +94,36 @@ Disallow to use specified RegEx patterns from SecretLint config.
         - `patterns?: string[]` - Array of RegExp-like strings to match against file content
         - `pattern?: string` - **[DEPRECATED]** Single RegExp-like string to match against file content (use `patterns` instead)
         - `filePathGlobs?: string[]` - Array of glob patterns to match against file paths
+        - `allows?: string[]` - Allows a list of [RegExp-like String](https://github.com/textlint/regexp-string-matcher#regexp-like-string) for this pattern only
+
+### Per-pattern allows
+
+Each pattern can have its own `allows` list in addition to the global `allows`. This is useful when you want to allow a value only for a specific pattern.
+
+```json
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-pattern",
+      "options": {
+        "patterns": [
+          {
+            "name": "password=",
+            "patterns": ["/password\\s*=\\s*(?<password>[\\w\\d]{1,256})\\b.*/gi"],
+            "allows": ["/^dummy-/"]
+          },
+          {
+            "name": "apikey=",
+            "patterns": ["/apikey\\s*=\\s*(?<apikey>[\\w\\d]{8,})\\b.*/gi"]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+In this example, `dummy-*` values are allowed only for the `password=` pattern, but still flagged for `apikey=`.
 
 ### Deprecated options
 

--- a/packages/@secretlint/secretlint-rule-pattern/README.md
+++ b/packages/@secretlint/secretlint-rule-pattern/README.md
@@ -85,20 +85,9 @@ Disallow to use specified RegEx patterns from SecretLint config.
 
 ## Options
 
-- `allows: string[]`
-    - Allows a list of [RegExp-like String](https://github.com/textlint/regexp-string-matcher#regexp-like-string)
-- `patterns: PatternType[]`
-    - Array of pattern configurations
-    - Each pattern can have:
-        - `name: string` - Name of the pattern (required)
-        - `patterns?: string[]` - Array of RegExp-like strings to match against file content
-        - `pattern?: string` - **[DEPRECATED]** Single RegExp-like string to match against file content (use `patterns` instead)
-        - `filePathGlobs?: string[]` - Array of glob patterns to match against file paths
-        - `allows?: string[]` - Allows a list of [RegExp-like String](https://github.com/textlint/regexp-string-matcher#regexp-like-string) for this pattern only
+### `allows`
 
-### Per-pattern allows
-
-Each pattern can have its own `allows` list in addition to the global `allows`. This is useful when you want to allow a value only for a specific pattern.
+A global list of [RegExp-like String](https://github.com/textlint/regexp-string-matcher#regexp-like-string) that are allowed across all patterns. Each pattern can additionally define its own `allows` list to allow values only for that specific pattern.
 
 ```json
 {
@@ -127,6 +116,16 @@ Each pattern can have its own `allows` list in addition to the global `allows`. 
 In this example:
 - `test-*` values are allowed globally for all patterns
 - `dummy-*` values are allowed only for the `password=` pattern, but still flagged for `apikey=`
+
+### `patterns`
+
+Array of pattern configurations. Each pattern can have:
+
+- `name: string` - Name of the pattern (required)
+- `patterns?: string[]` - Array of RegExp-like strings to match against file content
+- `pattern?: string` - **[DEPRECATED]** Single RegExp-like string to match against file content (use `patterns` instead)
+- `filePathGlobs?: string[]` - Array of glob patterns to match against file paths
+- `allows?: string[]` - Per-pattern allow list of [RegExp-like String](https://github.com/textlint/regexp-string-matcher#regexp-like-string), applied in addition to the global `allows`
 
 ### Deprecated options
 

--- a/packages/@secretlint/secretlint-rule-pattern/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-pattern/src/index.ts
@@ -25,6 +25,7 @@ export type PatternType = {
      */
     pattern?: string;
     filePathGlobs?: string[];
+    allows?: string[];
 };
 
 export type Options = {
@@ -36,7 +37,7 @@ function collectPatterns(patternConfig: PatternType): string[] {
     // Error if both patterns and pattern are specified
     if (patternConfig.patterns && patternConfig.patterns.length > 0 && patternConfig.pattern) {
         throw new Error(
-            `Pattern "${patternConfig.name}" cannot have both "patterns" and "pattern" specified. Use "patterns" array instead.`
+            `Pattern "${patternConfig.name}" cannot have both "patterns" and "pattern" specified. Use "patterns" array instead.`,
         );
     }
 
@@ -86,7 +87,9 @@ function reportIfFoundPattern({
                 const index = result.startIndex || 0;
                 const match = result.match || "";
                 const range = [index, index + match.length] as const;
-                const allowedResults = matchPatterns(match, options.allows);
+                const globalAllows = options.allows;
+                const patternAllows = p.allows ?? [];
+                const allowedResults = matchPatterns(match, [...globalAllows, ...patternAllows]);
                 if (allowedResults.length > 0) {
                     continue;
                 }
@@ -131,7 +134,7 @@ export const creator: SecretLintRuleCreator<Options> = {
             // Validate that patterns and pattern are not both specified
             if (p.patterns && p.patterns.length > 0 && p.pattern) {
                 throw new Error(
-                    `Pattern "${p.name}" cannot have both "patterns" and "pattern" specified. Use "patterns" array instead.`
+                    `Pattern "${p.name}" cannot have both "patterns" and "pattern" specified. Use "patterns" array instead.`,
                 );
             }
 
@@ -139,7 +142,7 @@ export const creator: SecretLintRuleCreator<Options> = {
             const hasFilePathGlobs = p.filePathGlobs && p.filePathGlobs.length > 0;
             if (!hasPatterns && !hasFilePathGlobs) {
                 throw new Error(
-                    `Pattern "${p.name}" must have either "patterns", "pattern" (deprecated), or "filePathGlobs" specified`
+                    `Pattern "${p.name}" must have either "patterns", "pattern" (deprecated), or "filePathGlobs" specified`,
                 );
             }
         }

--- a/packages/@secretlint/secretlint-rule-pattern/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-pattern/src/index.ts
@@ -82,14 +82,13 @@ function reportIfFoundPattern({
 
         // Check patterns if specified
         if (allPatterns.length > 0) {
+            const mergedAllows = [...options.allows, ...(p.allows ?? [])];
             const results = matchPatterns(source.content, allPatterns);
             for (const result of results) {
                 const index = result.startIndex || 0;
                 const match = result.match || "";
                 const range = [index, index + match.length] as const;
-                const globalAllows = options.allows;
-                const patternAllows = p.allows ?? [];
-                const allowedResults = matchPatterns(match, [...globalAllows, ...patternAllows]);
+                const allowedResults = matchPatterns(match, mergedAllows);
                 if (allowedResults.length > 0) {
                     continue;
                 }

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.pattern-allows-other-pattern/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.pattern-allows-other-pattern/.secretlintrc.json
@@ -1,0 +1,20 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-pattern",
+      "options": {
+        "patterns": [
+          {
+            "name": "password=",
+            "pattern": "/password\\s*=\\s*(?<password>[\\w\\d!@#$%^&(){}\\[\\]:\";'<>,.?/~`_+-=|]{1,256})\\b.*/gi",
+            "allows": ["foo-bar-baz"]
+          },
+          {
+            "name": "apikey=",
+            "pattern": "/apikey\\s*=\\s*(?<apikey>[\\w\\d_-]{8,})\\b.*/gi"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.pattern-allows-other-pattern/input.txt
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.pattern-allows-other-pattern/input.txt
@@ -1,0 +1,2 @@
+password = foo-bar-baz
+apikey = foo-bar-baz

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.pattern-allows-other-pattern/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ng.pattern-allows-other-pattern/output.json
@@ -1,0 +1,32 @@
+{
+    "filePath": "[SNAPSHOT]/ng.pattern-allows-other-pattern/input.txt",
+    "messages": [
+        {
+            "message": "found matching apikey=: apikey = foo-bar-baz",
+            "range": [
+                23,
+                43
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-pattern",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 20
+                }
+            },
+            "severity": "error",
+            "messageId": "PATTERN",
+            "data": {
+                "PATTERN_NAME": "apikey=",
+                "CREDENTIAL": "apikey = foo-bar-baz"
+            }
+        }
+    ],
+    "sourceContent": "password = foo-bar-baz\napikey = foo-bar-baz\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.pattern-allows/.secretlintrc.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.pattern-allows/.secretlintrc.json
@@ -1,0 +1,21 @@
+{
+  "rules": [
+    {
+      "id": "@secretlint/secretlint-rule-pattern",
+      "options": {
+        "patterns": [
+          {
+            "name": "password=",
+            "pattern": "/password\\s*=\\s*(?<password>[\\w\\d!@#$%^&(){}\\[\\]:\";'<>,.?/~`_+-=|]{1,256})\\b.*/gi",
+            "allows": ["foo-bar"]
+          },
+          {
+            "name": "apikey=",
+            "pattern": "/apikey\\s*=\\s*(?<apikey>[\\w\\d_-]{8,})\\b.*/gi",
+            "allows": ["myapikey123"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.pattern-allows/input.txt
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.pattern-allows/input.txt
@@ -1,0 +1,2 @@
+password = foo-bar
+apikey = myapikey123

--- a/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.pattern-allows/output.json
+++ b/packages/@secretlint/secretlint-rule-pattern/test/snapshots/ok.pattern-allows/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.pattern-allows/input.txt",
+    "messages": [],
+    "sourceContent": "password = foo-bar\napikey = myapikey123\n",
+    "sourceContentType": "text"
+}


### PR DESCRIPTION
## Summary
This PR adds support for per-pattern `allows` configuration in the secretlint-rule-pattern rule, enabling more granular control over which values are allowed for specific patterns.

## Key Changes
- Added `allows?: string[]` field to the `PatternType` interface to support pattern-level allowlist configuration
- Modified the pattern matching logic to merge global `allows` with pattern-specific `allows` when checking for allowed values
- Updated validation error messages with trailing commas for consistency
- Added comprehensive test cases demonstrating:
  - Pattern-specific allows that prevent false positives (ok.pattern-allows)
  - Pattern-specific allows that don't apply to other patterns (ng.pattern-allows-other-pattern)

## Implementation Details
The key change in the matching logic combines both global and pattern-specific allowlists:
```typescript
const globalAllows = options.allows;
const patternAllows = p.allows ?? [];
const allowedResults = matchPatterns(match, [...globalAllows, ...patternAllows]);
```

This allows users to define allowlists at both the global level (applying to all patterns) and at the individual pattern level (applying only to that specific pattern), providing flexibility in secret detection configuration.

https://claude.ai/code/session_0156Eig3oPpp7LeXG3AogZEs