### PR TITLE
Fix module resolution with pnpm global virtual store

### DIFF
--- a/packages/@secretlint/config-loader/src/SecretLintModuleResolver.ts
+++ b/packages/@secretlint/config-loader/src/SecretLintModuleResolver.ts
@@ -10,10 +10,11 @@ import { tryResolve } from "@secretlint/resolver";
  * Try to resolve module or file path.
  * @param modulePath
  */
-const tryResolveModulePath = (modulePath: string): string | undefined => {
+const tryResolveModulePath = (modulePath: string, moduleResolutionBase: string | URL): string | undefined => {
     return tryResolve(modulePath, {
         parentImportMeta: import.meta,
         parentModule: "config-loader",
+        moduleResolutionBase,
     });
 };
 
@@ -33,13 +34,15 @@ const tryResolveModulePath = (modulePath: string): string | undefined => {
  * - secretlint-config-*
  */
 export class SecretLintModuleResolver {
-    private baseDirectory: string;
+    private nodeModulesDirectory: string;
+    private moduleResolutionBase: string | URL;
 
-    constructor(config: { baseDirectory?: string }) {
+    constructor(config: { nodeModulesDirectory?: string; moduleResolutionBase: string | URL }) {
         /**
-         * @type {string} baseDirectory for resolving
+         * @type {string} node_modules directory for resolving
          */
-        this.baseDirectory = config && config.baseDirectory ? config.baseDirectory : "";
+        this.nodeModulesDirectory = config.nodeModulesDirectory ?? "";
+        this.moduleResolutionBase = config.moduleResolutionBase;
     }
 
     /**
@@ -48,18 +51,18 @@ export class SecretLintModuleResolver {
      * @returns {string} return path to module
      */
     resolveRulePackageName(packageName: string): string {
-        const baseDir = this.baseDirectory;
+        const nodeModulesDir = this.nodeModulesDirectory;
         const fullPackageName = createFullPackageName("secretlint-rule-", packageName);
         // <rule-name> or secretlint-rule-<rule-name>
         const pkgPath =
-            tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
-            tryResolveModulePath(path.join(baseDir, packageName));
+            tryResolveModulePath(path.join(nodeModulesDir, fullPackageName), this.moduleResolutionBase) ||
+            tryResolveModulePath(path.join(nodeModulesDir, packageName), this.moduleResolutionBase);
         if (!pkgPath) {
             debug(`rule fullPackageName: ${fullPackageName}`);
             throw new ReferenceError(`Failed to load secretlint's rule module: "${packageName}" is not found.
 
 cwd: ${process.cwd()}
-baseDir: ${baseDir}
+nodeModulesDir: ${nodeModulesDir}
 `);
         }
         return pkgPath;
@@ -71,18 +74,18 @@ baseDir: ${baseDir}
      * @returns {string} return path to module
      */
     resolveFilterRulePackageName(packageName: string): string {
-        const baseDir = this.baseDirectory;
+        const nodeModulesDir = this.nodeModulesDirectory;
         const fullPackageName = createFullPackageName("secretlint-filter-rule-", packageName);
         // <rule-name> or secretlint-filter-rule-<rule-name> or @scope/<rule-name>
         const pkgPath =
-            tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
-            tryResolveModulePath(path.join(baseDir, packageName));
+            tryResolveModulePath(path.join(nodeModulesDir, fullPackageName), this.moduleResolutionBase) ||
+            tryResolveModulePath(path.join(nodeModulesDir, packageName), this.moduleResolutionBase);
         if (!pkgPath) {
             debug(`filter rule fullPackageName: ${fullPackageName}`);
             throw new ReferenceError(`Failed to load secretlint's filter rule module: "${packageName}" is not found.
 
 cwd: ${process.cwd()}
-baseDir: ${baseDir}
+nodeModulesDir: ${nodeModulesDir}
 `);
         }
         return pkgPath;
@@ -94,18 +97,18 @@ baseDir: ${baseDir}
      * @returns {string} return path to module
      */
     resolvePluginPackageName(packageName: string): string {
-        const baseDir = this.baseDirectory;
+        const nodeModulesDir = this.nodeModulesDirectory;
         const fullPackageName = createFullPackageName("secretlint-plugin-", packageName);
         // <plugin-name> or secretlint-plugin-<rule-name>
         const pkgPath =
-            tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
-            tryResolveModulePath(path.join(baseDir, packageName));
+            tryResolveModulePath(path.join(nodeModulesDir, fullPackageName), this.moduleResolutionBase) ||
+            tryResolveModulePath(path.join(nodeModulesDir, packageName), this.moduleResolutionBase);
         if (!pkgPath) {
             debug(`plugin fullPackageName: ${fullPackageName}`);
             throw new ReferenceError(`Failed to load secretlint's plugin module: "${packageName}" is not found.
 
 cwd: ${process.cwd()}
-baseDir: ${baseDir}
+nodeModulesDir: ${nodeModulesDir}
 
 `);
         }
@@ -119,7 +122,7 @@ baseDir: ${baseDir}
      * @returns {string} return path to module
      */
     resolvePresetPackageName(packageName: string): string {
-        const baseDir = this.baseDirectory;
+        const nodeModulesDir = this.nodeModulesDirectory;
         const PREFIX = "secretlint-rule-preset-";
         /* Implementation Note
 
@@ -143,20 +146,20 @@ baseDir: ${baseDir}
         const fullFullPackageName = `${PREFIX}${packageNameWithoutPreset}`;
         const pkgPath =
             // secretlint-rule-preset-<preset-name> or @scope/secretlint-rule-preset-<preset-name>
-            tryResolveModulePath(path.join(baseDir, fullFullPackageName)) ||
+            tryResolveModulePath(path.join(nodeModulesDir, fullFullPackageName), this.moduleResolutionBase) ||
             // <preset-name>
-            tryResolveModulePath(path.join(baseDir, packageNameWithoutPreset)) ||
+            tryResolveModulePath(path.join(nodeModulesDir, packageNameWithoutPreset), this.moduleResolutionBase) ||
             // <rule-name>
-            tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
+            tryResolveModulePath(path.join(nodeModulesDir, fullPackageName), this.moduleResolutionBase) ||
             // <package-name>
-            tryResolveModulePath(path.join(baseDir, packageName));
+            tryResolveModulePath(path.join(nodeModulesDir, packageName), this.moduleResolutionBase);
         if (!pkgPath) {
             debug(`preset fullPackageName: ${fullPackageName}`);
             debug(`preset fullFullPackageName: ${fullFullPackageName}`);
             throw new ReferenceError(`Failed to load secretlint's preset module: "${packageName}" is not found.
 
 cwd: ${process.cwd()}
-baseDir: ${baseDir}
+nodeModulesDir: ${nodeModulesDir}
 `);
         }
         return pkgPath;
@@ -168,17 +171,17 @@ baseDir: ${baseDir}
      * @returns {string} return path to module
      */
     resolveConfigPackageName(packageName: string): string {
-        const baseDir = this.baseDirectory;
+        const nodeModulesDir = this.nodeModulesDirectory;
         const fullPackageName = createFullPackageName("secretlint-config-", packageName);
         // <plugin-name> or secretlint-config-<rule-name>
         const pkgPath =
-            tryResolveModulePath(path.join(baseDir, fullPackageName)) ||
-            tryResolveModulePath(path.join(baseDir, packageName));
+            tryResolveModulePath(path.join(nodeModulesDir, fullPackageName), this.moduleResolutionBase) ||
+            tryResolveModulePath(path.join(nodeModulesDir, packageName), this.moduleResolutionBase);
         if (!pkgPath) {
             throw new ReferenceError(`Failed to load secretlint's config module: "${packageName}" is not found.
 
 cwd: ${process.cwd()}
-baseDir: ${baseDir}
+nodeModulesDir: ${nodeModulesDir}
 `);
         }
         return pkgPath;

--- a/packages/@secretlint/config-loader/src/index.ts
+++ b/packages/@secretlint/config-loader/src/index.ts
@@ -29,6 +29,10 @@ export function importSecretlintCreator(
 export type SecretLintConfigLoaderOptions = {
     cwd?: string;
     configFilePath?: string;
+    /**
+     * Logical module entry used to resolve rules and presets.
+     */
+    moduleResolutionBase: string | URL;
     // For debugging
     /**
      * node_modules directory path
@@ -70,6 +74,10 @@ export type SecretLintLoadPackagesFromRawConfigOptions = {
      */
     configDescriptor: SecretLintConfigDescriptor;
     /**
+     * Logical module entry used to resolve rules and presets.
+     */
+    moduleResolutionBase: string | URL;
+    /**
      * node_modules directory path
      * Default: undefined
      */
@@ -106,7 +114,8 @@ export const loadPackagesFromConfigDescriptor = async (
     });
     // Search secretlint's module
     const moduleResolver = new SecretLintModuleResolver({
-        baseDirectory: options.node_moduleDir,
+        nodeModulesDirectory: options.node_moduleDir,
+        moduleResolutionBase: options.moduleResolutionBase,
     });
     // TODO: remove any
     const isSecretLintCoreConfigRulePreset = (v: SecretLintUnionRuleCreator): v is SecretLintRulePresetCreator => {
@@ -223,6 +232,7 @@ export const loadConfig = async (options: SecretLintConfigLoaderOptions): Promis
     });
     const configLoadResult = await loadPackagesFromConfigDescriptor({
         configDescriptor,
+        moduleResolutionBase: options.moduleResolutionBase,
         node_moduleDir: options.node_moduleDir,
         testReplaceDefinitions: options.testReplaceDefinitions,
     });

--- a/packages/@secretlint/config-loader/test/index.test.ts
+++ b/packages/@secretlint/config-loader/test/index.test.ts
@@ -21,6 +21,7 @@ describe("@secretlint/config-loader", () => {
     it("should load .secretlintrc.json with CJS rules", async () => {
         const config = await loadConfig({
             cwd: path.join(__dirname, "fixtures/valid-config-cjs/"),
+            moduleResolutionBase: import.meta.url,
             node_moduleDir: path.join(__dirname, "fixtures/valid-config-cjs/modules"),
         });
         // deep partial equality check
@@ -51,6 +52,7 @@ describe("@secretlint/config-loader", () => {
     it("should load .secretlintrc.json with ESM rule", async () => {
         const config = await loadConfig({
             cwd: path.join(__dirname, "fixtures/valid-config-esm"),
+            moduleResolutionBase: import.meta.url,
             node_moduleDir: path.join(__dirname, "fixtures/valid-config-esm/modules"),
         });
         const rule = config.config.rules[0] as SecretLintCoreConfigUnionRule;
@@ -62,6 +64,7 @@ describe("@secretlint/config-loader", () => {
     it("should return errors if rule module is not found in .secretlintrc.json", async () => {
         return loadConfig({
             cwd: path.join(__dirname, "fixtures/missing-rule-config"),
+            moduleResolutionBase: import.meta.url,
         })
             .then(() => assert.fail("should not be called"))
             .catch((error: unknown) => {
@@ -71,6 +74,7 @@ describe("@secretlint/config-loader", () => {
     it("should return errors if .secretlintrc.json is invalid format", async () => {
         return loadConfig({
             cwd: path.join(__dirname, "fixtures/invalid-config"),
+            moduleResolutionBase: import.meta.url,
         })
             .then(() => assert.fail("should not be called"))
             .catch((error: Error) => {

--- a/packages/@secretlint/config-loader/test/snapshot.test.ts
+++ b/packages/@secretlint/config-loader/test/snapshot.test.ts
@@ -12,7 +12,7 @@ const formatResult = (result: validateConfigResult) => {
         ? "OK"
         : result.error.message
               .replace(/cwd: .*/, "cwd: <cwd>")
-              .replace(/baseDir: .*/, "baseDir: <baseDir>")
+              .replace(/nodeModulesDir: .*/, "nodeModulesDir: <nodeModulesDir>")
               // 1. escape \n \t \r
               .replace(/\\([ntr])/g, "_!!!_$1")
               // 2. normalize path separator for Windows
@@ -39,6 +39,7 @@ describe("validateConfig", () => {
                 const actual = await validateConfig({
                     cwd: fixtureDir,
                     configFilePath: actualFilePath,
+                    moduleResolutionBase: import.meta.url,
                     node_moduleDir: path.join(fixtureDir, "modules"),
                 });
                 const expectedFilePath = path.join(fixtureDir, "output.txt");

--- a/packages/@secretlint/formatter/src/index.ts
+++ b/packages/@secretlint/formatter/src/index.ts
@@ -17,10 +17,11 @@ import tableFormatter from "./formatters/table.js";
 
 const BuiltInFormatters = ["json", "mask-result", "table"];
 const debug = debug0("@secretlint/formatter");
-const tryResolveModule = (moduleName: string) => {
+const tryResolveModule = (moduleName: string, moduleResolutionBase: string | URL) => {
     return tryResolve(moduleName, {
         parentImportMeta: import.meta,
         parentModule: "formatter",
+        moduleResolutionBase,
     });
 };
 type Formatter = (results: SecretLintCoreResult[], formatterConfig: FormatterConfig) => string;
@@ -41,6 +42,10 @@ export interface SecretLintFormatterConfig {
      * Default: false
      */
     terminalLink?: boolean;
+    /**
+     * Logical module entry used to resolve an external formatter package.
+     */
+    moduleResolutionBase: string | URL;
 }
 
 /**
@@ -104,6 +109,7 @@ const convertSecretLintResultToTextlintResult = (
 
 export async function loadFormatter(formatterConfig: SecretLintFormatterConfig) {
     const formatterName = formatterConfig.formatterName;
+    const moduleResolutionBase = formatterConfig.moduleResolutionBase;
     const isHumanReadableFormat = ["stylish", "pretty-error"].includes(formatterName);
     /**
      * Terminal Link is enabled when use human-readable format and option is enabled
@@ -119,7 +125,11 @@ export async function loadFormatter(formatterConfig: SecretLintFormatterConfig) 
             },
         };
     } catch {
-        const formatter = await textlintCreateFormatter(formatterConfig);
+        const textlintFormatterPath = tryResolveModule(`textlint-formatter-${formatterName}`, moduleResolutionBase);
+        const formatter = await textlintCreateFormatter({
+            ...formatterConfig,
+            formatterName: textlintFormatterPath ?? formatterName,
+        });
         return {
             format: (results: SecretLintCoreResult[]) => {
                 return formatter.format(
@@ -134,8 +144,11 @@ export async function loadFormatter(formatterConfig: SecretLintFormatterConfig) 
     }
 }
 
-export async function secretlintCreateFormatter(formatterConfig: FormatterConfig) {
+export async function secretlintCreateFormatter(
+    formatterConfig: FormatterConfig & Pick<SecretLintFormatterConfig, "moduleResolutionBase">
+) {
     const formatterName = formatterConfig.formatterName;
+    const moduleResolutionBase = formatterConfig.moduleResolutionBase;
     debug(`formatterName: ${formatterName}`);
     if (BuiltInFormatters.includes(formatterName)) {
         switch (formatterName) {
@@ -166,7 +179,9 @@ export async function secretlintCreateFormatter(formatterConfig: FormatterConfig
     } else if (fs.existsSync(path.resolve(process.cwd(), formatterName))) {
         formatterPath = path.resolve(process.cwd(), formatterName);
     } else {
-        const pkgPath = tryResolveModule(formatterName) || tryResolveModule(`secretlint-formatter-${formatterName}`);
+        const pkgPath =
+            tryResolveModule(formatterName, moduleResolutionBase) ||
+            tryResolveModule(`secretlint-formatter-${formatterName}`, moduleResolutionBase);
         if (pkgPath) {
             formatterPath = pkgPath;
         }

--- a/packages/@secretlint/formatter/test/fixtures/secretlint-formatter-logical-install-fixture/index.js
+++ b/packages/@secretlint/formatter/test/fixtures/secretlint-formatter-logical-install-fixture/index.js
@@ -1,0 +1,1 @@
+export default () => "loaded from the logical install group";

--- a/packages/@secretlint/formatter/test/fixtures/secretlint-formatter-logical-install-fixture/package.json
+++ b/packages/@secretlint/formatter/test/fixtures/secretlint-formatter-logical-install-fixture/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "secretlint-formatter-logical-install-fixture",
+    "version": "1.0.0",
+    "type": "module",
+    "exports": "./index.js"
+}

--- a/packages/@secretlint/formatter/test/fixtures/textlint-formatter-logical-install-fixture/index.js
+++ b/packages/@secretlint/formatter/test/fixtures/textlint-formatter-logical-install-fixture/index.js
@@ -1,0 +1,1 @@
+export default () => "loaded textlint formatter from the logical install group";

--- a/packages/@secretlint/formatter/test/fixtures/textlint-formatter-logical-install-fixture/package.json
+++ b/packages/@secretlint/formatter/test/fixtures/textlint-formatter-logical-install-fixture/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "textlint-formatter-logical-install-fixture",
+    "version": "1.0.0",
+    "type": "module",
+    "exports": "./index.js"
+}

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -5,6 +5,7 @@ import assert from "node:assert";
 import { loadFormatter, getFormatterList } from "../src/index.js";
 import { results } from "./snapshots/input.js";
 import escapeStringRegexp from "escape-string-regexp";
+import os from "node:os";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const snapshotsDir = path.join(__dirname, "snapshots");
@@ -34,6 +35,7 @@ describe("@secretlint/formatter", () => {
             const formatter = await loadFormatter({
                 color: false,
                 formatterName: formatterName,
+                moduleResolutionBase: import.meta.url,
             });
             const actual = snapshotReplace(formatter.format(results));
             const expectedFilePath = path.join(fixtureDir, `output.${formatterName}.txt`);
@@ -49,4 +51,60 @@ describe("@secretlint/formatter", () => {
             assert.strictEqual(actual, expected);
         });
     }
+    it.each([
+        {
+            testName: "Secretlint formatter",
+            formatterName: "secretlint-formatter-logical-install-fixture",
+            formatterPackageName: "secretlint-formatter-logical-install-fixture",
+            expectedOutput: "loaded from the logical install group"
+        },
+        {
+            testName: "textlint formatter shorthand",
+            formatterName: "logical-install-fixture",
+            formatterPackageName: "textlint-formatter-logical-install-fixture",
+            expectedOutput: "loaded textlint formatter from the logical install group"
+        }
+    ])("loads a $testName from an explicit logical install group", async (testCase) => {
+        const installGroupDirectory = fs.realpathSync(
+            fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-formatter-install-group-"))
+        );
+        const formatterDirectory = path.join(
+            installGroupDirectory,
+            "node_modules",
+            testCase.formatterPackageName
+        );
+        const moduleResolutionBase = path.join(
+            installGroupDirectory,
+            "node_modules",
+            "secretlint",
+            "bin",
+            "secretlint.js"
+        );
+        fs.mkdirSync(formatterDirectory, { recursive: true });
+        fs.writeFileSync(
+            path.join(formatterDirectory, "package.json"),
+            JSON.stringify({
+                name: testCase.formatterPackageName,
+                version: "1.0.0",
+                type: "module",
+                exports: "./index.js"
+            })
+        );
+        fs.writeFileSync(
+            path.join(formatterDirectory, "index.js"),
+            `export default () => ${JSON.stringify(testCase.expectedOutput)};\n`
+        );
+
+        try {
+            const formatter = await loadFormatter({
+                color: false,
+                formatterName: testCase.formatterName,
+                moduleResolutionBase
+            });
+
+            assert.strictEqual(formatter.format(results), testCase.expectedOutput);
+        } finally {
+            fs.rmSync(installGroupDirectory, { recursive: true, force: true });
+        }
+    });
 });

--- a/packages/@secretlint/formatter/test/index.test.ts
+++ b/packages/@secretlint/formatter/test/index.test.ts
@@ -56,50 +56,39 @@ describe("@secretlint/formatter", () => {
             testName: "Secretlint formatter",
             formatterName: "secretlint-formatter-logical-install-fixture",
             formatterPackageName: "secretlint-formatter-logical-install-fixture",
-            expectedOutput: "loaded from the logical install group"
+            expectedOutput: "loaded from the logical install group",
         },
         {
             testName: "textlint formatter shorthand",
             formatterName: "logical-install-fixture",
             formatterPackageName: "textlint-formatter-logical-install-fixture",
-            expectedOutput: "loaded textlint formatter from the logical install group"
-        }
+            expectedOutput: "loaded textlint formatter from the logical install group",
+        },
     ])("loads a $testName from an explicit logical install group", async (testCase) => {
         const installGroupDirectory = fs.realpathSync(
-            fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-formatter-install-group-"))
+            fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-formatter-install-group-")),
         );
-        const formatterDirectory = path.join(
-            installGroupDirectory,
-            "node_modules",
-            testCase.formatterPackageName
-        );
+        const formatterDirectory = path.join(installGroupDirectory, "node_modules", testCase.formatterPackageName);
+        const formatterFixtureDirectory = path.join(__dirname, "fixtures", testCase.formatterPackageName);
         const moduleResolutionBase = path.join(
             installGroupDirectory,
             "node_modules",
             "secretlint",
             "bin",
-            "secretlint.js"
+            "secretlint.js",
         );
-        fs.mkdirSync(formatterDirectory, { recursive: true });
-        fs.writeFileSync(
-            path.join(formatterDirectory, "package.json"),
-            JSON.stringify({
-                name: testCase.formatterPackageName,
-                version: "1.0.0",
-                type: "module",
-                exports: "./index.js"
-            })
-        );
-        fs.writeFileSync(
-            path.join(formatterDirectory, "index.js"),
-            `export default () => ${JSON.stringify(testCase.expectedOutput)};\n`
+        fs.mkdirSync(path.dirname(formatterDirectory), { recursive: true });
+        fs.symlinkSync(
+            formatterFixtureDirectory,
+            formatterDirectory,
+            process.platform === "win32" ? "junction" : "dir",
         );
 
         try {
             const formatter = await loadFormatter({
                 color: false,
                 formatterName: testCase.formatterName,
-                moduleResolutionBase
+                moduleResolutionBase,
             });
 
             assert.strictEqual(formatter.format(results), testCase.expectedOutput);

--- a/packages/@secretlint/node/src/index.ts
+++ b/packages/@secretlint/node/src/index.ts
@@ -21,6 +21,11 @@ export type SecretLintEngineOptionsBase = {
      */
     cwd?: string;
     /**
+     * Logical module entry used to resolve rules, presets, plugins, and external formatters.
+     * Use this when the physical package location differs from the installation that owns those packages.
+     */
+    moduleResolutionBase: string | URL;
+    /**
      * If color is false, disable ANSI-color of the output.
      * Default: true
      */
@@ -123,6 +128,7 @@ const executeOnContent = async ({
         color: options.color ?? true,
         formatterName: options.formatter,
         terminalLink: options.terminalLink ?? false,
+        moduleResolutionBase: options.moduleResolutionBase,
     });
     const output = formatter.format([result]);
     secretLintProfiler.mark({
@@ -162,6 +168,7 @@ const executeOnFiles = async ({
         color: options.color ?? true,
         formatterName: options.formatter,
         terminalLink: options.terminalLink ?? false,
+        moduleResolutionBase: options.moduleResolutionBase,
     });
     const output = formatter.format(results);
     secretLintProfiler.mark({
@@ -190,11 +197,13 @@ export const createEngine = async (options: SecretLintEngineOptions) => {
             debug("Load ConfigFileJSON: %s", options.configFileJSON);
             return loadPackagesFromConfigDescriptor({
                 configDescriptor: options.configFileJSON,
+                moduleResolutionBase: options.moduleResolutionBase,
             });
         }
         const loadConfigResult = await loadConfig({
             cwd: options.cwd,
             configFilePath: options.configFilePath,
+            moduleResolutionBase: options.moduleResolutionBase,
         });
         debug("Loaded ConfigFilePath: %s", loadConfigResult.configFilePath);
         return loadConfigResult;

--- a/packages/@secretlint/node/test/index.test.ts
+++ b/packages/@secretlint/node/test/index.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import assert from "node:assert";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import os from "node:os";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const normalizeFilePath = (content: string): string => {
@@ -15,6 +16,7 @@ describe("createEngine", () => {
                 color: false,
                 configFilePath: "/not/found/config",
                 formatter: "stylish",
+                moduleResolutionBase: import.meta.url,
             }),
             /secretlint config is not found/
         );
@@ -24,6 +26,7 @@ describe("createEngine", () => {
             color: false,
             cwd: path.join(__dirname, "fixtures/valid-config"),
             formatter: "stylish",
+            moduleResolutionBase: import.meta.url,
         });
         const result = await engine.executeOnFiles({ filePathList: [path.join(__dirname, "fixtures/SECRET.txt")] });
         assert.strictEqual(result.ok, false);
@@ -43,6 +46,7 @@ describe("createEngine", () => {
             color: false,
             cwd: path.join(__dirname, "fixtures/valid-config"),
             formatter: "stylish",
+            moduleResolutionBase: import.meta.url,
         });
         const filePath = path.join(__dirname, "fixtures/SECRET.txt");
         const content = fs.readFileSync(filePath, "utf-8");
@@ -68,6 +72,7 @@ describe("createEngine", () => {
             cwd: path.join(__dirname, "fixtures/valid-config"),
             formatter: "stylish",
             maskSecrets: true,
+            moduleResolutionBase: import.meta.url,
         });
         const filePath = path.join(__dirname, "fixtures/SECRET.txt");
         const content = fs.readFileSync(filePath, "utf-8");
@@ -86,5 +91,68 @@ describe("createEngine", () => {
 ✖ 1 problem (1 error, 0 warnings, 0 infos)
 `
         );
+    });
+    it("should load a rule from an explicit logical install group", async () => {
+        const installGroupDirectory = fs.realpathSync(
+            fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-node-install-group-"))
+        );
+        const globalVirtualStoreDirectory = fs.realpathSync(
+            fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-node-global-virtual-store-"))
+        );
+        const ruleName = "secretlint-rule-logical-install-fixture";
+        const ruleDirectory = path.join(globalVirtualStoreDirectory, "node_modules", ruleName);
+        const logicalRuleDirectory = path.join(installGroupDirectory, "node_modules", ruleName);
+        const moduleResolutionBase = path.join(
+            installGroupDirectory,
+            "node_modules",
+            "secretlint",
+            "bin",
+            "secretlint.js"
+        );
+        fs.mkdirSync(ruleDirectory, { recursive: true });
+        fs.writeFileSync(
+            path.join(ruleDirectory, "package.json"),
+            JSON.stringify({ name: ruleName, version: "1.0.0", type: "module", exports: "./index.js" })
+        );
+        fs.writeFileSync(
+            path.join(ruleDirectory, "index.js"),
+            `export const creator = {
+    messages: {},
+    meta: {
+        id: ${JSON.stringify(ruleName)},
+        recommended: false,
+        type: "scanner",
+        supportedContentTypes: ["text"],
+        docs: { url: "https://github.com/secretlint/secretlint/issues/1624" }
+    },
+    create() {
+        return { file() {} };
+    }
+};
+`
+        );
+        fs.mkdirSync(path.dirname(logicalRuleDirectory), { recursive: true });
+        fs.symlinkSync(
+            ruleDirectory,
+            logicalRuleDirectory,
+            process.platform === "win32" ? "junction" : "dir"
+        );
+
+        try {
+            const engine = await createEngine({
+                color: false,
+                configFileJSON: {
+                    rules: [{ id: ruleName }]
+                },
+                formatter: "json",
+                moduleResolutionBase
+            });
+            const result = await engine.executeOnContent({ content: "plain text", filePath: "fixture.txt" });
+
+            assert.strictEqual(result.ok, true);
+        } finally {
+            fs.rmSync(installGroupDirectory, { recursive: true, force: true });
+            fs.rmSync(globalVirtualStoreDirectory, { recursive: true, force: true });
+        }
     });
 });

--- a/packages/@secretlint/quick-start/src/index.ts
+++ b/packages/@secretlint/quick-start/src/index.ts
@@ -10,5 +10,7 @@ export const quickStart = async () => {
         ...cli.flags,
         secretlintrc: cli.flags.secretlintrc ?? defaultSecretlintRc,
     };
-    return run(cli.input, flags);
+    return run(cli.input, flags, {
+        moduleResolutionBase: process.argv[1],
+    });
 };

--- a/packages/@secretlint/resolver/src/index.ts
+++ b/packages/@secretlint/resolver/src/index.ts
@@ -8,13 +8,19 @@ export type ResolverContext = {
     parentImportMeta: ImportMeta;
     parentModule: "config-loader" | "formatter";
 };
+export type ResolveContext = ResolverContext & {
+    /**
+     * Logical module entry used as the package resolution base.
+     */
+    moduleResolutionBase: string | URL;
+};
 type ResolverSkipResult = undefined;
 /**
  * Resolve Hook
  */
 export type ResolveHook = (
     specifier: string,
-    context: ResolverContext
+    context: ResolveContext
 ) =>
     | {
           url: string | undefined;
@@ -52,7 +58,10 @@ export const registerResolveHook = (hook: ResolveHook) => {
  * @param packageName
  * @param context
  */
-export const tryResolve = (packageName: string, context: ResolverContext): string | undefined => {
+export const tryResolve = (packageName: string, context: ResolveContext): string | undefined => {
+    if (!context.moduleResolutionBase) {
+        throw new TypeError("moduleResolutionBase is required");
+    }
     try {
         for (const hook of resolveHooks) {
             const result = hook(packageName, context);
@@ -65,9 +74,7 @@ export const tryResolve = (packageName: string, context: ResolverContext): strin
             }
         }
 
-        // TODO: import.meta.resolve is not supported in Node.js 18
-        // We will change to import.meta.resolve(packageName)
-        return require.resolve(packageName);
+        return createRequire(context.moduleResolutionBase).resolve(packageName);
     } catch {
         return undefined;
     }

--- a/packages/@secretlint/resolver/test/index.test.ts
+++ b/packages/@secretlint/resolver/test/index.test.ts
@@ -3,6 +3,7 @@ import {
     registerResolveHook,
     registerImportHook,
     dynamicImport,
+    ResolveContext,
     ResolverContext,
     tryResolve,
     clearHooks,
@@ -41,6 +42,7 @@ describe("@secretlint/resolver", () => {
             const result = tryResolve("my-module", {
                 parentImportMeta: import.meta,
                 parentModule: "formatter",
+                moduleResolutionBase: import.meta.url,
             });
             assert.strictEqual(result, myModuleURL);
         });
@@ -48,8 +50,16 @@ describe("@secretlint/resolver", () => {
             const result = tryResolve("other-module", {
                 parentImportMeta: import.meta,
                 parentModule: "formatter",
+                moduleResolutionBase: import.meta.url,
             });
             assert.ok(!result);
+        });
+        it("should require moduleResolutionBase", () => {
+            const context = {
+                parentImportMeta: import.meta,
+                parentModule: "formatter",
+            } as ResolveContext;
+            assert.throws(() => tryResolve("other-module", context), /moduleResolutionBase is required/);
         });
     });
     describe("dynamicImport", () => {

--- a/packages/@secretlint/resolver/test/module-resolution-base.test.ts
+++ b/packages/@secretlint/resolver/test/module-resolution-base.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { clearHooks, tryResolve } from "../src/index.js";
+
+const RULE_NAME = "secretlint-rule-logical-install-fixture";
+const PHYSICAL_ONLY_PACKAGE_NAME = "secretlint-resolver-physical-install-fixture";
+
+describe("tryResolve moduleResolutionBase", () => {
+    let installGroupDirectory: string;
+    let globalVirtualStoreDirectory: string;
+    let moduleResolutionBase: string;
+    const physicalOnlyPackageDirectory = path.join(
+        import.meta.dirname,
+        "..",
+        "node_modules",
+        PHYSICAL_ONLY_PACKAGE_NAME
+    );
+
+    beforeEach(() => {
+        installGroupDirectory = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-install-group-")));
+        globalVirtualStoreDirectory = fs.realpathSync(
+            fs.mkdtempSync(path.join(os.tmpdir(), "secretlint-global-virtual-store-"))
+        );
+        moduleResolutionBase = path.join(installGroupDirectory, "node_modules", "secretlint", "bin", "secretlint.js");
+        fs.mkdirSync(physicalOnlyPackageDirectory, { recursive: true });
+        fs.writeFileSync(
+            path.join(physicalOnlyPackageDirectory, "package.json"),
+            JSON.stringify({ name: PHYSICAL_ONLY_PACKAGE_NAME, version: "1.0.0", main: "index.js" })
+        );
+        fs.writeFileSync(path.join(physicalOnlyPackageDirectory, "index.js"), "module.exports = {};");
+    });
+
+    afterEach(() => {
+        clearHooks();
+        fs.rmSync(installGroupDirectory, { recursive: true, force: true });
+        fs.rmSync(globalVirtualStoreDirectory, { recursive: true, force: true });
+        fs.rmSync(physicalOnlyPackageDirectory, { recursive: true, force: true });
+    });
+
+    it("resolves a package linked from a global virtual store into the logical install group", () => {
+        const storedPackageDirectory = path.join(globalVirtualStoreDirectory, "node_modules", RULE_NAME);
+        const logicalPackageDirectory = path.join(installGroupDirectory, "node_modules", RULE_NAME);
+        const packageEntry = path.join(storedPackageDirectory, "index.js");
+        fs.mkdirSync(storedPackageDirectory, { recursive: true });
+        fs.writeFileSync(
+            path.join(storedPackageDirectory, "package.json"),
+            JSON.stringify({ name: RULE_NAME, version: "1.0.0", main: "index.js" })
+        );
+        fs.writeFileSync(packageEntry, "module.exports = {};");
+        fs.mkdirSync(path.dirname(logicalPackageDirectory), { recursive: true });
+        fs.symlinkSync(
+            storedPackageDirectory,
+            logicalPackageDirectory,
+            process.platform === "win32" ? "junction" : "dir"
+        );
+
+        const result = tryResolve(RULE_NAME, {
+            parentImportMeta: import.meta,
+            parentModule: "config-loader",
+            moduleResolutionBase
+        });
+
+        assert.strictEqual(result, packageEntry);
+
+        const resultFromFileUrl = tryResolve(RULE_NAME, {
+            parentImportMeta: import.meta,
+            parentModule: "config-loader",
+            moduleResolutionBase: pathToFileURL(moduleResolutionBase)
+        });
+        assert.strictEqual(resultFromFileUrl, packageEntry);
+    });
+
+    it("does not fall back to the resolver's physical install when an explicit base is provided", () => {
+        const resolverRelativeResult = tryResolve(PHYSICAL_ONLY_PACKAGE_NAME, {
+            parentImportMeta: import.meta,
+            parentModule: "config-loader",
+            moduleResolutionBase: import.meta.url
+        });
+        assert.ok(resolverRelativeResult, "The control package should be visible from @secretlint/resolver");
+
+        const result = tryResolve(PHYSICAL_ONLY_PACKAGE_NAME, {
+            parentImportMeta: import.meta,
+            parentModule: "config-loader",
+            moduleResolutionBase
+        });
+
+        assert.strictEqual(result, undefined);
+    });
+});

--- a/packages/@secretlint/tester/src/index.ts
+++ b/packages/@secretlint/tester/src/index.ts
@@ -165,13 +165,13 @@ export const snapshot = (options: SnapshotOptions) => {
                             throw new Error(`Not found input file in ${testCaseDir}`);
                         }
                         const actualFilePath = path.join(testCaseDir, actualFileName);
-                        const loadedConfig = await (fs.existsSync(secretlintrcFilePath)
-                              ? loadConfig({
+                        const loadedConfig = fs.existsSync(secretlintrcFilePath)
+                            ? await loadConfig({
                                   configFilePath: secretlintrcFilePath,
                                   moduleResolutionBase: secretlintrcFilePath,
                                   testReplaceDefinitions: testDefinitions,
                               })
-                            : undefined);
+                            : undefined;
                         const config = loadedConfig && loadedConfig.ok ? loadedConfig.config : options.defaultConfig;
                         const rawSource = await createRawSource(actualFilePath);
                         const actualResult = await lintSource({

--- a/packages/@secretlint/tester/src/index.ts
+++ b/packages/@secretlint/tester/src/index.ts
@@ -166,8 +166,9 @@ export const snapshot = (options: SnapshotOptions) => {
                         }
                         const actualFilePath = path.join(testCaseDir, actualFileName);
                         const loadedConfig = await (fs.existsSync(secretlintrcFilePath)
-                            ? loadConfig({
+                              ? loadConfig({
                                   configFilePath: secretlintrcFilePath,
+                                  moduleResolutionBase: secretlintrcFilePath,
                                   testReplaceDefinitions: testDefinitions,
                               })
                             : undefined);

--- a/packages/secretlint/bin/secretlint.js
+++ b/packages/secretlint/bin/secretlint.js
@@ -13,8 +13,7 @@ try {
     // if imported code is syntax error, throw error -> exit 2
     const { run, cli } = await import("../module/cli.js");
     const { exitStatus, stderr, stdout } = await run(cli.input, cli.flags, {
-        // process.argv[1] preserves the logical command entry created by package managers.
-        // This lets rules and formatters resolve from the same install group as this CLI.
+        // Resolve rules and formatters from this CLI's installation, not the current working directory.
         moduleResolutionBase: process.argv[1],
     });
     if (stdout) {

--- a/packages/secretlint/bin/secretlint.js
+++ b/packages/secretlint/bin/secretlint.js
@@ -12,7 +12,11 @@
 try {
     // if imported code is syntax error, throw error -> exit 2
     const { run, cli } = await import("../module/cli.js");
-    const { exitStatus, stderr, stdout } = await run(cli.input, cli.flags);
+    const { exitStatus, stderr, stdout } = await run(cli.input, cli.flags, {
+        // process.argv[1] preserves the logical command entry created by package managers.
+        // This lets rules and formatters resolve from the same install group as this CLI.
+        moduleResolutionBase: process.argv[1],
+    });
     if (stdout) {
         console.log(stdout);
     }

--- a/packages/secretlint/src/cli.ts
+++ b/packages/secretlint/src/cli.ts
@@ -237,8 +237,11 @@ const readCliOptions = async ({ input = cli.input, flags = cli.flags }): Promise
     }
 };
 export const run = async (
-    input = cli.input,
-    flags = cli.flags,
+    input: string[],
+    flags: typeof cli.flags,
+    runtimeOptions: {
+        moduleResolutionBase: string | URL;
+    },
 ): Promise<{ exitStatus: number; stdout: string | null; stderr: Error | null }> => {
     if (flags.help) {
         return {
@@ -283,6 +286,7 @@ export const run = async (
                   // Parse config string as JSON
                   configFileJSON: JSON.parse(flags.secretlintrcJSON),
                   cwd: cwd,
+                  moduleResolutionBase: runtimeOptions.moduleResolutionBase,
                   formatter: flags.format,
                   color: flags.color,
                   terminalLink: flags.terminalLink,
@@ -292,6 +296,7 @@ export const run = async (
             : {
                   configFilePath: flags.secretlintrc,
                   cwd: cwd,
+                  moduleResolutionBase: runtimeOptions.moduleResolutionBase,
                   formatter: flags.format,
                   color: flags.color,
                   terminalLink: flags.terminalLink,

--- a/packages/secretlint/test/cli.test.ts
+++ b/packages/secretlint/test/cli.test.ts
@@ -42,14 +42,18 @@ const createSnapshotReplacer = () => {
  */
 describe("cli snapshot testing", () => {
     it("--version should return version", async () => {
-        const actual = await run([], {
-            ...cli.flags,
-            version: true,
-            cwd: process.cwd(),
-            // Less diff between env
-            color: false,
-            format: "json",
-        });
+        const actual = await run(
+            [],
+            {
+                ...cli.flags,
+                version: true,
+                cwd: process.cwd(),
+                // Less diff between env
+                color: false,
+                format: "json",
+            },
+            { moduleResolutionBase: import.meta.url }
+        );
         assert.ok(actual.stdout);
         assert.match(actual.stdout, /^[\d.]+$/);
     });
@@ -64,14 +68,18 @@ describe("cli snapshot testing", () => {
             const actualInputs = options.inputs;
             // Logging Group
             console.group(`Snapshot Fixture: ${fixtureDir}`);
-            const actual = await run(actualInputs ? actualInputs : [actualFilePath], {
-                ...cli.flags,
-                ...actualOptions,
-                cwd: fixtureDir,
-                // Less diff between env
-                color: false,
-                format: "json",
-            }).catch((error) => {
+            const actual = await run(
+                actualInputs ? actualInputs : [actualFilePath],
+                {
+                    ...cli.flags,
+                    ...actualOptions,
+                    cwd: fixtureDir,
+                    // Less diff between env
+                    color: false,
+                    format: "json",
+                },
+                { moduleResolutionBase: import.meta.url }
+            ).catch((error) => {
                 // if throw an error, save it
                 return `Error: ${error.message}`;
             });

--- a/publish/binary-compiler/src/entry.ts
+++ b/publish/binary-compiler/src/entry.ts
@@ -33,7 +33,7 @@ if (cli.flags.version) {
     process.exit(0);
 }
 // secretlint CLI wrapper
-run(cli.input, cli.flags).then(
+run(cli.input, cli.flags, { moduleResolutionBase: process.execPath }).then(
     ({ exitStatus, stderr, stdout }) => {
         if (stdout) {
             console.log(stdout);


### PR DESCRIPTION
## Summary

Fixes #1624.

Secretlint previously resolved rules, presets, plugins, and external formatters from the physical location of `@secretlint/resolver`. This fails when pnpm stores package contents outside the logical installation with `enableGlobalVirtualStore: true`.

This change resolves packages from the logical installation context of the running Secretlint CLI instead. It keeps project-local and global installation groups isolated and avoids changing package ownership based on `cwd`.

## Background

With pnpm's global virtual store, packages linked into a project's `node_modules` may physically live in a shared store outside the project. Resolving from `@secretlint/resolver`'s physical location therefore cannot reach rules or presets installed alongside the Secretlint CLI.

The reproduction repository verifies that:

- Resolver-relative lookup fails from the physical global store.
- Lookup from the logical Secretlint CLI entry succeeds.
- The same project works when `enableGlobalVirtualStore` is disabled.

References:

- Issue: https://github.com/secretlint/secretlint/issues/1624
- Reproduction: https://github.com/azu/secretlint-issue-1624
- pnpm `enableGlobalVirtualStore`: https://pnpm.io/settings#enableglobalvirtualstore

## Changes

- Add a required `moduleResolutionBase` and pass it through the CLI, engine, config loader, formatter loader, and resolver.
- Capture the logical CLI entry from `process.argv[1]`.
- Resolve packages with `createRequire(moduleResolutionBase).resolve()`.
- Use the same resolution base for rules, presets, plugins, Secretlint formatters, and textlint formatter shorthands.
- Keep `cwd` responsible for config discovery and lint targets rather than package ownership.
- Use `process.execPath` as the resolution base for the standalone binary.
- Rename the explicit `node_modules` directory option to `nodeModulesDirectory` to distinguish it from the logical module-resolution base.
- Add regression tests with logical installation groups and physically separate package stores.
- Add fixed formatter package fixtures instead of dynamically constructing JavaScript source in tests.

## Resolution semantics

- A project-local Secretlint resolves packages from its local installation group.
- A globally installed Secretlint resolves packages from its global installation group.
- A global Secretlint does not silently load a same-named rule from the linted local project.
- Programmatic API callers explicitly provide the intended module-resolution base.

## Breaking Changes

`moduleResolutionBase` is now required by the affected programmatic loader, formatter, engine, and resolver APIs.

The Secretlint CLI supplies this value automatically.

## Test Plan

- TypeScript build passed for the affected packages.
- 75 resolver, config-loader, formatter, node, and CLI tests passed locally.
- Verified the fix against the pnpm 11.5.1 reproduction with `enableGlobalVirtualStore: true`.
- GitHub Actions passed on Node.js 22 and 24 across Linux, macOS, and Windows.
- CodeQL, `test-diff`, `binary-test`, provenance, and automerge gate passed.