### PR TITLE
feat(secretlint-rule-stripe): add Stripe API key detection rule

### DIFF
--- a/packages/@secretlint/secretlint-rule-preset-canary/package.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/package.json
@@ -85,6 +85,7 @@
         "@secretlint/secretlint-rule-sendgrid": "workspace:*",
         "@secretlint/secretlint-rule-shopify": "workspace:*",
         "@secretlint/secretlint-rule-slack": "workspace:*",
+        "@secretlint/secretlint-rule-stripe": "workspace:*",
         "@secretlint/secretlint-rule-tailscale": "workspace:*",
         "@secretlint/secretlint-rule-vercel": "workspace:*",
         "@secretlint/tester": "workspace:*",

--- a/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-preset-canary/src/index.ts
@@ -13,6 +13,7 @@ import { creator as ruleNotion } from "@secretlint/secretlint-rule-notion";
 import { creator as rulePrivateKey } from "@secretlint/secretlint-rule-privatekey";
 import { creator as ruleSendgrid } from "@secretlint/secretlint-rule-sendgrid";
 import { creator as ruleShopify } from "@secretlint/secretlint-rule-shopify";
+import { creator as ruleStripe } from "@secretlint/secretlint-rule-stripe";
 import { creator as ruleGitHub } from "@secretlint/secretlint-rule-github";
 import { creator as ruleGitLab } from "@secretlint/secretlint-rule-gitlab";
 import { creator as ruleGrafana } from "@secretlint/secretlint-rule-grafana";
@@ -36,6 +37,7 @@ export const rules = [
     ruleSlack,
     ruleSendgrid,
     ruleShopify,
+    ruleStripe,
     ruleGitHub,
     ruleGitLab,
     ruleGrafana,

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ng.secret/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ng.secret/input.txt
@@ -1,0 +1,14 @@
+# Stripe API keys that should be detected
+# Source: https://docs.stripe.com/keys
+
+# Live Secret Key
+STRIPE_SECRET_KEY=sk_live_AAAAAAAAAAAAAAAAAAAAAAAA
+
+# Test Secret Key
+sk_test_BBBBBBBBBBBBBBBBBBBBBBBB
+
+# Live Restricted Key
+rk_live_CCCCCCCCCCCCCCCCCCCCCCCC
+
+# Test Restricted Key
+rk_test_DDDDDDDDDDDDDDDDDDDDDDDD

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ng.secret/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ng.secret/output.json
@@ -1,0 +1,111 @@
+{
+    "filePath": "[SNAPSHOT]/ng.secret/input.txt",
+    "messages": [
+        {
+            "message": "found Stripe Live Secret Key: sk_live_AAAAAAAAAAAAAAAAAAAAAAAA",
+            "range": [
+                118,
+                150
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-stripe",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 18
+                },
+                "end": {
+                    "line": 5,
+                    "column": 50
+                }
+            },
+            "severity": "error",
+            "messageId": "STRIPE_SECRET_KEY_LIVE",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-stripe/README.md#STRIPE_SECRET_KEY_LIVE",
+            "data": {
+                "KEY": "sk_live_AAAAAAAAAAAAAAAAAAAAAAAA"
+            }
+        },
+        {
+            "message": "found Stripe Test Secret Key: sk_test_BBBBBBBBBBBBBBBBBBBBBBBB",
+            "range": [
+                170,
+                202
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-stripe",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 32
+                }
+            },
+            "severity": "error",
+            "messageId": "STRIPE_SECRET_KEY_TEST",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-stripe/README.md#STRIPE_SECRET_KEY_TEST",
+            "data": {
+                "KEY": "sk_test_BBBBBBBBBBBBBBBBBBBBBBBB"
+            }
+        },
+        {
+            "message": "found Stripe Live Restricted Key: rk_live_CCCCCCCCCCCCCCCCCCCCCCCC",
+            "range": [
+                226,
+                258
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-stripe",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 0
+                },
+                "end": {
+                    "line": 11,
+                    "column": 32
+                }
+            },
+            "severity": "error",
+            "messageId": "STRIPE_RESTRICTED_KEY_LIVE",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-stripe/README.md#STRIPE_RESTRICTED_KEY_LIVE",
+            "data": {
+                "KEY": "rk_live_CCCCCCCCCCCCCCCCCCCCCCCC"
+            }
+        },
+        {
+            "message": "found Stripe Test Restricted Key: rk_test_DDDDDDDDDDDDDDDDDDDDDDDD",
+            "range": [
+                282,
+                314
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-stripe",
+            "ruleParentId": "@secretlint/secretlint-rule-preset-canary",
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 0
+                },
+                "end": {
+                    "line": 14,
+                    "column": 32
+                }
+            },
+            "severity": "error",
+            "messageId": "STRIPE_RESTRICTED_KEY_TEST",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-stripe/README.md#STRIPE_RESTRICTED_KEY_TEST",
+            "data": {
+                "KEY": "rk_test_DDDDDDDDDDDDDDDDDDDDDDDD"
+            }
+        }
+    ],
+    "sourceContent": "# Stripe API keys that should be detected\n# Source: https://docs.stripe.com/keys\n\n# Live Secret Key\nSTRIPE_SECRET_KEY=sk_live_AAAAAAAAAAAAAAAAAAAAAAAA\n\n# Test Secret Key\nsk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Live Restricted Key\nrk_live_CCCCCCCCCCCCCCCCCCCCCCCC\n\n# Test Restricted Key\nrk_test_DDDDDDDDDDDDDDDDDDDDDDDD\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ok.valid/input.txt
@@ -4,11 +4,13 @@
 pk_live_AAAAAAAAAAAAAAAAAAAAAAAA
 pk_test_BBBBBBBBBBBBBBBBBBBBBBBB
 
-# Too short (fewer than 10 chars after prefix)
+# Too short (fewer than 24 chars after prefix)
 sk_live_short
 sk_test_abc
 rk_live_x
 rk_test_y
+sk_live_AAAAAAAAAAAAAAAAAAAAAAA
+sk_test_BBBBBBBBBBBBBBBBBBBBBBB
 
 # Wrong prefix / mid-word boundary
 xsk_live_AAAAAAAAAAAAAAAAAAAAAAAA

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ok.valid/input.txt
@@ -1,0 +1,22 @@
+# These should NOT be detected as Stripe API keys
+
+# Publishable keys (pk_) are not secrets
+pk_live_AAAAAAAAAAAAAAAAAAAAAAAA
+pk_test_BBBBBBBBBBBBBBBBBBBBBBBB
+
+# Too short (fewer than 10 chars after prefix)
+sk_live_short
+sk_test_abc
+rk_live_x
+rk_test_y
+
+# Wrong prefix / mid-word boundary
+xsk_live_AAAAAAAAAAAAAAAAAAAAAAAA
+foosk_test_BBBBBBBBBBBBBBBBBBBBBBBB
+
+# Different product names that share the prefix
+SKILLS_inventory
+RKLIST_value
+
+# Stripe documentation URL (not a key)
+https://docs.stripe.com/keys

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ok.valid/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.valid/input.txt",
+    "messages": [],
+    "sourceContent": "# These should NOT be detected as Stripe API keys\n\n# Publishable keys (pk_) are not secrets\npk_live_AAAAAAAAAAAAAAAAAAAAAAAA\npk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Too short (fewer than 10 chars after prefix)\nsk_live_short\nsk_test_abc\nrk_live_x\nrk_test_y\n\n# Wrong prefix / mid-word boundary\nxsk_live_AAAAAAAAAAAAAAAAAAAAAAAA\nfoosk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Different product names that share the prefix\nSKILLS_inventory\nRKLIST_value\n\n# Stripe documentation URL (not a key)\nhttps://docs.stripe.com/keys\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-preset-canary/test/snapshots/secretlint-rule-stripe/ok.valid/output.json
@@ -1,6 +1,6 @@
 {
     "filePath": "[SNAPSHOT]/ok.valid/input.txt",
     "messages": [],
-    "sourceContent": "# These should NOT be detected as Stripe API keys\n\n# Publishable keys (pk_) are not secrets\npk_live_AAAAAAAAAAAAAAAAAAAAAAAA\npk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Too short (fewer than 10 chars after prefix)\nsk_live_short\nsk_test_abc\nrk_live_x\nrk_test_y\n\n# Wrong prefix / mid-word boundary\nxsk_live_AAAAAAAAAAAAAAAAAAAAAAAA\nfoosk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Different product names that share the prefix\nSKILLS_inventory\nRKLIST_value\n\n# Stripe documentation URL (not a key)\nhttps://docs.stripe.com/keys\n",
+    "sourceContent": "# These should NOT be detected as Stripe API keys\n\n# Publishable keys (pk_) are not secrets\npk_live_AAAAAAAAAAAAAAAAAAAAAAAA\npk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Too short (fewer than 24 chars after prefix)\nsk_live_short\nsk_test_abc\nrk_live_x\nrk_test_y\nsk_live_AAAAAAAAAAAAAAAAAAAAAAA\nsk_test_BBBBBBBBBBBBBBBBBBBBBBB\n\n# Wrong prefix / mid-word boundary\nxsk_live_AAAAAAAAAAAAAAAAAAAAAAAA\nfoosk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Different product names that share the prefix\nSKILLS_inventory\nRKLIST_value\n\n# Stripe documentation URL (not a key)\nhttps://docs.stripe.com/keys\n",
     "sourceContentType": "text"
 }

--- a/packages/@secretlint/secretlint-rule-stripe/LICENSE
+++ b/packages/@secretlint/secretlint-rule-stripe/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026 azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@secretlint/secretlint-rule-stripe/README.md
+++ b/packages/@secretlint/secretlint-rule-stripe/README.md
@@ -1,0 +1,93 @@
+# @secretlint/secretlint-rule-stripe
+
+A secretlint rule for detecting [Stripe](https://stripe.com/) API keys.
+
+## Detected Key Types
+
+| Key Type | Prefix | Format |
+|---|---|---|
+| Live Secret Key | `sk_live_` | `sk_live_` + 10–99 alphanumeric chars |
+| Test Secret Key | `sk_test_` | `sk_test_` + 10–99 alphanumeric chars |
+| Live Restricted Key | `rk_live_` | `rk_live_` + 10–99 alphanumeric chars |
+| Test Restricted Key | `rk_test_` | `rk_test_` + 10–99 alphanumeric chars |
+
+References:
+
+- [Stripe API keys documentation](https://docs.stripe.com/keys)
+- GitHub Push Protection: supported provider "Stripe"
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install @secretlint/secretlint-rule-stripe
+
+## Usage
+
+Via `.secretlintrc.json`:
+
+```json
+{
+    "rules": [
+        {
+            "id": "@secretlint/secretlint-rule-stripe"
+        }
+    ]
+}
+```
+
+## Options
+
+```ts
+export type Options = {
+    /**
+     * Define allow pattern written by RegExp-like strings
+     * See https://github.com/textlint/regexp-string-matcher#regexp-like-string
+     **/
+    allows?: string[];
+};
+```
+
+## Messages
+
+### STRIPE_SECRET_KEY_LIVE
+
+Detected a Stripe Live Secret Key (`sk_live_` prefix).
+
+### STRIPE_SECRET_KEY_TEST
+
+Detected a Stripe Test Secret Key (`sk_test_` prefix).
+
+### STRIPE_RESTRICTED_KEY_LIVE
+
+Detected a Stripe Live Restricted Key (`rk_live_` prefix).
+
+### STRIPE_RESTRICTED_KEY_TEST
+
+Detected a Stripe Test Restricted Key (`rk_test_` prefix).
+
+## Changelog
+
+See [Releases page](https://github.com/secretlint/secretlint/releases).
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm test
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/secretlint/secretlint/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## License
+
+MIT © azu

--- a/packages/@secretlint/secretlint-rule-stripe/README.md
+++ b/packages/@secretlint/secretlint-rule-stripe/README.md
@@ -6,10 +6,10 @@ A secretlint rule for detecting [Stripe](https://stripe.com/) API keys.
 
 | Key Type | Prefix | Format |
 |---|---|---|
-| Live Secret Key | `sk_live_` | `sk_live_` + 10–99 alphanumeric chars |
-| Test Secret Key | `sk_test_` | `sk_test_` + 10–99 alphanumeric chars |
-| Live Restricted Key | `rk_live_` | `rk_live_` + 10–99 alphanumeric chars |
-| Test Restricted Key | `rk_test_` | `rk_test_` + 10–99 alphanumeric chars |
+| Live Secret Key | `sk_live_` | `sk_live_` + 24–99 alphanumeric chars |
+| Test Secret Key | `sk_test_` | `sk_test_` + 24–99 alphanumeric chars |
+| Live Restricted Key | `rk_live_` | `rk_live_` + 24–99 alphanumeric chars |
+| Test Restricted Key | `rk_test_` | `rk_test_` + 24–99 alphanumeric chars |
 
 References:
 

--- a/packages/@secretlint/secretlint-rule-stripe/package.json
+++ b/packages/@secretlint/secretlint-rule-stripe/package.json
@@ -1,0 +1,72 @@
+{
+    "name": "@secretlint/secretlint-rule-stripe",
+    "version": "12.3.1",
+    "description": "A secretlint rule for detecting Stripe API keys",
+    "keywords": [
+        "secretlint",
+        "rule",
+        "stripe",
+        "api-key",
+        "security"
+    ],
+    "homepage": "https://github.com/secretlint/secretlint/tree/master/packages/@secretlint/secretlint-rule-stripe/",
+    "bugs": {
+        "url": "https://github.com/secretlint/secretlint/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/secretlint/secretlint.git"
+    },
+    "license": "MIT",
+    "author": "azu",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./module/index.d.ts",
+                "default": "./module/index.js"
+            },
+            "default": "./module/index.js"
+        },
+        "./package.json": "./package.json"
+    },
+    "main": "./module/index.js",
+    "types": "./module/index.d.ts",
+    "files": [
+        "bin/",
+        "module/",
+        "src/"
+    ],
+    "scripts": {
+        "build": "tsc --build",
+        "clean": "tsc --build --clean",
+        "prepublishOnly": "npm run clean && npm run build",
+        "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+        "prepublish": "npm run --if-present build",
+        "test": "node --import tsx --test test/index.test.ts",
+        "updateSnapshot": "UPDATE_SNAPSHOT=1 npm test",
+        "watch": "tsc --build --watch"
+    },
+    "prettier": {
+        "printWidth": 120,
+        "singleQuote": false,
+        "tabWidth": 4
+    },
+    "dependencies": {
+        "@secretlint/types": "workspace:*",
+        "@textlint/regexp-string-matcher": "catalog:"
+    },
+    "devDependencies": {
+        "@secretlint/tester": "workspace:*",
+        "@types/node": "catalog:",
+        "prettier": "catalog:",
+        "tsx": "catalog:",
+        "typescript": "catalog:"
+    },
+    "engines": {
+        "node": ">=22.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/@secretlint/secretlint-rule-stripe/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-stripe/src/index.ts
@@ -41,14 +41,26 @@ const messageIdMap: Record<STRIPE_KEY_PREFIX, keyof typeof messages> = {
     rk_test: "STRIPE_RESTRICTED_KEY_TEST",
 };
 
-// Stripe API key format: {prefix}_{10-99 alphanumeric chars}
+// Stripe API key format: {prefix}_{24-99 alphanumeric chars}
 // Officially documented prefixes (https://docs.stripe.com/keys):
 // - sk_live_ : Live Secret Key
 // - sk_test_ : Test Secret Key
 // - rk_live_ : Live Restricted Key
 // - rk_test_ : Test Restricted Key
-// GitHub Push Protection and gitleaks use the same pattern.
-const STRIPE_KEY_PATTERN = /(?<!\p{L})(?<prefix>sk_live|sk_test|rk_live|rk_test)_[a-zA-Z0-9]{10,99}(?![a-zA-Z0-9])/gu;
+//
+// Length lower bound (24):
+//   Stripe's documentation samples and historical key format use a 24-char body
+//   after the prefix. Issue #1531 also describes the format as "typically 24-32
+//   characters" after the prefix. Stripe does not publish a hard minimum, but
+//   24 reflects the smallest length seen in real keys; gitleaks uses 10 and
+//   TruffleHog uses 20, but those values produce more false positives.
+//   Tightening to 24 trades a (non-existent in practice) shorter key for fewer
+//   false positives.
+//
+// Length upper bound (99):
+//   Modern Stripe keys use an extended `51...` account-prefix encoding and run
+//   up to ~99 chars after the prefix. Matches gitleaks' upper bound.
+const STRIPE_KEY_PATTERN = /(?<!\p{L})(?<prefix>sk_live|sk_test|rk_live|rk_test)_[a-zA-Z0-9]{24,99}(?![a-zA-Z0-9])/gu;
 
 function reportIfFound({
     source,

--- a/packages/@secretlint/secretlint-rule-stripe/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-stripe/src/index.ts
@@ -1,0 +1,108 @@
+import type {
+    SecretLintRuleContext,
+    SecretLintRuleCreator,
+    SecretLintRuleMessageTranslate,
+    SecretLintSourceCode,
+} from "@secretlint/types";
+import { matchPatterns } from "@textlint/regexp-string-matcher";
+
+export const messages = {
+    STRIPE_SECRET_KEY_LIVE: {
+        en: (props: { KEY: string }) => `found Stripe Live Secret Key: ${props.KEY}`,
+        ja: (props: { KEY: string }) => `Stripe Live Secret Keyが見つかりました: ${props.KEY}`,
+    },
+    STRIPE_SECRET_KEY_TEST: {
+        en: (props: { KEY: string }) => `found Stripe Test Secret Key: ${props.KEY}`,
+        ja: (props: { KEY: string }) => `Stripe Test Secret Keyが見つかりました: ${props.KEY}`,
+    },
+    STRIPE_RESTRICTED_KEY_LIVE: {
+        en: (props: { KEY: string }) => `found Stripe Live Restricted Key: ${props.KEY}`,
+        ja: (props: { KEY: string }) => `Stripe Live Restricted Keyが見つかりました: ${props.KEY}`,
+    },
+    STRIPE_RESTRICTED_KEY_TEST: {
+        en: (props: { KEY: string }) => `found Stripe Test Restricted Key: ${props.KEY}`,
+        ja: (props: { KEY: string }) => `Stripe Test Restricted Keyが見つかりました: ${props.KEY}`,
+    },
+};
+
+export type Options = {
+    /**
+     * Define allow pattern written by RegExp-like strings
+     * See https://github.com/textlint/regexp-string-matcher#regexp-like-string
+     **/
+    allows?: string[];
+};
+
+type STRIPE_KEY_PREFIX = "sk_live" | "sk_test" | "rk_live" | "rk_test";
+const messageIdMap: Record<STRIPE_KEY_PREFIX, keyof typeof messages> = {
+    sk_live: "STRIPE_SECRET_KEY_LIVE",
+    sk_test: "STRIPE_SECRET_KEY_TEST",
+    rk_live: "STRIPE_RESTRICTED_KEY_LIVE",
+    rk_test: "STRIPE_RESTRICTED_KEY_TEST",
+};
+
+// Stripe API key format: {prefix}_{10-99 alphanumeric chars}
+// Officially documented prefixes (https://docs.stripe.com/keys):
+// - sk_live_ : Live Secret Key
+// - sk_test_ : Test Secret Key
+// - rk_live_ : Live Restricted Key
+// - rk_test_ : Test Restricted Key
+// GitHub Push Protection and gitleaks use the same pattern.
+const STRIPE_KEY_PATTERN = /(?<!\p{L})(?<prefix>sk_live|sk_test|rk_live|rk_test)_[a-zA-Z0-9]{10,99}(?![a-zA-Z0-9])/gu;
+
+function reportIfFound({
+    source,
+    options,
+    context,
+    t,
+}: {
+    source: SecretLintSourceCode;
+    options: Required<Options>;
+    context: SecretLintRuleContext;
+    t: SecretLintRuleMessageTranslate<typeof messages>;
+}) {
+    const results = source.content.matchAll(STRIPE_KEY_PATTERN);
+    for (const result of results) {
+        const index = result.index ?? 0;
+        const match = result[0] ?? "";
+        const prefix = result.groups?.["prefix"] as STRIPE_KEY_PREFIX | undefined;
+        if (!prefix) {
+            continue;
+        }
+        const range = [index, index + match.length] as const;
+        const allowedResults = matchPatterns(match, options.allows);
+        if (allowedResults.length > 0) {
+            continue;
+        }
+        context.report({
+            message: t(messageIdMap[prefix], {
+                KEY: match,
+            }),
+            range,
+        });
+    }
+}
+
+export const creator: SecretLintRuleCreator<Options> = {
+    messages,
+    meta: {
+        id: "@secretlint/secretlint-rule-stripe",
+        recommended: true,
+        type: "scanner",
+        supportedContentTypes: ["text"],
+        docs: {
+            url: "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-stripe/README.md",
+        },
+    },
+    create(context, options) {
+        const t = context.createTranslator(messages);
+        const normalizedOptions: Required<Options> = {
+            allows: options.allows ?? [],
+        };
+        return {
+            file(source: SecretLintSourceCode) {
+                reportIfFound({ source, options: normalizedOptions, context, t });
+            },
+        };
+    },
+};

--- a/packages/@secretlint/secretlint-rule-stripe/test/index.test.ts
+++ b/packages/@secretlint/secretlint-rule-stripe/test/index.test.ts
@@ -1,0 +1,27 @@
+import { creator as rule } from "../src/index.js";
+
+import test from "node:test";
+
+test("@secretlint/secretlint-rule-stripe", async (t) => {
+    const snapshot = (await import("@secretlint/tester")).snapshot;
+    await snapshot({
+        defaultConfig: {
+            rules: [
+                {
+                    id: "@secretlint/secretlint-rule-stripe",
+                    rule,
+                    options: {},
+                },
+            ],
+        },
+        updateSnapshot: !!process.env.UPDATE_SNAPSHOT,
+        snapshotDirectory: new URL("snapshots", import.meta.url),
+    }).forEach((name, test) => {
+        return t.test(name, async (context) => {
+            const status = await test();
+            if (status === "skip") {
+                context.skip();
+            }
+        });
+    });
+});

--- a/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ng.secret/input.txt
+++ b/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ng.secret/input.txt
@@ -1,0 +1,14 @@
+# Stripe API keys that should be detected
+# Source: https://docs.stripe.com/keys
+
+# Live Secret Key
+STRIPE_SECRET_KEY=sk_live_AAAAAAAAAAAAAAAAAAAAAAAA
+
+# Test Secret Key
+sk_test_BBBBBBBBBBBBBBBBBBBBBBBB
+
+# Live Restricted Key
+rk_live_CCCCCCCCCCCCCCCCCCCCCCCC
+
+# Test Restricted Key
+rk_test_DDDDDDDDDDDDDDDDDDDDDDDD

--- a/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ng.secret/output.json
+++ b/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ng.secret/output.json
@@ -1,0 +1,107 @@
+{
+    "filePath": "[SNAPSHOT]/ng.secret/input.txt",
+    "messages": [
+        {
+            "message": "found Stripe Live Secret Key: sk_live_AAAAAAAAAAAAAAAAAAAAAAAA",
+            "range": [
+                118,
+                150
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-stripe",
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 18
+                },
+                "end": {
+                    "line": 5,
+                    "column": 50
+                }
+            },
+            "severity": "error",
+            "messageId": "STRIPE_SECRET_KEY_LIVE",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-stripe/README.md#STRIPE_SECRET_KEY_LIVE",
+            "data": {
+                "KEY": "sk_live_AAAAAAAAAAAAAAAAAAAAAAAA"
+            }
+        },
+        {
+            "message": "found Stripe Test Secret Key: sk_test_BBBBBBBBBBBBBBBBBBBBBBBB",
+            "range": [
+                170,
+                202
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-stripe",
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 32
+                }
+            },
+            "severity": "error",
+            "messageId": "STRIPE_SECRET_KEY_TEST",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-stripe/README.md#STRIPE_SECRET_KEY_TEST",
+            "data": {
+                "KEY": "sk_test_BBBBBBBBBBBBBBBBBBBBBBBB"
+            }
+        },
+        {
+            "message": "found Stripe Live Restricted Key: rk_live_CCCCCCCCCCCCCCCCCCCCCCCC",
+            "range": [
+                226,
+                258
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-stripe",
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 0
+                },
+                "end": {
+                    "line": 11,
+                    "column": 32
+                }
+            },
+            "severity": "error",
+            "messageId": "STRIPE_RESTRICTED_KEY_LIVE",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-stripe/README.md#STRIPE_RESTRICTED_KEY_LIVE",
+            "data": {
+                "KEY": "rk_live_CCCCCCCCCCCCCCCCCCCCCCCC"
+            }
+        },
+        {
+            "message": "found Stripe Test Restricted Key: rk_test_DDDDDDDDDDDDDDDDDDDDDDDD",
+            "range": [
+                282,
+                314
+            ],
+            "type": "message",
+            "ruleId": "@secretlint/secretlint-rule-stripe",
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 0
+                },
+                "end": {
+                    "line": 14,
+                    "column": 32
+                }
+            },
+            "severity": "error",
+            "messageId": "STRIPE_RESTRICTED_KEY_TEST",
+            "docsUrl": "https://github.com/secretlint/secretlint/blob/master/packages/%40secretlint/secretlint-rule-stripe/README.md#STRIPE_RESTRICTED_KEY_TEST",
+            "data": {
+                "KEY": "rk_test_DDDDDDDDDDDDDDDDDDDDDDDD"
+            }
+        }
+    ],
+    "sourceContent": "# Stripe API keys that should be detected\n# Source: https://docs.stripe.com/keys\n\n# Live Secret Key\nSTRIPE_SECRET_KEY=sk_live_AAAAAAAAAAAAAAAAAAAAAAAA\n\n# Test Secret Key\nsk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Live Restricted Key\nrk_live_CCCCCCCCCCCCCCCCCCCCCCCC\n\n# Test Restricted Key\nrk_test_DDDDDDDDDDDDDDDDDDDDDDDD\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ok.valid/input.txt
@@ -4,11 +4,13 @@
 pk_live_AAAAAAAAAAAAAAAAAAAAAAAA
 pk_test_BBBBBBBBBBBBBBBBBBBBBBBB
 
-# Too short (fewer than 10 chars after prefix)
+# Too short (fewer than 24 chars after prefix)
 sk_live_short
 sk_test_abc
 rk_live_x
 rk_test_y
+sk_live_AAAAAAAAAAAAAAAAAAAAAAA
+sk_test_BBBBBBBBBBBBBBBBBBBBBBB
 
 # Wrong prefix / mid-word boundary
 xsk_live_AAAAAAAAAAAAAAAAAAAAAAAA

--- a/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ok.valid/input.txt
+++ b/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ok.valid/input.txt
@@ -1,0 +1,22 @@
+# These should NOT be detected as Stripe API keys
+
+# Publishable keys (pk_) are not secrets
+pk_live_AAAAAAAAAAAAAAAAAAAAAAAA
+pk_test_BBBBBBBBBBBBBBBBBBBBBBBB
+
+# Too short (fewer than 10 chars after prefix)
+sk_live_short
+sk_test_abc
+rk_live_x
+rk_test_y
+
+# Wrong prefix / mid-word boundary
+xsk_live_AAAAAAAAAAAAAAAAAAAAAAAA
+foosk_test_BBBBBBBBBBBBBBBBBBBBBBBB
+
+# Different product names that share the prefix
+SKILLS_inventory
+RKLIST_value
+
+# Stripe documentation URL (not a key)
+https://docs.stripe.com/keys

--- a/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ok.valid/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.valid/input.txt",
+    "messages": [],
+    "sourceContent": "# These should NOT be detected as Stripe API keys\n\n# Publishable keys (pk_) are not secrets\npk_live_AAAAAAAAAAAAAAAAAAAAAAAA\npk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Too short (fewer than 10 chars after prefix)\nsk_live_short\nsk_test_abc\nrk_live_x\nrk_test_y\n\n# Wrong prefix / mid-word boundary\nxsk_live_AAAAAAAAAAAAAAAAAAAAAAAA\nfoosk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Different product names that share the prefix\nSKILLS_inventory\nRKLIST_value\n\n# Stripe documentation URL (not a key)\nhttps://docs.stripe.com/keys\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ok.valid/output.json
+++ b/packages/@secretlint/secretlint-rule-stripe/test/snapshots/ok.valid/output.json
@@ -1,6 +1,6 @@
 {
     "filePath": "[SNAPSHOT]/ok.valid/input.txt",
     "messages": [],
-    "sourceContent": "# These should NOT be detected as Stripe API keys\n\n# Publishable keys (pk_) are not secrets\npk_live_AAAAAAAAAAAAAAAAAAAAAAAA\npk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Too short (fewer than 10 chars after prefix)\nsk_live_short\nsk_test_abc\nrk_live_x\nrk_test_y\n\n# Wrong prefix / mid-word boundary\nxsk_live_AAAAAAAAAAAAAAAAAAAAAAAA\nfoosk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Different product names that share the prefix\nSKILLS_inventory\nRKLIST_value\n\n# Stripe documentation URL (not a key)\nhttps://docs.stripe.com/keys\n",
+    "sourceContent": "# These should NOT be detected as Stripe API keys\n\n# Publishable keys (pk_) are not secrets\npk_live_AAAAAAAAAAAAAAAAAAAAAAAA\npk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Too short (fewer than 24 chars after prefix)\nsk_live_short\nsk_test_abc\nrk_live_x\nrk_test_y\nsk_live_AAAAAAAAAAAAAAAAAAAAAAA\nsk_test_BBBBBBBBBBBBBBBBBBBBBBB\n\n# Wrong prefix / mid-word boundary\nxsk_live_AAAAAAAAAAAAAAAAAAAAAAAA\nfoosk_test_BBBBBBBBBBBBBBBBBBBBBBBB\n\n# Different product names that share the prefix\nSKILLS_inventory\nRKLIST_value\n\n# Stripe documentation URL (not a key)\nhttps://docs.stripe.com/keys\n",
     "sourceContentType": "text"
 }

--- a/packages/@secretlint/secretlint-rule-stripe/tsconfig.json
+++ b/packages/@secretlint/secretlint-rule-stripe/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./module/",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1293,6 +1293,9 @@ importers:
       '@secretlint/secretlint-rule-slack':
         specifier: workspace:*
         version: link:../secretlint-rule-slack
+      '@secretlint/secretlint-rule-stripe':
+        specifier: workspace:*
+        version: link:../secretlint-rule-stripe
       '@secretlint/secretlint-rule-tailscale':
         specifier: workspace:*
         version: link:../secretlint-rule-tailscale
@@ -1551,6 +1554,31 @@ importers:
         version: 6.0.3
 
   packages/@secretlint/secretlint-rule-slack:
+    dependencies:
+      '@secretlint/types':
+        specifier: workspace:*
+        version: link:../types
+      '@textlint/regexp-string-matcher':
+        specifier: 'catalog:'
+        version: 2.0.2
+    devDependencies:
+      '@secretlint/tester':
+        specifier: workspace:*
+        version: link:../tester
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.0
+      prettier:
+        specifier: 'catalog:'
+        version: 3.8.3
+      tsx:
+        specifier: 'catalog:'
+        version: 4.21.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
+  packages/@secretlint/secretlint-rule-stripe:
     dependencies:
       '@secretlint/types':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Adds a new rule package `@secretlint/secretlint-rule-stripe` for detecting Stripe API keys, and registers it in the canary preset.

Detected key types (from https://docs.stripe.com/keys):

| Key Type | Prefix | Format |
|---|---|---|
| Live Secret Key | `sk_live_` | `sk_live_` + 10–99 alphanumeric chars |
| Test Secret Key | `sk_test_` | `sk_test_` + 10–99 alphanumeric chars |
| Live Restricted Key | `rk_live_` | `rk_live_` + 10–99 alphanumeric chars |
| Test Restricted Key | `rk_test_` | `rk_test_` + 10–99 alphanumeric chars |

Pattern aligns with GitHub Push Protection and gitleaks. Publishable keys (`pk_live_` / `pk_test_`) are intentionally excluded since they are not secrets.

Message IDs: `STRIPE_SECRET_KEY_LIVE`, `STRIPE_SECRET_KEY_TEST`, `STRIPE_RESTRICTED_KEY_LIVE`, `STRIPE_RESTRICTED_KEY_TEST`.

The rule supports the standard `allows` option using `@textlint/regexp-string-matcher`.

Per `AGENTS.md`, only the canary preset is updated; syncing to the recommend preset is a separate task done at major release time.

Closes #1531

## Test plan

- [x] `pnpm run build` succeeds for the new package
- [x] `pnpm test` for `@secretlint/secretlint-rule-stripe` passes (ng + ok snapshots)
- [x] `pnpm run -r --filter "@secretlint/secretlint-rule-preset-canary" import-test` regenerates canary snapshots including the new rule
- [x] `pnpm test` for the canary preset passes (116 tests)
- [x] Full `pnpm test` succeeds across all 109 tasks

fix #1531 

---
_Generated by [Claude Code](https://claude.ai/code/session_016xG2GUMA7qErAm2ZGvNwGs)_