### PR TITLE
Fix secp256k1 private key detection to avoid false positives

### DIFF
--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/src/index.ts
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/src/index.ts
@@ -33,7 +33,10 @@ export const creator: SecretLintRuleCreator<Options> = {
         const t = context.createTranslator(messages);
         return {
             file(source: SecretLintSourceCode) {
-                const pattern = /[0-9a-f]{64}/gi;
+                // Require non-hex boundaries so substrings inside longer hex strings
+                // (e.g. DOTENV_PUBLIC_KEY which is 66 hex chars, or sha512 hashes which are 128 hex chars)
+                // are not falsely matched as 64-hex-char private keys.
+                const pattern = /(?<![0-9a-f])[0-9a-f]{64}(?![0-9a-f])/gi;
                 const matches = source.content.matchAll(pattern);
                 for (const match of matches) {
                     const index = match.index || 0;
@@ -41,7 +44,7 @@ export const creator: SecretLintRuleCreator<Options> = {
                     const range = [index, index + matchString.length] as const;
                     try {
                         if (!secp256k1.privateKeyVerify(new BN(matchString, 16).toBuffer())) {
-                            return;
+                            continue;
                         }
                         context.report({
                             message: t("secp256k1Priv", {

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/snapshots/ok.dotenvx_public_key/input.txt
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/snapshots/ok.dotenvx_public_key/input.txt
@@ -1,0 +1,8 @@
+#/-------------------[DOTENV_PUBLIC_KEY]--------------------/
+#/            public-key encryption for .env files          /
+#/       [how it works](https://dotenvx.com/encryption)     /
+#/----------------------------------------------------------/
+DOTENV_PUBLIC_KEY="037cfbfc90234cfdab7eb54050566293789efaa1a35dc420749662db400dc9c4b2"
+
+# .env
+HELLO="encrypted:BLAH"

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/snapshots/ok.dotenvx_public_key/output.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/snapshots/ok.dotenvx_public_key/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.dotenvx_public_key/input.txt",
+    "messages": [],
+    "sourceContent": "#/-------------------[DOTENV_PUBLIC_KEY]--------------------/\n#/            public-key encryption for .env files          /\n#/       [how it works](https://dotenvx.com/encryption)     /\n#/----------------------------------------------------------/\nDOTENV_PUBLIC_KEY=\"037cfbfc90234cfdab7eb54050566293789efaa1a35dc420749662db400dc9c4b2\"\n\n# .env\nHELLO=\"encrypted:BLAH\"\n",
+    "sourceContentType": "text"
+}

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/snapshots/ok.packagemanager_sha512/input.txt
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/snapshots/ok.packagemanager_sha512/input.txt
@@ -1,0 +1,4 @@
+{
+    "name": "example",
+    "packageManager": "pnpm@10.4.1+sha512.0a31fc7ee2cca8f25aacafb0fae1c5d27e8c4d3ecbf3eea76e9c4be73f6d4f3b27c00fc99e83c8cae0a6e7e4ce6c2a8b9e5b7d6e5d62e35f50e3a85a8b3d4d4"
+}

--- a/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/snapshots/ok.packagemanager_sha512/output.json
+++ b/packages/@secretlint/secretlint-rule-secp256k1-privatekey/test/snapshots/ok.packagemanager_sha512/output.json
@@ -1,0 +1,6 @@
+{
+    "filePath": "[SNAPSHOT]/ok.packagemanager_sha512/input.txt",
+    "messages": [],
+    "sourceContent": "{\n    \"name\": \"example\",\n    \"packageManager\": \"pnpm@10.4.1+sha512.0a31fc7ee2cca8f25aacafb0fae1c5d27e8c4d3ecbf3eea76e9c4be73f6d4f3b27c00fc99e83c8cae0a6e7e4ce6c2a8b9e5b7d6e5d62e35f50e3a85a8b3d4d4\"\n}\n",
+    "sourceContentType": "text"
+}


### PR DESCRIPTION
## Summary

Fix false positives in `@secretlint/secretlint-rule-secp256k1-privatekey` where 64-char hex substrings inside longer hex sequences (such as `DOTENV_PUBLIC_KEY`, which is 66 hex chars, and pnpm `packageManager` sha512 hashes, which are 128 hex chars) were incorrectly reported as secp256k1 private keys.

## Changes

- Add non-hex boundary assertions to the regex so substrings inside longer hex strings are no longer matched:
  - `/[0-9a-f]{64}/gi` → `/(?<![0-9a-f])[0-9a-f]{64}(?![0-9a-f])/gi`
- Replace `return` with `continue` in the private-key verification loop so a single non-private-key candidate no longer aborts scanning the rest of the file.
- Add snapshot tests reproducing both reported false-positive scenarios (`ok.dotenvx_public_key`, `ok.packagemanager_sha512`).

## Breaking Changes

None. Existing detections remain valid (verified by the existing `ng.privkey` snapshot, which is preserved).

## Test Plan

- `pnpm test` in `packages/@secretlint/secretlint-rule-secp256k1-privatekey/` — all 5 snapshots pass.
- New `ok.dotenvx_public_key` snapshot confirms `DOTENV_PUBLIC_KEY="037cfbfc…c9c4b2"` (66 hex chars, a secp256k1 compressed public key per dotenvx encryption) is no longer flagged.
- New `ok.packagemanager_sha512` snapshot confirms a pnpm `packageManager` field with an embedded 128-char sha512 hash is no longer flagged.
- Existing `ng.privkey` snapshot continues to detect the leaked private key.

Fixes #1560