### PR TITLE
docs: Update README and CONTRIBUTING with new rules and corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ After getting your clone, you can start playing with secretlint.
     $ pnpm run build
     ```
 
-Under the hood, secretlint uses Turbopack to manage multiple packages:
+Under the hood, secretlint uses Turborepo to manage multiple packages:
 
 - `packages/*`
 - `packages/@secretlint/*`
@@ -116,7 +116,7 @@ This repository uses [Prettier](https://prettier.io/) for code formatter. We use
 - Run Prettier to reformat code:
 
     ```sh
-    $ pnpm prettier
+    $ pnpm format
     ```
 
 ##### Commit Message Format

--- a/README.md
+++ b/README.md
@@ -342,6 +342,11 @@ Secretlint rules has been implemented as separated modules.
 - [@secretlint/secretlint-rule-databricks](./packages/%40secretlint/secretlint-rule-databricks)
 - [@secretlint/secretlint-rule-hashicorp-vault](./packages/%40secretlint/secretlint-rule-hashicorp-vault)
 - [@secretlint/secretlint-rule-vercel](./packages/%40secretlint/secretlint-rule-vercel)
+- [@secretlint/secretlint-rule-azure](./packages/%40secretlint/secretlint-rule-azure)
+- [@secretlint/secretlint-rule-docker](./packages/%40secretlint/secretlint-rule-docker)
+- [@secretlint/secretlint-rule-figma](./packages/%40secretlint/secretlint-rule-figma)
+- [@secretlint/secretlint-rule-huggingface](./packages/%40secretlint/secretlint-rule-huggingface)
+- [@secretlint/secretlint-rule-notion](./packages/%40secretlint/secretlint-rule-notion)
 - [@secretlint/secretlint-rule-secp256k1-privatekey](./packages/@secretlint/secretlint-rule-secp256k1-privatekey)
 - [@secretlint/secretlint-rule-no-k8s-kind-secret](./packages/@secretlint/secretlint-rule-no-k8s-kind-secret)
 - [@secretlint/secretlint-rule-pattern](./packages/@secretlint/secretlint-rule-pattern)
@@ -709,10 +714,10 @@ See also, [CONTRIBUTING.md](./CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](./CODE_O
 
 ### Add New Rule
 
-You can use `npm run gen:rule` command to create new rule.
+You can use `pnpm run gen:rule` command to create new rule.
 
 ```shell script
-npm run gen:rule
+pnpm run gen:rule
 ```
 
 For more details, please see [CONTRIBUTING.md](./CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
This PR updates documentation to reflect new secretlint rules and corrects references to build tools and commands.

## Key Changes
- **Added 5 new secretlint rules** to the README rules list:
  - Azure
  - Docker
  - Figma
  - HuggingFace
  - Notion

- **Updated command references** from `npm` to `pnpm` for consistency with the project's package manager:
  - `npm run gen:rule` → `pnpm run gen:rule`

- **Fixed documentation errors**:
  - Corrected "Turbopack" to "Turborepo" in CONTRIBUTING.md (the actual monorepo tool used)
  - Updated Prettier command reference from `pnpm prettier` to `pnpm format` to match actual npm scripts

## Notes
These changes ensure the documentation accurately reflects the current state of the project, including newly available rules and the correct tooling/commands for contributors.

https://claude.ai/code/session_01PyFaNNG9eVNU1SgpsVxt4g