### PR TITLE
fix(profiler): enable profiling only when --profile is specified

### DIFF
--- a/packages/@secretlint/profiler/README.md
+++ b/packages/@secretlint/profiler/README.md
@@ -10,7 +10,24 @@ Install with [npm](https://www.npmjs.com/):
 
 ## Usage
 
-- [ ] Write usage instructions
+`@secretlint/profiler` exports a shared `secretLintProfiler` instance. Secretlint packages mark their own timings with it.
+
+Profiling costs performance—`performance.mark()` is called for each rule and each file—so the profiler should be enabled only when you need the profiling result.
+The `secretlint` CLI enables it only when the `--profile` flag is passed.
+
+```js
+import { secretLintProfiler } from "@secretlint/profiler";
+
+// Disable profiling: `mark()` becomes no-op and `PerformanceObserver` is not started
+secretLintProfiler.setEnabled(false);
+
+// Enable profiling before running secretlint
+secretLintProfiler.setEnabled(true);
+// ... run secretlint ...
+const measures = await secretLintProfiler.getMeasures();
+```
+
+The profiler is enabled by default. If you use Secretlint as a library and do not need the profiling result, call `secretLintProfiler.setEnabled(false)` before running secretlint.
 
 ## Changelog
 

--- a/packages/@secretlint/profiler/src/index.ts
+++ b/packages/@secretlint/profiler/src/index.ts
@@ -100,19 +100,65 @@ export type LimitedPerformanceObserver = Constructor<{
 export type SecretLintProfilerOptions = {
     perf: Performance;
     PerformanceObserver: LimitedPerformanceObserver;
+    /**
+     * If `enabled` is `false`, the profiler does not do anything.
+     * `mark()` becomes no-op and `PerformanceObserver` is not started.
+     * Default: true
+     */
+    enabled?: boolean;
 };
 
 export class SecretLintProfiler {
     private perf: Performance;
+    private PerformanceObserver: LimitedPerformanceObserver;
+    private observer: InstanceType<LimitedPerformanceObserver> | undefined;
+    /**
+     * Profiling costs performance.
+     * `performance.mark()` and `PerformanceObserver` callback are called for each rule and each file.
+     * So, the profiler should be disabled if the user does not need the profiling result.
+     * https://github.com/secretlint/secretlint/issues/1633
+     */
+    private enabled: boolean;
     private entries: PerformanceEntry[] = [];
     private measures: PerformanceEntry[] = [];
+    /**
+     * Set of mark names that have already been marked as `{mark}::start`
+     */
+    private startMarkNames: Set<string> = new Set();
 
     private executionPromises: Promise<void>[] = [];
 
     constructor(options: SecretLintProfilerOptions) {
         this.perf = options.perf;
+        this.PerformanceObserver = options.PerformanceObserver;
+        this.enabled = options.enabled ?? true;
+    }
+
+    get isEnabled(): boolean {
+        return this.enabled;
+    }
+
+    /**
+     * Enable or Disable the profiler.
+     * If the profiler is disabled, `mark()` does nothing and collected entries are cleared.
+     * @param enabled
+     */
+    setEnabled(enabled: boolean) {
+        if (this.enabled === enabled) {
+            return;
+        }
+        this.enabled = enabled;
+        if (!enabled) {
+            this.stopObserving();
+        }
+    }
+
+    private startObserving() {
         const pattern = /(.*?)::end(\|\|.*)?/;
-        const observer = new options.PerformanceObserver((items: PerformanceObserverEntryList) => {
+        const observer = new this.PerformanceObserver((items: PerformanceObserverEntryList) => {
+            if (!this.enabled) {
+                return;
+            }
             const entries = items.getEntries();
             entries.forEach((entry) => {
                 if (entry.entryType === "mark") {
@@ -121,23 +167,18 @@ export class SecretLintProfiler {
                     const suffix = match && match[2] ? match[2] : "";
                     // if mark already {mark}::start, measure start to end
                     if (endIdentifier) {
-                        const startIdentifier = `${endIdentifier}::start`;
-                        this.entries.find((savedEntry) => {
-                            return savedEntry.name === startIdentifier;
-                        });
-                        // create measure
-                        if (startIdentifier) {
+                        const startMarkName = `${endIdentifier}::start${suffix}`;
+                        // create measure only when the paired `{mark}::start` is already marked
+                        if (this.startMarkNames.has(startMarkName)) {
                             // FIXME: avoid ERR_INVALID_PERFORMANCE_MARK error
                             this.executionPromises.push(
                                 Promise.resolve().then(() => {
-                                    this.perf.measure(
-                                        endIdentifier + suffix,
-                                        `${endIdentifier}::start${suffix}`,
-                                        `${endIdentifier}::end${suffix}`
-                                    );
-                                })
+                                    this.perf.measure(endIdentifier + suffix, startMarkName, entry.name);
+                                }),
                             );
                         }
+                    } else {
+                        this.startMarkNames.add(entry.name);
                     }
                     this.entries.push(entry);
                 } else if (entry.entryType === "measure") {
@@ -146,9 +187,27 @@ export class SecretLintProfiler {
             });
         });
         observer.observe({ entryTypes: ["mark", "measure"] });
+        this.observer = observer;
+    }
+
+    private stopObserving() {
+        this.observer?.disconnect();
+        this.observer = undefined;
+        this.entries.length = 0;
+        this.measures.length = 0;
+        this.executionPromises.length = 0;
+        this.startMarkNames.clear();
     }
 
     mark(marker: SecretLintProfilerMarker) {
+        if (!this.enabled) {
+            return;
+        }
+        // Start observing lazily
+        // It avoids to start PerformanceObserver when the profiler is disabled before the first mark
+        if (!this.observer) {
+            this.startObserving();
+        }
         if ("id" in marker) {
             this.perf.mark(`${marker.type}||${marker.id}`);
         } else {

--- a/packages/@secretlint/profiler/test/index.test.ts
+++ b/packages/@secretlint/profiler/test/index.test.ts
@@ -1,6 +1,39 @@
 import assert from "assert";
 import perf_hooks from "node:perf_hooks";
 import { SecretLintProfiler } from "../src/node.js";
+
+const createSpyPerformanceObserver = () => {
+    const state = {
+        createdCount: 0,
+        observedCount: 0,
+        disconnectedCount: 0,
+    };
+    class SpyPerformanceObserver {
+        constructor(_callback: (items: PerformanceObserverEntryList) => void) {
+            state.createdCount++;
+        }
+
+        observe(_options?: any): void {
+            state.observedCount++;
+        }
+
+        disconnect(): void {
+            state.disconnectedCount++;
+        }
+    }
+
+    return { state, SpyPerformanceObserver };
+};
+const createSpyPerformance = () => {
+    const markNames: string[] = [];
+    const perf = {
+        mark: (name: string) => {
+            markNames.push(name);
+        },
+        measure: () => {},
+    } as unknown as typeof perf_hooks.performance;
+    return { markNames, perf };
+};
 describe("profile", () => {
     it("should profile", async () => {
         const profiler = new SecretLintProfiler({
@@ -25,5 +58,121 @@ describe("profile", () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
         const results = await profiler.getEntries();
         assert.strictEqual(results.length, 4);
+    });
+    it("should measure the duration between ::start and ::end", async () => {
+        const profiler = new SecretLintProfiler({
+            perf: perf_hooks.performance,
+            PerformanceObserver: perf_hooks.PerformanceObserver,
+        });
+        profiler.mark({
+            type: "@core>lint::start",
+            id: "measure-test",
+        });
+        profiler.mark({
+            type: "@core>lint::end",
+            id: "measure-test",
+        });
+        // wait for finish
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        const measures = await profiler.getMeasures();
+        assert.ok(
+            measures.some((measure) => measure.name === "@core>lint||measure-test"),
+            `should have a measure for the marked pair: ${measures.map((measure) => measure.name).join(", ")}`,
+        );
+    });
+    it("should be enabled by default", () => {
+        const { SpyPerformanceObserver } = createSpyPerformanceObserver();
+        const { perf } = createSpyPerformance();
+        const profiler = new SecretLintProfiler({
+            perf,
+            PerformanceObserver: SpyPerformanceObserver,
+        });
+        assert.strictEqual(profiler.isEnabled, true);
+    });
+    it("should not mark and not observe if the profiler is disabled", async () => {
+        const { state, SpyPerformanceObserver } = createSpyPerformanceObserver();
+        const { markNames, perf } = createSpyPerformance();
+        const profiler = new SecretLintProfiler({
+            perf,
+            PerformanceObserver: SpyPerformanceObserver,
+            enabled: false,
+        });
+        profiler.mark({
+            type: "secretlint>cli::start",
+        });
+        profiler.mark({
+            type: "@core>lint::start",
+            id: "disabled-test",
+        });
+        profiler.mark({
+            type: "@core>lint::end",
+            id: "disabled-test",
+        });
+        profiler.mark({
+            type: "secretlint>cli::end",
+        });
+        assert.strictEqual(profiler.isEnabled, false);
+        assert.deepStrictEqual(markNames, [], "performance.mark() should not be called");
+        assert.strictEqual(state.createdCount, 0, "PerformanceObserver should not be created");
+        assert.deepStrictEqual(await profiler.getEntries(), []);
+        assert.deepStrictEqual(await profiler.getMeasures(), []);
+    });
+    it("should not observe if setEnabled(false) is called before marking", () => {
+        const { state, SpyPerformanceObserver } = createSpyPerformanceObserver();
+        const { markNames, perf } = createSpyPerformance();
+        const profiler = new SecretLintProfiler({
+            perf,
+            PerformanceObserver: SpyPerformanceObserver,
+        });
+        profiler.setEnabled(false);
+        profiler.mark({
+            type: "secretlint>cli::start",
+        });
+        assert.deepStrictEqual(markNames, [], "performance.mark() should not be called");
+        assert.strictEqual(state.createdCount, 0, "PerformanceObserver should not be created");
+    });
+    it("should disconnect the observer and clear collected entries if setEnabled(false) is called", async () => {
+        const { state, SpyPerformanceObserver } = createSpyPerformanceObserver();
+        const { markNames, perf } = createSpyPerformance();
+        const profiler = new SecretLintProfiler({
+            perf,
+            PerformanceObserver: SpyPerformanceObserver,
+        });
+        profiler.mark({
+            type: "secretlint>cli::start",
+        });
+        assert.deepStrictEqual(markNames, ["secretlint>cli::start"]);
+        assert.strictEqual(state.createdCount, 1);
+        assert.strictEqual(state.observedCount, 1);
+        profiler.setEnabled(false);
+        assert.strictEqual(state.disconnectedCount, 1, "PerformanceObserver should be disconnected");
+        assert.deepStrictEqual(await profiler.getEntries(), []);
+        assert.deepStrictEqual(await profiler.getMeasures(), []);
+        // marking again should do nothing
+        profiler.mark({
+            type: "secretlint>cli::end",
+        });
+        assert.deepStrictEqual(markNames, ["secretlint>cli::start"]);
+        assert.strictEqual(state.createdCount, 1, "PerformanceObserver should not be created again");
+    });
+    it("should observe again if setEnabled(true) is called", async () => {
+        const { state, SpyPerformanceObserver } = createSpyPerformanceObserver();
+        const { markNames, perf } = createSpyPerformance();
+        const profiler = new SecretLintProfiler({
+            perf,
+            PerformanceObserver: SpyPerformanceObserver,
+            enabled: false,
+        });
+        profiler.mark({
+            type: "secretlint>cli::start",
+        });
+        profiler.setEnabled(true);
+        profiler.mark({
+            type: "secretlint>cli::end",
+        });
+        assert.strictEqual(profiler.isEnabled, true);
+        assert.deepStrictEqual(markNames, ["secretlint>cli::end"]);
+        assert.strictEqual(state.createdCount, 1);
+        assert.strictEqual(state.observedCount, 1);
     });
 });

--- a/packages/secretlint/src/cli.ts
+++ b/packages/secretlint/src/cli.ts
@@ -255,6 +255,9 @@ export const run = async (
             stderr: null,
         };
     }
+    // Profiling costs performance, so it is enabled only when --profile is specified
+    // https://github.com/secretlint/secretlint/issues/1633
+    secretLintProfiler.setEnabled(Boolean(flags.profile));
     secretLintProfiler.mark({
         type: "secretlint>cli::start",
     });

--- a/packages/secretlint/test/cli.test.ts
+++ b/packages/secretlint/test/cli.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import assert from "node:assert";
 import { cli, run } from "../src/cli.js";
+import { secretLintProfiler } from "@secretlint/profiler";
 import { fileURLToPath } from "url";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -88,7 +89,7 @@ describe("cli snapshot testing", () => {
                 fs.writeFileSync(
                     expectedFilePath,
                     JSON.stringify(normalizedActual, createSnapshotReplacer(), 4),
-                    "utf-8"
+                    "utf-8",
                 );
                 t.skip(); // skip when updating snapshots
                 return;
@@ -102,8 +103,49 @@ describe("cli snapshot testing", () => {
 Fixture: ${fixtureDir}
 Result:
 ${JSON.stringify(normalizedActual, createSnapshotReplacer(), 4)}
-`
+`,
             );
         });
+    });
+});
+
+describe("--profile", () => {
+    const fixtureDir = path.join(SNAPSHOT_DIR, "--format=json");
+    const inputFilePath = path.join(fixtureDir, "input.txt");
+    afterEach(() => {
+        // reset the profiler state for other tests
+        secretLintProfiler.setEnabled(false);
+    });
+    it("should not enable the profiler if --profile is not specified", async () => {
+        await run([inputFilePath], {
+            ...cli.flags,
+            cwd: fixtureDir,
+            color: false,
+            format: "json",
+        });
+        assert.strictEqual(secretLintProfiler.isEnabled, false);
+    });
+    it("should enable the profiler and print the measures if --profile is specified", async () => {
+        const logs: string[] = [];
+        const consoleLog = console.log;
+        console.log = (...args: unknown[]) => {
+            logs.push(args.join(" "));
+        };
+        try {
+            await run([inputFilePath], {
+                ...cli.flags,
+                cwd: fixtureDir,
+                color: false,
+                format: "stylish",
+                profile: true,
+            });
+        } finally {
+            console.log = consoleLog;
+        }
+        assert.strictEqual(secretLintProfiler.isEnabled, true);
+        assert.ok(
+            logs.some((log) => /^.+ - [\d.]+ms$/.test(log)),
+            `should print the measures: ${JSON.stringify(logs)}`,
+        );
     });
 });


### PR DESCRIPTION
## Summary

`@secretlint/profiler` profiled every run, even when `--profile` was not passed.
`performance.mark()` is called for each rule and each file, so most of the time of a normal `secretlint` run was spent on instrumentation that nobody reads.

This PR makes profiling opt-in: the CLI enables the profiler only when `--profile` is specified.

- Fixes #1633
- Fixes #1653

## Root cause

1. **The profiler always ran.** The singleton profiler started a `PerformanceObserver` at module load time and `mark()` always called `performance.mark()`. `--profile` only controlled whether the collected measures were *printed*.
2. **The observer callback was O(n^2).** On every `::end` mark, the callback ran `this.entries.find(...)` over an ever-growing array and threw the result away. The `if (startIdentifier)` guard on the next line was always `true` (it is a template literal), so the scan was dead code — but its cost grew with the number of marks, which is why the per-file cost increased with the corpus size.

## Changes

- `@secretlint/profiler`
    - Add `enabled` state (default: `true`), `setEnabled(enabled)` and `isEnabled`.
    - `mark()` is a no-op while disabled, and `PerformanceObserver` is started lazily on the first `mark()`, so nothing is observed when the profiler is disabled before it is used.
    - `setEnabled(false)` disconnects the observer and clears the collected entries.
    - Replace the dead `entries.find()` scan with a `Set` of already-marked `::start` names. A measure is created only when the paired `::start` mark exists, which also avoids a possible `ERR_INVALID_PERFORMANCE_MARK` rejection.
    - Document the behavior in the package README.
- `secretlint` (CLI)
    - `secretLintProfiler.setEnabled(Boolean(flags.profile))` before the first mark, so no mark is recorded without `--profile`.

The API default stays `enabled: true`, so direct `@secretlint/profiler` API consumers are not affected. If you use Secretlint as a library and do not need the profiling result, call `secretLintProfiler.setEnabled(false)`.

## Benchmark

Node.js v22.22.2, `@secretlint/secretlint-rule-preset-canary`, `examples/benchmark/targets` (1x = 588 files, 4x = the same corpus copied 4 times), median of the measured runs (1x: 1 warmup + 5 runs, 4x: 3 runs, `--profile`: 1 warmup + 3 runs).

| Corpus | before | after | speedup |
| --- | ---: | ---: | ---: |
| 588 files | 8,143 ms | 1,009 ms | **8.1x** |
| 2,352 files | 136,921 ms | 2,859 ms | **47.9x** |
| 588 files with `--profile` | 8,338 ms | 1,305 ms | **6.4x** |

Per-file cost — before, it grew with the corpus size (the O(n^2) scan); after, it is flat:

| Corpus | before | after |
| --- | ---: | ---: |
| 588 files | 13.8 ms/file | 1.7 ms/file |
| 2,352 files | 58.2 ms/file | 1.2 ms/file |

`--profile` output itself is unchanged (the same measures are printed), and it also got faster because the O(n^2) scan is gone.

## Test plan

- `packages/@secretlint/profiler`: added tests for the default state, no `performance.mark()`/`PerformanceObserver` while disabled, `setEnabled(false)` disconnecting and clearing entries, re-enabling, and that a `::start`/`::end` pair is still measured.
- `packages/secretlint`: added CLI tests that the profiler stays disabled without `--profile` and that `--profile` enables it and prints the measures.
- `pnpm test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QC6n5nAevK79r8MsdaTm7R

---
_Generated by [Claude Code](https://claude.ai/code/session_01QC6n5nAevK79r8MsdaTm7R)_