### PR TITLE
fix(resolver): resolve rules and presets from the linted project

### DIFF
--- a/packages/@secretlint/config-loader/src/SecretLintModuleResolver.ts
+++ b/packages/@secretlint/config-loader/src/SecretLintModuleResolver.ts
@@ -7,17 +7,6 @@ const debug = debug0("@secretlint/config-loader");
 import { tryResolve } from "@secretlint/resolver";
 
 /**
- * Try to resolve module or file path.
- * @param modulePath
- */
-const tryResolveModulePath = (modulePath: string): string | undefined => {
-    return tryResolve(modulePath, {
-        parentImportMeta: import.meta,
-        parentModule: "config-loader",
-    });
-};
-
-/**
  * This class aim to resolve secretlint's package name and get the module path.
  *
  * Define
@@ -34,12 +23,30 @@ const tryResolveModulePath = (modulePath: string): string | undefined => {
  */
 export class SecretLintModuleResolver {
     private baseDirectory: string;
+    private baseDirectories: string[];
 
-    constructor(config: { baseDirectory?: string }) {
+    constructor(config: { baseDirectory?: string; cwd?: string }) {
         /**
          * @type {string} baseDirectory for resolving
          */
         this.baseDirectory = config && config.baseDirectory ? config.baseDirectory : "";
+        /**
+         * Rules and presets are dependencies of the linted project, so resolve them from the
+         * project instead of from the location that secretlint itself is installed in.
+         */
+        this.baseDirectories = [config?.cwd ?? process.cwd()];
+    }
+
+    /**
+     * Try to resolve module or file path.
+     * @param modulePath
+     */
+    private tryResolveModulePath(modulePath: string): string | undefined {
+        return tryResolve(modulePath, {
+            parentImportMeta: import.meta,
+            parentModule: "config-loader",
+            baseDirectories: this.baseDirectories,
+        });
     }
 
     /**
@@ -52,8 +59,8 @@ export class SecretLintModuleResolver {
         const fullPackageName = createFullPackageName("secretlint-rule-", packageName);
         // <rule-name> or secretlint-rule-<rule-name>
         const pkgPath =
-            tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
-            tryResolveModulePath(path.join(baseDir, packageName));
+            this.tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
+            this.tryResolveModulePath(path.join(baseDir, packageName));
         if (!pkgPath) {
             debug(`rule fullPackageName: ${fullPackageName}`);
             throw new ReferenceError(`Failed to load secretlint's rule module: "${packageName}" is not found.
@@ -75,8 +82,8 @@ baseDir: ${baseDir}
         const fullPackageName = createFullPackageName("secretlint-filter-rule-", packageName);
         // <rule-name> or secretlint-filter-rule-<rule-name> or @scope/<rule-name>
         const pkgPath =
-            tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
-            tryResolveModulePath(path.join(baseDir, packageName));
+            this.tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
+            this.tryResolveModulePath(path.join(baseDir, packageName));
         if (!pkgPath) {
             debug(`filter rule fullPackageName: ${fullPackageName}`);
             throw new ReferenceError(`Failed to load secretlint's filter rule module: "${packageName}" is not found.
@@ -98,8 +105,8 @@ baseDir: ${baseDir}
         const fullPackageName = createFullPackageName("secretlint-plugin-", packageName);
         // <plugin-name> or secretlint-plugin-<rule-name>
         const pkgPath =
-            tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
-            tryResolveModulePath(path.join(baseDir, packageName));
+            this.tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
+            this.tryResolveModulePath(path.join(baseDir, packageName));
         if (!pkgPath) {
             debug(`plugin fullPackageName: ${fullPackageName}`);
             throw new ReferenceError(`Failed to load secretlint's plugin module: "${packageName}" is not found.
@@ -143,13 +150,13 @@ baseDir: ${baseDir}
         const fullFullPackageName = `${PREFIX}${packageNameWithoutPreset}`;
         const pkgPath =
             // secretlint-rule-preset-<preset-name> or @scope/secretlint-rule-preset-<preset-name>
-            tryResolveModulePath(path.join(baseDir, fullFullPackageName)) ||
+            this.tryResolveModulePath(path.join(baseDir, fullFullPackageName)) ||
             // <preset-name>
-            tryResolveModulePath(path.join(baseDir, packageNameWithoutPreset)) ||
+            this.tryResolveModulePath(path.join(baseDir, packageNameWithoutPreset)) ||
             // <rule-name>
-            tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
+            this.tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
             // <package-name>
-            tryResolveModulePath(path.join(baseDir, packageName));
+            this.tryResolveModulePath(path.join(baseDir, packageName));
         if (!pkgPath) {
             debug(`preset fullPackageName: ${fullPackageName}`);
             debug(`preset fullFullPackageName: ${fullFullPackageName}`);
@@ -172,8 +179,8 @@ baseDir: ${baseDir}
         const fullPackageName = createFullPackageName("secretlint-config-", packageName);
         // <plugin-name> or secretlint-config-<rule-name>
         const pkgPath =
-            tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
-            tryResolveModulePath(path.join(baseDir, packageName));
+            this.tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
+            this.tryResolveModulePath(path.join(baseDir, packageName));
         if (!pkgPath) {
             throw new ReferenceError(`Failed to load secretlint's config module: "${packageName}" is not found.
 

--- a/packages/@secretlint/config-loader/src/index.ts
+++ b/packages/@secretlint/config-loader/src/index.ts
@@ -70,6 +70,12 @@ export type SecretLintLoadPackagesFromRawConfigOptions = {
      */
     configDescriptor: SecretLintConfigDescriptor;
     /**
+     * Working directory of the linted project.
+     * Rules and presets are resolved from this directory.
+     * Default: process.cwd()
+     */
+    cwd?: string;
+    /**
      * node_modules directory path
      * Default: undefined
      */
@@ -107,6 +113,7 @@ export const loadPackagesFromConfigDescriptor = async (
     // Search secretlint's module
     const moduleResolver = new SecretLintModuleResolver({
         baseDirectory: options.node_moduleDir,
+        cwd: options.cwd,
     });
     // TODO: remove any
     const isSecretLintCoreConfigRulePreset = (v: SecretLintUnionRuleCreator): v is SecretLintRulePresetCreator => {
@@ -223,6 +230,7 @@ export const loadConfig = async (options: SecretLintConfigLoaderOptions): Promis
     });
     const configLoadResult = await loadPackagesFromConfigDescriptor({
         configDescriptor,
+        cwd: options.cwd,
         node_moduleDir: options.node_moduleDir,
         testReplaceDefinitions: options.testReplaceDefinitions,
     });

--- a/packages/@secretlint/config-loader/test/SecretLintModuleResolver.test.ts
+++ b/packages/@secretlint/config-loader/test/SecretLintModuleResolver.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { SecretLintModuleResolver } from "../src/SecretLintModuleResolver.js";
+
+/**
+ * These packages exist *only* in the temporary project created below.
+ * They must not be names that are resolvable from this repository, otherwise the
+ * workspace's own node_modules would satisfy the resolution and hide the bug.
+ */
+const RULE_NAME = "secretlint-rule-fixture-not-installed-in-this-repo";
+const PRESET_NAME = "secretlint-rule-preset-fixture-not-installed-in-this-repo";
+
+/**
+ * Rules and presets are dependencies of the linted project, so they have to be resolved
+ * from the project - not from the location that secretlint itself is installed in.
+ * Those are the same directory only when the package manager happens to install secretlint
+ * inside the project. pnpm's `enableGlobalVirtualStore: true` stores packages outside of
+ * the project, and then resolving from secretlint's own location cannot see the project's
+ * rules at all.
+ *
+ * Here the project lives in a temp dir while secretlint is loaded from this repo, which
+ * reproduces that layout.
+ */
+describe("SecretLintModuleResolver", () => {
+    let projectDir: string;
+    const installPackage = (packageName: string) => {
+        const packageDir = path.join(projectDir, "node_modules", packageName);
+        fs.mkdirSync(packageDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(packageDir, "package.json"),
+            JSON.stringify({ name: packageName, version: "1.0.0", main: "index.js" }),
+        );
+        fs.writeFileSync(path.join(packageDir, "index.js"), "module.exports = {};");
+        return path.join(packageDir, "index.js");
+    };
+    beforeEach(() => {
+        projectDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-config-loader-")));
+    });
+    afterEach(() => {
+        fs.rmSync(projectDir, { recursive: true, force: true });
+    });
+
+    it("should resolve a rule that is installed in `cwd`", () => {
+        const expected = installPackage(RULE_NAME);
+        const moduleResolver = new SecretLintModuleResolver({ cwd: projectDir });
+        assert.strictEqual(moduleResolver.resolveRulePackageName(RULE_NAME), expected);
+    });
+
+    it("should resolve a preset that is installed in `cwd`", () => {
+        const expected = installPackage(PRESET_NAME);
+        const moduleResolver = new SecretLintModuleResolver({ cwd: projectDir });
+        assert.strictEqual(
+            moduleResolver.resolvePresetPackageName("preset-fixture-not-installed-in-this-repo"),
+            expected,
+        );
+    });
+
+    it("should throw an error when the rule is not installed in `cwd`", () => {
+        const moduleResolver = new SecretLintModuleResolver({ cwd: projectDir });
+        assert.throws(() => moduleResolver.resolveRulePackageName(RULE_NAME), ReferenceError);
+    });
+});

--- a/packages/@secretlint/node/src/index.ts
+++ b/packages/@secretlint/node/src/index.ts
@@ -190,6 +190,7 @@ export const createEngine = async (options: SecretLintEngineOptions) => {
             debug("Load ConfigFileJSON: %s", options.configFileJSON);
             return loadPackagesFromConfigDescriptor({
                 configDescriptor: options.configFileJSON,
+                cwd: options.cwd,
             });
         }
         const loadConfigResult = await loadConfig({

--- a/packages/@secretlint/resolver/src/index.ts
+++ b/packages/@secretlint/resolver/src/index.ts
@@ -7,6 +7,14 @@ const require = createRequire(import.meta.url);
 export type ResolverContext = {
     parentImportMeta: ImportMeta;
     parentModule: "config-loader" | "formatter";
+    /**
+     * Directories to resolve `packageName` from.
+     * Secretlint's rules, presets and formatters are dependencies of the user's project,
+     * so they have to be resolved from the project instead of from the location that
+     * `@secretlint/resolver` itself is installed in.
+     * Default: `[process.cwd()]`
+     */
+    baseDirectories?: string[];
 };
 type ResolverSkipResult = undefined;
 /**
@@ -65,6 +73,21 @@ export const tryResolve = (packageName: string, context: ResolverContext): strin
             }
         }
 
+        // Resolve from the user's project first.
+        // Node.js looks up `node_modules` by walking up from the importer, so `require` -
+        // which is created from this module's own url - only finds the project's packages
+        // when this module happens to be installed inside the project. That is not the case
+        // when the package manager stores packages outside of the project, as pnpm does with
+        // `enableGlobalVirtualStore: true`.
+        // https://github.com/secretlint/secretlint/issues/1624
+        const baseDirectories = context.baseDirectories ?? [process.cwd()];
+        if (baseDirectories.length > 0) {
+            try {
+                return require.resolve(packageName, { paths: baseDirectories });
+            } catch {
+                // Fallback to resolving from this module's own location
+            }
+        }
         // TODO: import.meta.resolve is not supported in Node.js 18
         // We will change to import.meta.resolve(packageName)
         return require.resolve(packageName);

--- a/packages/@secretlint/resolver/test/base-directories.test.ts
+++ b/packages/@secretlint/resolver/test/base-directories.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { clearHooks, tryResolve } from "../src/index.js";
+
+/**
+ * Rule package that exists *only* in the temporary project created below.
+ * It must not be a name that is resolvable from this repository, otherwise the
+ * workspace's own node_modules would satisfy the resolution and hide the bug.
+ */
+const RULE_NAME = "secretlint-rule-fixture-not-installed-in-this-repo";
+
+/**
+ * Emulates pnpm's `enableGlobalVirtualStore: true` layout.
+ *
+ * Node resolves bare specifiers by walking `node_modules` upwards from the importer.
+ * With a global virtual store the packages live outside the project, so walking up
+ * from @secretlint/resolver's own location never reaches the project's node_modules.
+ * Here the resolver is imported from this repo while the "project" lives in a temp
+ * dir: two disjoint trees, which is exactly the shape that breaks under a global
+ * virtual store. Without a global virtual store the store is nested inside the
+ * project, so the upwards walk happens to reach the project - that is why this only
+ * reproduces with the flag enabled.
+ */
+describe("tryResolve baseDirectories", () => {
+    let projectDir: string;
+    beforeEach(() => {
+        projectDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-virtual-store-")));
+        const ruleDir = path.join(projectDir, "node_modules", RULE_NAME);
+        fs.mkdirSync(ruleDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(ruleDir, "package.json"),
+            JSON.stringify({ name: RULE_NAME, version: "1.0.0", main: "index.js" }),
+        );
+        fs.writeFileSync(path.join(ruleDir, "index.js"), "module.exports = {};");
+    });
+    afterEach(() => {
+        clearHooks();
+        fs.rmSync(projectDir, { recursive: true, force: true });
+    });
+
+    it("should resolve a package that is only installed in the baseDirectories", () => {
+        const result = tryResolve(RULE_NAME, {
+            parentImportMeta: import.meta,
+            parentModule: "config-loader",
+            baseDirectories: [projectDir],
+        });
+        assert.strictEqual(result, path.join(projectDir, "node_modules", RULE_NAME, "index.js"));
+    });
+
+    it("should not resolve a package that is installed outside of the baseDirectories", () => {
+        const result = tryResolve(RULE_NAME, {
+            parentImportMeta: import.meta,
+            parentModule: "config-loader",
+            baseDirectories: [os.tmpdir()],
+        });
+        assert.ok(!result);
+    });
+});


### PR DESCRIPTION
Fixes #1624

## Problem

Secretlint cannot find rules/presets that are installed in the project when the package manager stores packages **outside** of the project directory — e.g. pnpm's [`enableGlobalVirtualStore: true`](https://pnpm.io/settings#enableglobalvirtualstore) (pnpm 11):

```
Failed to load secretlint's rule module: "@secretlint/secretlint-rule-preset-recommend" is not found.
```

…even though the preset is a direct `devDependency`, symlinked at `<repo>/node_modules/@secretlint/secretlint-rule-preset-recommend`.

## Root cause

`tryResolve()` resolves rule/preset ids with a `require` created from **`@secretlint/resolver`'s own module url**:

```js
const require = createRequire(import.meta.url);
return require.resolve(packageName);
```

Node resolves bare specifiers by walking `node_modules` **upwards from the importer**, so this only finds the project's rules when `@secretlint/resolver` itself lives inside the project's directory tree.

A normal pnpm install satisfies that **by accident**: the virtual store is nested at `<project>/node_modules/.pnpm/…`, so walking up from the resolver eventually reaches `<project>/node_modules`. With a *global* virtual store the packages live outside the project, the upwards walk never reaches it, and every rule fails to load.

So the resolution anchor is simply wrong — rules, presets and formatters are dependencies of the **user's project**, not of secretlint. pnpm's global virtual store only exposes it. (`baseDirectory` doesn't help: it defaults to `""`, and `cwd` — which the config-loader already knows and uses to locate `.secretlintrc` — was never passed down to `SecretLintModuleResolver`.)

Worth noting: [`@pnpm/plugin-esm-node-path`](https://github.com/pnpm/plugin-esm-node-path), the documented remedy for pnpm's ESM/`NODE_PATH` caveat, does **not** fix this — it registers an *ESM loader hook*, while secretlint resolves through *CJS* `createRequire().resolve`, which the hook never intercepts. See #1624 for the other workarounds that were ruled out.

## Fix

Resolve from the linted project first, keeping the existing resolver-relative resolution as a fallback:

- `@secretlint/resolver`: `ResolverContext` gains an optional `baseDirectories`, and `tryResolve()` tries `require.resolve(name, { paths: baseDirectories })` first, defaulting to `[process.cwd()]`.
- `@secretlint/config-loader`: `SecretLintModuleResolver` takes a `cwd` and resolves from it; `loadPackagesFromConfigDescriptor()` gains a `cwd` option and `loadConfig()` passes its existing `cwd` through.
- `@secretlint/node`: passes `cwd` through for the `configFileJSON` path.

This only **adds** a lookup location, so existing setups keep resolving exactly as before. The default of `process.cwd()` also fixes `@secretlint/formatter`, which resolves `secretlint-formatter-*` with the same anchor, without extra plumbing.

## Tests

Two regression tests that emulate the layout by putting the "project" in a temp dir while secretlint is loaded from the repo — two disjoint trees, which is exactly the shape a global virtual store produces. They use package names that are *not* resolvable from this repo, so the workspace's own `node_modules` can't mask the bug.

- `@secretlint/resolver` — `tryResolve()` finds a package installed only in `baseDirectories`.
- `@secretlint/config-loader` — `SecretLintModuleResolver` resolves a rule and a preset installed only in `cwd`.

Both fail on `master` and pass with this change.

## Verification

- `pnpm run build` — 54/54 tasks
- `pnpm run test` — 109/109 tasks, no regressions
- End-to-end with the real CLI: a project whose rule is installed **only** in its own `node_modules`, linted with `cwd` set to that project while secretlint is loaded from elsewhere. On `master` this fails with `Failed to load rule module: …`; with this change the rule loads and reports as expected.

I don't have pnpm 11 with a real global virtual store in this environment, so the failing tests reproduce the *mechanism* (disjoint resolver/project trees) rather than driving pnpm itself. Happy to adjust if you'd prefer a different anchor (e.g. the `.secretlintrc` directory rather than `cwd`).
