### PR TITLE
ci(release): prevent cache poisoning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,10 @@ jobs:
         run: pnpm run build
       # build the binary
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0 # zizmor: ignore[cache-poisoning]
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: "./publish/binary-compiler/.bun-version"
+          no-cache: true
       - name: Build binary
         run: bun run build-binary
         working-directory: ./publish/binary-compiler
@@ -127,9 +128,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Set TAG_NAME
+        env:
+          VERSION: ${{ needs.publish.outputs.version }}
         run: |
-          echo "TAG_NAME=v${{ needs.publish.outputs.version }}" >> $GITHUB_ENV
-          echo "SECRETLINT_VERSION=${{ needs.publish.outputs.version }}" >> $GITHUB_ENV
+          echo "TAG_NAME=v${VERSION}" >> $GITHUB_ENV
+          echo "SECRETLINT_VERSION=${VERSION}" >> $GITHUB_ENV
       - name: Set HUB_TAG
         run: |
           echo "PKG_TAG=${DOCKER_BASE_NAME}:${TAG_NAME}" >> $GITHUB_ENV
@@ -199,10 +202,12 @@ jobs:
           prerelease: false
           files: ./binary-dist/**
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          VERSION: ${{ needs.publish.outputs.version }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const version = '${{ needs.publish.outputs.version }}';
+            const version = process.env.VERSION;
             const repository = process.env.GITHUB_REPOSITORY;
             github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
## Summary

Address zizmor security findings in `.github/workflows/release.yml` by avoiding direct template expansion of job outputs in `run` scripts and by disabling Bun setup cache to mitigate the cache-poisoning warning without suppressing it.

Context: TanStack is affected by cache poisoning
[Postmortem: TanStack npm supply-chain compromise | TanStack Blog](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem)

## Changes

- Pass `needs.publish.outputs.version` via the `env:` block (`VERSION`) and reference `${VERSION}` inside the `Set TAG_NAME` shell step instead of inlining `${{ ... }}` in `run:`.
- Apply the same `env`-based pattern to the `actions/github-script` step that comments the release, reading `process.env.VERSION` instead of inlining the expression in the script.
- Remove the `# zizmor: ignore[cache-poisoning]` comment on `oven-sh/setup-bun` and instead disable caching with `no-cache: true` so the underlying concern is resolved.

## Breaking Changes

None.

## Test Plan

- [ ] Confirm the release workflow YAML parses (GitHub Actions lint passes on push).
- [ ] Re-run `zizmor` (or rely on the workflow's zizmor job) to verify the previously flagged findings are resolved.
- [ ] On the next release, verify `TAG_NAME`, `SECRETLINT_VERSION`, and the GitHub release comment still reflect the published version.
