### PR TITLE
chore(docker): add OCI image source label

### DIFF
--- a/publish/docker/Dockerfile
+++ b/publish/docker/Dockerfile
@@ -2,6 +2,8 @@ FROM node:22-alpine
 
 LABEL maintainer="azu <azuciao@gmail.com>"
 LABEL description="Docker Container for secretlint"
+LABEL org.opencontainers.image.source="https://github.com/secretlint/secretlint"
+LABEL org.opencontainers.image.licenses="MIT"
 
 ARG SECRETLINT_VERSION
 ENV SECRETLINT_VERSION=${SECRETLINT_VERSION:-4.0.0}


### PR DESCRIPTION
## Summary

Add standard OCI image labels to `publish/docker/Dockerfile` so downstream
tooling (Renovate, Dependabot, Docker Hub image page, GHCR "Connect repository")
can auto-resolve this repository as the image source.

## Why

When a consumer project updates `secretlint/secretlint` via Renovate, the
generated PR body currently has no repository link and no release notes
section, because the Docker datasource reads `org.opencontainers.image.source`
from the image metadata to discover the source repo. Adding this single label
fixes this for every downstream consumer without any configuration on their
end.

For context, the `npx` snippet shown in the README is the standard setup —
this proposal is specifically useful when users additionally pin a specific
`secretlint/secretlint` Docker tag for reproducible CI, since in that setup
Renovate / Dependabot update PRs become the main surface for reviewing what
changed between versions.

## Changes

- Add `LABEL org.opencontainers.image.source` (points to this repo)
- Add `LABEL org.opencontainers.image.licenses="MIT"` (matches the project LICENSE)

## References

- [OCI image-spec — pre-defined annotation keys](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys)
- Same labels are used by projects like renovatebot/renovate and fluent/fluent-bit.

## Verification

- `docker build -t secretlint publish/docker/` succeeds locally.
- `docker image inspect <tag> --format '{{json .Config.Labels}}'` shows the new labels:
  ```json
  {
    "description": "Docker Container for secretlint",
    "maintainer": "azu <azuciao@gmail.com>",
    "org.opencontainers.image.licenses": "MIT",
    "org.opencontainers.image.source": "https://github.com/secretlint/secretlint"
  }
  ```
- `docker run --rm <tag> secretlint --version` → `4.0.0`

Closes #1510
