### PR TITLE
fix(cli): flush piped output before exit

### DIFF
--- a/packages/@secretlint/quick-start/bin/quick-start.js
+++ b/packages/@secretlint/quick-start/bin/quick-start.js
@@ -9,8 +9,8 @@ try {
     if (stderr) {
         console.error(stderr);
     }
-    process.exit(exitStatus);
+    process.exitCode = exitStatus;
 } catch (error) {
     console.error(error);
-    process.exit(2); // fatal error
+    process.exitCode = 2; // fatal error
 }

--- a/packages/@secretlint/quick-start/package.json
+++ b/packages/@secretlint/quick-start/package.json
@@ -47,7 +47,7 @@
         "prepublishOnly": "npm run clean && npm run build",
         "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepublish": "npm run --if-present build",
-        "test": "node bin/quick-start.js \"**/*\" && exit 1 || exit 0",
+        "test": "node --test test/*.test.js",
         "watch": "tsc --build --watch"
     },
     "prettier": {

--- a/packages/@secretlint/quick-start/test/bin.test.js
+++ b/packages/@secretlint/quick-start/test/bin.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { text } from "node:stream/consumers";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const binPath = path.join(packageDirectory, "bin", "quick-start.js");
+
+test("quick-start does not truncate large JSON output piped to another process", async () => {
+    const input = `AWS_SECRET_ACCESS_KEY = wJalrXUtnFEMI/K7MDENG/bPxRfiCYSECRETSKEY\n${"a".repeat(2 * 1024 * 1024)}`;
+    const child = spawn(process.execPath, [binPath, "--stdinFileName=input.txt", "--format=json"], {
+        cwd: packageDirectory,
+        env: {
+            ...process.env,
+            // Make the package-local preset visible when testing from the pnpm workspace.
+            NODE_PATH: path.join(packageDirectory, "node_modules"),
+        },
+        stdio: "pipe",
+    });
+    const closePromise = once(child, "close");
+    const stdoutPromise = text(child.stdout);
+    const stderrPromise = text(child.stderr);
+    child.stdin.end(input);
+
+    const [[exitCode, signal], stdout, stderr] = await Promise.all([closePromise, stdoutPromise, stderrPromise]);
+
+    assert.strictEqual(signal, null);
+    assert.strictEqual(exitCode, 1, stderr);
+    assert.ok(Buffer.byteLength(stdout) > 1024 * 1024, "stdout should contain more than 1 MiB");
+    const results = JSON.parse(stdout);
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].sourceContent, input);
+    assert.ok(results[0].messages.length > 0);
+});

--- a/packages/secretlint/bin/secretlint.js
+++ b/packages/secretlint/bin/secretlint.js
@@ -19,8 +19,8 @@ try {
     if (stderr) {
         console.error(stderr);
     }
-    process.exit(exitStatus);
+    process.exitCode = exitStatus;
 } catch (error) {
     console.error(error);
-    process.exit(2); // fatal error
+    process.exitCode = 2; // fatal error
 }

--- a/packages/secretlint/test/bin.test.ts
+++ b/packages/secretlint/test/bin.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { text } from "node:stream/consumers";
+import { fileURLToPath } from "node:url";
+
+const packageDirectory = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const binPath = path.join(packageDirectory, "bin", "secretlint.js");
+
+describe("secretlint bin", () => {
+    it("does not truncate large JSON output piped to another process", async () => {
+        const input = `SECRET\n${"a".repeat(2 * 1024 * 1024)}`;
+        const secretlintrcJSON = JSON.stringify({
+            rules: [
+                {
+                    id: "@secretlint/secretlint-rule-example",
+                },
+            ],
+        });
+        const child = spawn(
+            process.execPath,
+            [binPath, "--stdinFileName=input.txt", "--format=json", `--secretlintrcJSON=${secretlintrcJSON}`],
+            {
+                cwd: packageDirectory,
+                stdio: "pipe",
+            },
+        );
+        const closePromise = once(child, "close");
+        const stdoutPromise = text(child.stdout);
+        const stderrPromise = text(child.stderr);
+        child.stdin.end(input);
+
+        const [[exitCode, signal], stdout, stderr] = await Promise.all([closePromise, stdoutPromise, stderrPromise]);
+
+        assert.strictEqual(signal, null);
+        assert.strictEqual(exitCode, 1, stderr);
+        assert.ok(Buffer.byteLength(stdout) > 1024 * 1024, "stdout should contain more than 1 MiB");
+        const results = JSON.parse(stdout);
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].sourceContent, input);
+        assert.strictEqual(results[0].messages.length, 1);
+    });
+});

--- a/publish/binary-compiler/src/entry.ts
+++ b/publish/binary-compiler/src/entry.ts
@@ -3,6 +3,12 @@ import { cli, run } from "secretlint/cli";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+const writeOutput = async (output: string, destination: "stdout" | "stderr") => {
+    const writer = (destination === "stdout" ? Bun.stdout : Bun.stderr).writer();
+    writer.write(output);
+    await writer.end();
+};
+
 // --init override
 if (cli.flags.init) {
     // write .secretlintrc.json
@@ -33,18 +39,18 @@ if (cli.flags.version) {
     process.exit(0);
 }
 // secretlint CLI wrapper
-run(cli.input, cli.flags).then(
-    ({ exitStatus, stderr, stdout }) => {
-        if (stdout) {
-            console.log(stdout);
-        }
-        if (stderr) {
-            console.error(stderr);
-        }
-        process.exit(exitStatus);
-    },
-    (error) => {
-        console.error(error);
-        process.exit(1);
+try {
+    const { exitStatus, stderr, stdout } = await run(cli.input, cli.flags);
+    if (stdout) {
+        await writeOutput(`${stdout}\n`, "stdout");
     }
-);
+    if (stderr) {
+        const errorMessage = stderr.stack ?? stderr.message;
+        await writeOutput(`${errorMessage}\n`, "stderr");
+    }
+    process.exit(exitStatus);
+} catch (error) {
+    const errorMessage = error instanceof Error ? (error.stack ?? error.message) : String(error);
+    await writeOutput(`${errorMessage}\n`, "stderr");
+    process.exit(1);
+}

--- a/publish/binary-compiler/test.sh
+++ b/publish/binary-compiler/test.sh
@@ -40,4 +40,31 @@ fi
 ./secretlint --help
 # run "**/*" test
 ./secretlint "**/*"
+
+# Verify that large JSON output is fully flushed before the process exits.
+node -e 'process.stdout.write("AWS_SECRET_ACCESS_KEY = wJalrXUtnFEMI/K7MDENG/bPxRfiCYSECRETSKEY\n" + "a".repeat(2 * 1024 * 1024))' > large-input.txt
+set +e
+./secretlint large-input.txt --format=json | node -e '
+const fs = require("node:fs");
+const chunks = [];
+process.stdin.on("data", (chunk) => chunks.push(chunk));
+process.stdin.on("end", () => {
+    try {
+        const results = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+        const expectedSource = fs.readFileSync("large-input.txt", "utf8");
+        if (results.length !== 1 || results[0].sourceContent !== expectedSource) {
+            throw new Error("source content does not match");
+        }
+    } catch {
+        console.error("secretlint JSON output was truncated");
+        process.exitCode = 1;
+    }
+});
+'
+pipeline_status=("${PIPESTATUS[@]}")
+set -e
+if [ "${pipeline_status[0]}" -ne 1 ] || [ "${pipeline_status[1]}" -ne 0 ]; then
+    echo "❌ Large piped JSON output test failed"
+    exit 1
+fi
 cd -


### PR DESCRIPTION
## Summary
- Fixes #1634 by preventing large CLI output from being truncated when stdout is piped to another process.
- Covers the Node.js CLI entry points and the compiled Bun binary.

## Changes
- Replace immediate `process.exit()` calls with `process.exitCode` in the secretlint and quick-start Node.js entry points, allowing pending stdout and stderr writes to finish.
- Write Bun binary output through a `FileSink` and await `end()` before exiting.
- Add regression tests that send more than 2 MiB of input through the CLI and verify the complete JSON output.
- Extend the compiled binary smoke test with the same large piped-output scenario.

## Breaking Changes
- None.

## Test Plan
- `turbo run test --filter=secretlint --filter=@secretlint/quick-start` — all relevant tasks passed.
- Ran the repository self-lint through `packages/secretlint/bin/secretlint.js`.
- `bash -n publish/binary-compiler/test.sh`
- Compiled the macOS arm64 binary and verified complete 2 MiB piped JSON output, with secretlint exiting with status 1 and the JSON consumer exiting with status 0.